### PR TITLE
enforce minimum python 3.8 when running benchpark script

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -6,6 +6,7 @@ import pathlib
 import os
 import shutil
 import shlex
+import sys
 
 DEBUG = False
 
@@ -14,6 +15,9 @@ def debug_print(message):
         print("(debug) " + str(message))
 
 def main():
+    if sys.version_info[:2] < (3, 8):
+       raise Exception("Benchpark requires at least python 3.8+.")
+
     parser = argparse.ArgumentParser(description="Benchpark")
 
     subparsers = parser.add_subparsers(title="Subcommands", dest="subcommand")

--- a/docs/1-getting-started.rst
+++ b/docs/1-getting-started.rst
@@ -2,7 +2,7 @@
 Getting started with Benchpark
 =========
 
-Git is needed to clone Benchpark, and Python 3.6 is needed to run Benchpark::
+Git is needed to clone Benchpark, and Python 3.8+ is needed to run Benchpark::
 
   git clone git@github.com:LLNL/benchpark.git   
   cd benchpark


### PR DESCRIPTION
- update docs

Fixes #31 