### PR TITLE
Adding support for AWS x86 ParallelCluster 3.7.2 w/EFA

### DIFF
--- a/configs/AWS-x86-ParallelCluster-3.7.2/README.txt
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/README.txt
@@ -4,7 +4,7 @@ AWS x86 ParallelCluster 3.7.2
 This config should work on any AWS x86 ParallelCluster 3.7.2 instance with the
 following caveats:
 
-1) All compute instances must be x86 and EFA enabled. Supported instances types
+1) All compute instances must be x86 and EFA enabled. Supported instance types
    can be found here:
 
    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
@@ -17,7 +17,7 @@ following caveats:
 
    sudo yum install lapack
 
-3) OpenMPI is the only supported MPI flavor. InelMPI is not yet supported.
+3) OpenMPI is the only supported MPI flavor. IntelMPI is not yet supported.
 
    OpenMPI is running in verbose mode so the user than confirm that EFA is
    being used when running experiments. A line similar to the following in

--- a/configs/AWS-x86-ParallelCluster-3.7.2/README.txt
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/README.txt
@@ -1,0 +1,29 @@
+AWS x86 ParallelCluster 3.7.2
+-----------------------------
+
+This config should work on any AWS x86 ParallelCluster 3.7.2 instance with the
+following caveats:
+
+1) All compute instances must be x86 and EFA enabled. Supported instances types
+   can be found here:
+
+   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
+
+2) Any OS supported by ParallelCluster 3.7.2 should work, but only Amazon
+   Linux 2 has been tested
+
+3) ParallelCluster does not install optimized versions of BLAS/LAPACK. This
+   config uses the generic versions installed via:
+
+   sudo yum install lapack
+
+3) OpenMPI is the only supported MPI flavor. InelMPI is not yet supported.
+
+   OpenMPI is running in verbose mode so the user than confirm that EFA is
+   being used when running experiments. A line similar to the following in
+   slurm-NNN.out confirms EFA is being used:
+
+   mtl_ofi_component.c:362: mtl:ofi:provider: rdmap0s6-rdm 
+
+   This debugging output can be silenced by removing the env variable
+   'OMPI_MCA_mtl_base_verbose=100' from the srun line in variables.yaml. 

--- a/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/compilers.yaml
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/compilers.yaml
@@ -2,7 +2,7 @@ compilers:
 - compiler:
     spec: gcc@7.3.1
     paths:
-      cc: /usr//bin/gcc
+      cc: /usr/bin/gcc
       cxx: /usr/bin/g++
       f77: /usr/bin/gfortran
       fc: /usr/bin/gfortran

--- a/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/compilers.yaml
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: gcc@7.3.1
+    paths:
+      cc: /usr//bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: alinux2
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/packages.yaml
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/auxiliary_software_files/packages.yaml
@@ -1,0 +1,27 @@
+packages:
+  tar:
+    externals:
+    - spec: tar@1.26
+      prefix: /usr
+      buildable: false
+  gmake:
+    externals:
+    - spec: gmake@3.8.2
+      prefix: /usr
+  blas:
+    externals:
+    - spec: blas@3.4.2
+      prefix: /usr
+      buildable: false
+  lapack:
+    externals:
+    - spec: lapack@3.4.2
+      prefix: /usr
+      buildable: false
+  mpi:
+    externals:
+    - spec: openmpi@4.1.5-gcc731
+      prefix: /opt/amazon/openmpi
+      buildable: false
+      extra_attributes:
+        ldflags: "-L/opt/amazon/openmpi/lib -lmpi"

--- a/configs/AWS-x86-ParallelCluster-3.7.2/spack.yaml
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/spack.yaml
@@ -1,0 +1,12 @@
+spack:
+  packages:
+    default-compiler:
+      spack_spec: gcc@7.3.1
+    default-mpi:
+      spack_spec: openmpi@4.1.5-gcc731
+    compiler-gcc:
+      spack_spec: gcc@7.3.1
+    lapack:
+      spack_spec: lapack@3.4.2
+    mpi-gcc:
+      spack_spec: openmpi@4.1.5-gcc731

--- a/configs/AWS-x86-ParallelCluster-3.7.2/variables.yaml
+++ b/configs/AWS-x86-ParallelCluster-3.7.2/variables.yaml
@@ -1,0 +1,7 @@
+variables:
+  batch_time: '02:00'
+  mpi_command: 'srun -N {n_nodes} -n {n_ranks} --mpi=pmix --export=ALL,FI_EFA_USE_DEVICE_RDMA=1,FI_PROVIDER="efa",OMPI_MCA_mtl_base_verbose=100'
+  batch_submit: 'sbatch {execute_experiment}'
+  batch_nodes: '#SBATCH -N {n_nodes}'
+  batch_ranks: '#SBATCH -n {n_ranks}'
+  batch_timeout: '#SBATCH -t {batch_time}:00'


### PR DESCRIPTION
Adding initial support for AWS ParallelCluster 3.7.2 instances with x86/EFA compute nodes. This config should work with any non-GPU, x86, EFA-enabled instance type. Only OpenMPI is currently supported. I'll add IntelMPI and GPU support in a future commit. I've added a README.txt to the config directory for details on the ParallelCluster config. 

All non-cuda/non-rocm experiments run.