### PR TITLE
Add gromacs openmp config

### DIFF
--- a/configs/ats4/auxiliary_software_files/packages.yaml
+++ b/configs/ats4/auxiliary_software_files/packages.yaml
@@ -189,6 +189,11 @@ packages:
     buildable: false
   hypre:
     variants: amdgpu_target=gfx90a
+  hwloc:
+    externals:
+    - spec: hwloc@2.9.1
+      prefix: /usr
+      buildable: false
   mpi:
     buildable: false
   cray-mpich:

--- a/configs/cts1/auxiliary_software_files/packages.yaml
+++ b/configs/cts1/auxiliary_software_files/packages.yaml
@@ -23,6 +23,16 @@ packages:
     - spec: intel-oneapi-mkl@2022.1.0
       prefix: /usr/tce/backend/installations/linux-rhel8-x86_64/intel-19.0.4/intel-oneapi-mkl-2022.1.0-sksz67twjxftvwchnagedk36gf7plkrp
       buildable: false
+  hwloc:
+    externals:
+    - spec: hwloc@2.9.1
+      prefix: /usr
+      buildable: false
+  fftw:
+    externals:
+    - spec: fftw@3.3.10
+      prefix: /usr/tce/packages/fftw/fftw-3.3.10
+      buildable: false
   mpi:
     externals:
     - spec: mvapich2@2.3.7-gcc1211

--- a/experiments/gromacs/openmp/execute_experiment.tpl
+++ b/experiments/gromacs/openmp/execute_experiment.tpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+{batch_nodes}
+{batch_ranks}
+{batch_timeout}
+
+cd {experiment_run_dir}
+
+{spack_setup}
+
+{experiment_setup}
+
+{command}

--- a/experiments/gromacs/openmp/ramble.yaml
+++ b/experiments/gromacs/openmp/ramble.yaml
@@ -1,0 +1,50 @@
+ramble:
+  include:
+  - ./configs/spack.yaml
+  - ./configs/variables.yaml
+
+  config:
+    deprecated: true
+    spack_flags:
+      install: '--add --keep-stage'
+      concretize: '-U -f'
+
+  applications:
+    gromacs:
+      workloads:
+        water_gmx50:
+          env_vars:
+            set:
+              OMP_NUM_THREADS: '{omp_num_threads}'
+          variables:
+            n_ranks: '{processes_per_node} * {n_nodes}'
+            size: ['1536', '3072']
+            experiment_setup: ''
+            processes_per_node: ['8', '4']
+            n_nodes: ['1', '2']
+            threads_per_node_core: ['2', '4']
+            omp_num_threads: '{threads_per_node_core} * {n_nodes}'
+          experiments:
+            gromacs_omp_water_gmx50_{n_nodes}_{omp_num_threads}_{size}:
+              variables:
+                env_name: gromacs-omp
+              matrices:
+                - size_threads:
+                  - size
+                  - threads_per_node_core
+  spack:
+    concretized: true
+    packages:
+      fftw-omp:
+        spack_spec: fftw@3.3.10 +mpi+openmp
+        compiler: default-compiler
+      gromacs-omp:
+        spack_spec: gromacs@main +mpi+openmp~hwloc
+        compiler: default-compiler
+    environments:
+      gromacs-omp:
+        packages:
+        - lapack
+        - default-mpi
+        - fftw-omp
+        - gromacs-omp


### PR DESCRIPTION
1. Added the gromacs openmp config
2. The config works with for the systems: cts1 and x86 (on cts1) 
3. The config fails for ats4 due to a cmake error within gromacs (this probably needs to be fixed within the gromacs build system)
4. Running gromacs with hwloc on results in a runtime error on cts1 (hence the code is built with hwloc off)