### PR TITLE
use --disable-progress-bar when calling ramble so tqdm not required

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -237,9 +237,9 @@ To build these benchmarks, do the following:
 
     export SPACK_DISABLE_LOCAL_CONFIG=1
 
-    ramble -D . workspace setup
+    ramble -P -D . workspace setup
 
-Further steps are needed to run the experiments (ramble -D . on)
+Further steps are needed to run the experiments (ramble -P -D . on)
 """
     print(instructions)
 

--- a/docs/5-build-experiment.rst
+++ b/docs/5-build-experiment.rst
@@ -11,7 +11,7 @@ Build experiment
 
   export SPACK_DISABLE_LOCAL_CONFIG=1
 
-  ramble -D . workspace setup  
+  ramble -P -D . workspace setup  
 
 which will build the source code and set up the following workspace directory structure::
 

--- a/docs/6-run-experiment.rst
+++ b/docs/6-run-experiment.rst
@@ -37,7 +37,7 @@ Analyze the experiment results
 -----------------------------------------
 Once the experiments have been run, the command:: 
 
-  ramble -D . workspace analyze 
+  ramble -P -D . workspace analyze 
 
 can be used to analyze figures of merit and evaluate 
 `success/failure <https://googlecloudplatform.github.io/ramble/success_criteria.html>`_ 


### PR DESCRIPTION
~installs required packages into user's python environment before running ramble commands~

Instead, use `--disable-progress-bar` when calling ramble to avoid having tqdm be a required dependency.

Fixes #39 