### PR TITLE
Add Nightly CI to Continually Test Benchmark Builds and Runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,13 @@
+name: nightly
+on:
+  schedule:
+    - cron: '0 14 * * *'
+
+#------------------------------------------------------------------------
+# Execute a nightly CI run to verify benchmarks continue to build & run
+# sucessfully. Will also update the CI buildcache to minimize build
+# times in PRs.
+#------------------------------------------------------------------------
+jobs:
+  run:
+    uses: ./.github/workflows/run.yml


### PR DESCRIPTION
Added a minimal nightly CI system to build & test benchmarks nightly.

In follow up PRs I'd like to add onto this CI to allow it to automatically create issues when nightly runs fail and tag the relevant benchmark maintainers. (But this is a start to get us building & testing nightly.)