### PR TITLE
use cray-libsci for lapack explicitly with rocm

### DIFF
--- a/configs/ats4/auxiliary_software_files/compilers.yaml
+++ b/configs/ats4/auxiliary_software_files/compilers.yaml
@@ -2,21 +2,17 @@ compilers:
 - compiler:
     spec: cce@16.0.0-rocm5.5.1
     paths:
-      cc: /opt/cray/pe/craype/2.7.21/bin/cc
-      cxx: /opt/cray/pe/craype/2.7.21/bin/CC
-      f77: /opt/cray/pe/craype/2.7.21/bin/ftn
-      fc: /opt/cray/pe/craype/2.7.21/bin/ftn
-#      cc:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/craycc
-#      cxx:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayCC
-#      f77:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
-#      fc:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
+      cc:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/craycc
+      cxx:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayCC
+      f77:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
+      fc:  /usr/tce/packages/cce-tce/cce-16.0.0/bin/crayftn
     flags:
       cflags: -g -O2
       cxxflags: -g -O2 -std=c++14
       fflags: -g -O2 -hnopattern
     operating_system: rhel8
     target: x86_64
-    modules: [StdEnv, PrgEnv-cray/8.4.0, rocm/5.5.1, craype/2.7.21, craype-accel-amd-gfx90a, cce/16.0.0]
+    modules: []
     environment: {}
     extra_rpaths: [/opt/cray/pe/gcc-libs/]
 - compiler:

--- a/configs/ats4/auxiliary_software_files/packages.yaml
+++ b/configs/ats4/auxiliary_software_files/packages.yaml
@@ -137,18 +137,16 @@ packages:
     externals:
     - spec: rocthrust@5.4.3
       prefix: /opt/rocm-5.4.3
-      buildable: false
     - spec: rocthrust@5.5.1
       prefix: /opt/rocm-5.5.1
-      buildable: false
+    buildable: false
   hip:
     externals:
     - spec: hip@5.4.3
       prefix: /opt/rocm-5.4.3
-      buildable: false
     - spec: hip@5.5.1
       prefix: /opt/rocm-5.5.1
-      buildable: false
+    buildable: false
   hsa-rocr-dev:
     externals:
     - spec: hsa-rocr-dev@5.4.3
@@ -183,8 +181,12 @@ packages:
       buildable: false
   cray-libsci:
     externals:
-    - spec: cray-libsci@23.05.1.4
+    - spec: cray-libsci@23.05.1.4%cce
+      prefix: /opt/cray/pe/libsci/23.05.1.4/cray/12.0/x86_64/
+    - spec: cray-libsci@23.05.1.4%gcc
       prefix: /opt/cray/pe/libsci/23.05.1.4/gnu/10.3/x86_64/
+  lapack:
+    buildable: false
   hypre:
     variants: amdgpu_target=gfx90a
   mpi:

--- a/configs/ats4/spack.yaml
+++ b/configs/ats4/spack.yaml
@@ -10,8 +10,8 @@ spack:
       spack_spec: gcc@12.2.0
     blas-rocm:
       spack_spec: rocblas@5.5.1
-    lapack-rocm:
-      spack_spec: rocsolver@5.5.1
+#    lapack-rocm:
+#      spack_spec: rocsolver@5.5.1
     lapack:
       spack_spec: cray-libsci@23.05.1.4
     mpi-compiler-rocm:

--- a/experiments/amg2023/rocm/ramble.yaml
+++ b/experiments/amg2023/rocm/ramble.yaml
@@ -64,14 +64,14 @@ ramble:
       amg2023-gpu-{gtl}:
         packages:
         - blas-rocm
-        - lapack-rocm
+        - lapack
         - mpi-{gtl}
         - hypre-{gtl}
         - amg2023-gpu-{gtl}
       amg2023-omp:
         packages:
         - blas-rocm
-        - lapack-rocm
+        - lapack
         - default-mpi
         - hypre-omp
         - amg2023-omp

--- a/repo/amg2023/package.py
+++ b/repo/amg2023/package.py
@@ -45,7 +45,7 @@ class Amg2023(MakefilePackage, CudaPackage, ROCmPackage):
             makefile.filter('HYPRE_HIP_LIBS    =', '#HYPRE_HIP_LIBS    =')
 
         if "+rocm" in spec:
-            makefile.filter('HYPRE_HIP_PATH    = .*', 'HYPRE_HIP_PATH    = ${ROCM_PATH}')
+            makefile.filter('HYPRE_HIP_PATH    = .*', f'HYPRE_HIP_PATH    = {spec["hip"].prefix}')
         else:
             makefile.filter('HYPRE_HIP_PATH    =', '#HYPRE_HIP_PATH    =')
             makefile.filter('HYPRE_HIP_INCLUDE =', '#HYPRE_HIP_INCLUDE =')

--- a/repo/hypre/package.py
+++ b/repo/hypre/package.py
@@ -7,6 +7,11 @@ class Hypre(BuiltinHypre):
     requires("+rocm", when="^rocblas")
     requires("+rocm", when="^rocsolver")
 
+    compiler_to_cpe_name = {
+        "cce": "cray",
+        "gcc": "gnu",
+    }
+
     def configure_args(self):
         configure_args = super().configure_args()
 
@@ -29,3 +34,11 @@ class Hypre(BuiltinHypre):
         if spec["lapack"].satisfies("rocsolver"):
             rocm_rpath_flag = f"-Wl,-rpath,{os.path.dirname(spec['lapack'].prefix)}/lib"
             env.append_flags("LDFLAGS", rocm_rpath_flag)
+        if spec["lapack"].satisfies("cray-libsci"):
+            libsci_name = "sci_"
+            libsci_name += self.compiler_to_cpe_name[spec.compiler.name]
+            if spec.satisfies("+mpi"):
+                libsci_name += "_mpi"
+            if spec.satisfies("+openmp"):
+                libsci_name += "_mp"
+            env.append_flags("LDFLAGS", f"-L{spec['lapack'].prefix}/lib -l{libsci_name}")


### PR DESCRIPTION
Fixes issues with amg2023/openmp ats4 and amg2023/rocm ats4