### PR TITLE
Throw exceptions for bad input parameters

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -97,7 +97,7 @@ def benchpark_list_handler(args):
                     print(f"\t{system}")
             else:
                 raise ValueError(
-                    f"Invalid benchpark list \"{sublist}\" - must choose [benchmarks], [systems], or leave empty"
+                    f'Invalid benchpark list "{sublist}" - must choose [benchmarks], [systems], or leave empty'
                 )
 
 
@@ -105,7 +105,7 @@ def benchpark_check_benchmark(arg_str):
     benchmarks = benchpark_benchmarks()
     found = arg_str in benchmarks
     if not found:
-        out_str = f"Invalid benchmark/experiment \"{arg_str}\" - must choose one of: "
+        out_str = f'Invalid benchmark/experiment "{arg_str}" - must choose one of: '
         for benchmark in benchmarks:
             out_str += f"\n\t{benchmark}"
         raise ValueError(out_str)
@@ -116,7 +116,7 @@ def benchpark_check_system(arg_str):
     systems = benchpark_systems()
     found = arg_str in systems
     if not found:
-        out_str = f"Invalid system \"{arg_str}\" - must choose one of: "
+        out_str = f'Invalid system "{arg_str}" - must choose one of: '
         for system in systems:
             out_str += f"\n\t{system}"
         raise ValueError(out_str)
@@ -194,7 +194,11 @@ def benchpark_setup_handler(args):
     debug_print(f"specified system = {system}")
     valid_system = benchpark_check_system(system)
     if not (valid_benchmark and valid_system):
-        raise ValueError("Invalid benchmark/experiment and system provided: {0} {1}".format(benchmark, system))
+        raise ValueError(
+            "Invalid benchmark/experiment and system provided: {0} {1}".format(
+                benchmark, system
+            )
+        )
 
     workspace_dir = workspace_root / str(benchmark) / str(system)
 

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -96,8 +96,8 @@ def benchpark_list_handler(args):
                 for system in systems:
                     print(f"\t{system}")
             else:
-                print(
-                    f"Invalid benchpark list [{sublist}] - must choose [benchmarks],[systems], or leave empty"
+                raise ValueError(
+                    f"Invalid benchpark list \"{sublist}\" - must choose [benchmarks], [systems], or leave empty"
                 )
 
 
@@ -105,9 +105,10 @@ def benchpark_check_benchmark(arg_str):
     benchmarks = benchpark_benchmarks()
     found = arg_str in benchmarks
     if not found:
-        print(f"Invalid benchmark/experiment {arg_str} - must choose one of: ")
+        out_str = f"Invalid benchmark/experiment \"{arg_str}\" - must choose one of: "
         for benchmark in benchmarks:
-            print(f"\t{benchmark}")
+            out_str += f"\n\t{benchmark}"
+        raise ValueError(out_str)
     return found
 
 
@@ -115,9 +116,10 @@ def benchpark_check_system(arg_str):
     systems = benchpark_systems()
     found = arg_str in systems
     if not found:
-        print(f"Invalid system {arg_str} - must choose one of: ")
+        out_str = f"Invalid system \"{arg_str}\" - must choose one of: "
         for system in systems:
-            print(f"\t{system}")
+            out_str += f"\n\t{system}"
+        raise ValueError(out_str)
     return found
 
 
@@ -192,7 +194,7 @@ def benchpark_setup_handler(args):
     debug_print(f"specified system = {system}")
     valid_system = benchpark_check_system(system)
     if not (valid_benchmark and valid_system):
-        return
+        raise ValueError("Invalid benchmark/experiment and system provided: {0} {1}".format(benchmark, system))
 
     workspace_dir = workspace_root / str(benchmark) / str(system)
 


### PR DESCRIPTION
Basic exception handling, will work towards creating benchpark-specific exception handling in the future.

Fixes #35 

```
$ benchpark setup sax/cu cts1 .
Traceback (most recent call last):
  ...
ValueError: Invalid benchmark/experiment "sax/cu" - must choose one of:
	saxpy/cuda
	saxpy/rocm
	saxpy/openmp
	amg2023/cuda
	amg2023/rocm
	amg2023/openmp
	raja-perf/cuda
	raja-perf/mpi-only
	raja-perf/rocm
	raja-perf/openmp
```

```
$ benchpark list mysys
Traceback (most recent call last):
  ...
ValueError: Invalid benchpark list "mysys" - must choose [benchmarks],[systems], or leave empty
```

```
$ benchpark setup saxpy/openmp mysys .
Traceback (most recent call last):
  ...
ValueError: Invalid system "mysys" - must choose one of: 
	cts1
	ats2
	ats4
	x86
```

```
$ benchpark se
usage: benchpark [-h] {list,setup} ...
benchpark: error: argument subcommand: invalid choice: 'se' (choose from 'list', 'setup')
```

```
$ benchpark setup
usage: benchpark setup [-h] benchmark system workspace_root
benchpark setup: error: the following arguments are required: benchmark, system, workspace_root
```

```
$ benchpark --help
usage: benchpark [-h] {list,setup} ...

Benchpark

options:
  -h, --help    show this help message and exit

Subcommands:
  {list,setup}
    list        List available benchmarks and systems
    setup       Create a benchmark and prepare it to build/run
```