### PR TITLE
Allow CI to use an unsigned packages from the GH Actions Cache

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,9 +26,10 @@ jobs:
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
           spack config add "packages:all:target:[x86_64_v3]"
+          export SPACK_INSTALL_FLAGS=--no-check-signature
 
           env | grep SPACK >> "$GITHUB_ENV"
-          env | grep SPACK >> "$GITHUB_ENV"
+          env | grep RAMBLE >> "$GITHUB_ENV"
           echo "PATH=$PATH" >> "$GITHUB_ENV"
 
       - name: Setup Saxpy Workspace

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,7 +26,6 @@ jobs:
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
           spack config add "packages:all:target:[x86_64_v3]"
-          ramble config add "config:spack:flags:install:'--reuse --no-check-signature'"
 
           env | grep SPACK >> "$GITHUB_ENV"
           env | grep RAMBLE >> "$GITHUB_ENV"
@@ -35,20 +34,45 @@ jobs:
       - name: Setup Saxpy Workspace
         working-directory: ./workspace/saxpy/openmp/x86/workspace/
         run: |
-          ramble --workspace-dir . --disable-progress-bar --disable-logger workspace setup
+          ramble \
+            --workspace-dir . \
+            --disable-progress-bar \
+            --disable-logger \
+            -c config:spack_flags:install:'--no-check-signature' \
+            workspace setup
 
       - name: Run Saxpy Experiments
         working-directory: ./workspace/saxpy/openmp/x86/workspace/
         run: |
-          ramble -c variables:n_nodes:1 -c variables:n_ranks:1 --workspace-dir . --disable-progress-bar --disable-logger on
+          ramble \
+            -c variables:n_nodes:1 \
+            -c variables:n_ranks:1 \
+            --workspace-dir . \
+            --disable-progress-bar \
+            --disable-logger \
+            on
 
       - name: Analyze Saxpy Results
         working-directory: ./workspace/saxpy/openmp/x86/workspace/
         run: |
-          ramble --workspace-dir . --disable-progress-bar --disable-logger workspace analyze
+          ramble \
+            --workspace-dir . \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace analyze
 
       - name: Upload Binaries to CI Cache
         if: github.ref == 'refs/heads/develop'
         run: |
-          spack mirror set --push --oci-username ${{ github.actor }} --oci-password "${{ secrets.GITHUB_TOKEN }}" ci-buildcache
-          spack buildcache push -j $(($(nproc) + 1)) --base-image ubuntu:22.04 --unsigned --update-index ci-buildcache $(spack find --format '/{hash}')
+          spack mirror set \
+            --push \
+            --oci-username ${{ github.actor }} \
+            --oci-password "${{ secrets.GITHUB_TOKEN }}" \
+            ci-buildcache
+
+          spack buildcache push \
+            -j $(($(nproc) + 1)) \
+            --base-image ubuntu:22.04 \
+            --unsigned \
+            --update-index ci-buildcache \
+            $(spack find --format '/{hash}')

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,7 +26,7 @@ jobs:
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
           spack config add "packages:all:target:[x86_64_v3]"
-          export SPACK_INSTALL_FLAGS=--no-check-signature
+          ramble config add "config:spack:flags:install:'--reuse --no-check-signature'"
 
           env | grep SPACK >> "$GITHUB_ENV"
           env | grep RAMBLE >> "$GITHUB_ENV"


### PR DESCRIPTION
Update the `run.yml` ci script to allow the workspace to be setup with unsigned binaries from the local GitHub binary cache.