### PR TITLE
Clone Spack (and Ramble) less

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Setup Ramble & Spack
         run: |
-          . workspace/saxpy/openmp/x86/spack/share/spack/setup-env.sh
-          . workspace/saxpy/openmp/x86/ramble/share/ramble/setup-env.sh
+          . workspace/spack/share/spack/setup-env.sh
+          . workspace/ramble/share/ramble/setup-env.sh
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
           spack config add "packages:all:target:[x86_64_v3]"

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -180,8 +180,8 @@ def benchpark_setup_handler(args):
                     configs/
                         (everything from source/configs/<system>)
                         (everything from source/experiments/<benchmark>)
-                spack/
-                ramble/
+        spack/
+        ramble/
     """
 
     benchmark = args.benchmark
@@ -226,43 +226,45 @@ def benchpark_setup_handler(args):
     symlink_tree(configs_src_dir, ramble_configs_dir)
     symlink_tree(experiment_src_dir, ramble_configs_dir)
 
-    spack_location = workspace_dir / "spack"
-    ramble_location = workspace_dir / "ramble"
-
-    print(f"Cloning spack into {spack_location}")
-    run_command(
-        "git clone --depth=1 -c feature.manyFiles=true "
-        "https://github.com/spack/spack.git "
-        f"{spack_location}"
-    )
-
-    print(f"Cloning ramble into {ramble_location}")
-    run_command(
-        "git clone --depth=1 -c feature.manyFiles=true "
-        "https://github.com/GoogleCloudPlatform/ramble.git "
-        f"{ramble_location}"
-    )
+    spack_location = workspace_root / "spack"
+    ramble_location = workspace_root / "ramble"
 
     spack_exe = spack_location / "bin" / "spack"
     ramble_exe = ramble_location / "bin" / "ramble"
     spack_cache_location = spack_location / "misc-cache"
 
-    env = {"SPACK_DISABLE_LOCAL_CONFIG": "1"}
-    run_command(
-        f"{spack_exe} config --scope=site add config:misc_cache:{spack_cache_location}",
-        env=env,
-    )
-    run_command(f"{spack_exe} repo add --scope=site {source_dir}/repo", env=env)
+    if not spack_location.exists():
+        print(f"Cloning spack into {spack_location}")
+        run_command(
+            "git clone --depth=1 -c feature.manyFiles=true "
+            "https://github.com/spack/spack.git "
+            f"{spack_location}"
+        )
 
-    run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
+        env = {"SPACK_DISABLE_LOCAL_CONFIG": "1"}
+        run_command(
+            f"{spack_exe} config --scope=site add config:misc_cache:{spack_cache_location}",
+            env=env,
+        )
+        run_command(f"{spack_exe} repo add --scope=site {source_dir}/repo", env=env)
+
+    if not ramble_location.exists():
+        print(f"Cloning ramble into {ramble_location}")
+        run_command(
+            "git clone --depth=1 -c feature.manyFiles=true "
+            "https://github.com/GoogleCloudPlatform/ramble.git "
+            f"{ramble_location}"
+        )
+
+        run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
 
     instructions = f"""\
 To complete the benchpark setup, do the following:
 
     cd {workspace_dir}/workspace
 
-    . {workspace_dir}/spack/share/spack/setup-env.sh
-    . {workspace_dir}/ramble/share/ramble/setup-env.sh
+    . {spack_location}/share/spack/setup-env.sh
+    . {ramble_location}/share/ramble/setup-env.sh
 
     export SPACK_DISABLE_LOCAL_CONFIG=1
 


### PR DESCRIPTION
Clone spack and ramble once per benchpark workspace (vs. once per benchmark workspace).

For example

```
benchpark setup saxpy/openmp x86 test-workspace
benchpark setup raja-perf/openmp x86 test-workspace
```

would have normally cloned Spack and Ramble twice (two copies of each).

This moves Spack and Ramble into the benchpark workspace dir (i.e. `workspace_root` in `benchpark setup --help`). With the changes here, the `test-workspace` dir would look like:

```
$ ls test-workspace/
raja-perf  ramble  saxpy  spack
```

which might be confusing: perhaps `ramble` and `spack` could be put into a `tools` or `libs` subdirectory.