### PR TITLE
Fix build/run instructions

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -174,7 +174,7 @@ def benchpark_setup_handler(args):
     instructions = f"""\
 To build/run these benchmarks, do the following:
 
-    cd {workspace_dir}
+    cd {ramble_workspace_dir}
 
     . {workspace_dir}/spack/share/spack/setup-env.sh
     . {workspace_dir}/ramble/share/ramble/setup-env.sh


### PR DESCRIPTION
The user was being instructed to cd to the incorrect directory.
```
To build/run these benchmarks, do the following:

    cd /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi

    . /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi/spack/share/spack/setup-env.sh
    . /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi/ramble/share/ramble/setup-env.sh

    export SPACK_DISABLE_LOCAL_CONFIG=1

    ramble -D . workspace setup
    ramble -D . on
```
when the instructions should be
```
To build/run these benchmarks, do the following:

    cd /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi/workspace

    . /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi/spack/share/spack/setup-env.sh
    . /home/klinalic/benchpark/bin/lemhi-test/saxpy/openmp/lemhi/ramble/share/ramble/setup-env.sh

    export SPACK_DISABLE_LOCAL_CONFIG=1

    ramble -D . workspace setup
    ramble -D . on
```