### PR TITLE
Add README.rst to the docs ci filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             docs:
               - '.github/**'
               - 'docs/**'
+              - 'README.rst'
             style:
               - '.github/**'
               - 'bin/**'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,6 +25,7 @@ jobs:
           . workspace/saxpy/openmp/x86/ramble/share/ramble/setup-env.sh
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
+          spack config add "packages:all:target:[x86_64_v3]"
 
           env | grep SPACK >> "$GITHUB_ENV"
           env | grep SPACK >> "$GITHUB_ENV"

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 ==================================================
-Benchpark 
+Benchpark
 ==================================================
 
-You can find detailed documentation in `ReadTheDocs
+You can find detailed documentation at `software.llnl.gov/benchpark
 <https://software.llnl.gov/benchpark>`_. Benchpark can also be found on `GitHub
 <https://github.com/llnl/benchpark>`_.
 
@@ -10,7 +10,7 @@ Benchpark is an open collaborative repository for reproducible specifications of
 Benchpark enables cross-site collaboration on benchmarking by providing a mechanism for sharing
 reproducible, working specifications for the following:
 
-1. **System specifications** 
+1. **System specifications**
 
 - location of system compilers and system MPI
 - system scheduler and launcher
@@ -19,7 +19,7 @@ reproducible, working specifications for the following:
 
 - source repo and version
 - build (Spack) configuration
-- run (Ramble) configuration 
+- run (Ramble) configuration
 
 3. **Experiment specifications**
 
@@ -35,14 +35,14 @@ Benchpark uses the following open source projects for specifying configurations:
 
 Community
 ---------
-Benchpark is an open source project.  Questions, discussion, and contributions 
+Benchpark is an open source project.  Questions, discussion, and contributions
 of new benchmarks, experiments, and system specifications are welcome.
 We use `github discussions <https://github.com/llnl/benchpark/discussions>`_ for Q&A and discussion.
 
 Contributing
 ------------
-To contribute to Benchpark, please open a `pull request 
-<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_ 
+To contribute to Benchpark, please open a `pull request
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_
 to the `develop` branch.  Your PR must pass Benchpark's unit tests, and must be `PEP 8 <https://peps.python.org/pep-0008/>`_ compliant.
 
 Authors and citations
@@ -53,12 +53,12 @@ Benchpark was created by Olga Pearce, Alec Scott, Greg Becker, Riyaz Haque, and 
 
 To cite Benchpark, please use the following citation:
 
-Olga Pearce, Alec Scott, Gregory Becker, Riyaz Haque, Nathan Hanford, Stephanie Brink, 
-Doug Jacobsen, Heidi Poxon, Jens Domke, and Todd Gamblin. 2023. 
-Towards Collaborative Continuous Benchmarking for HPC. 
-In Workshops of The International Conference on High Performance Computing, 
-Network, Storage, and Analysis (SC-W 2023), November 12–17, 2023, Denver, CO, USA. 
-ACM, New York, NY, USA, 9 pages. 
+Olga Pearce, Alec Scott, Gregory Becker, Riyaz Haque, Nathan Hanford, Stephanie Brink,
+Doug Jacobsen, Heidi Poxon, Jens Domke, and Todd Gamblin. 2023.
+Towards Collaborative Continuous Benchmarking for HPC.
+In Workshops of The International Conference on High Performance Computing,
+Network, Storage, and Analysis (SC-W 2023), November 12–17, 2023, Denver, CO, USA.
+ACM, New York, NY, USA, 9 pages.
 `doi.org/10.1145/3624062.3624135 <https://doi.org/10.1145/3624062.3624135>`_.
 
 License


### PR DESCRIPTION
Changes to the README should force a rebuild of the docs since the README is used as the docs index.