### PR TITLE
Fix Dependabot Config & Expand to Manage Python CI Deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
-versions: 2
+version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/.github/workflows/requirements"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # setuptools releases new versions almost daily
+      - dependency-name: "setuptools"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
- Fixed a typo in our dependabot configuration that was preventing automatic CI dependency updates.
- Expanded the dependabot configuration to include checking python dependencies in CI via pip.