### PR TITLE
Save Workspace Archive as CI Artifact

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -61,6 +61,22 @@ jobs:
             --disable-logger \
             workspace analyze
 
+      - name: Archive Experiment Workspace
+        if: always()
+        run: |
+          ramble \
+            --workspace-dir . \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace archive
+
+      - name: Upload Workspace Archive as CI Artifact
+        if: always()
+        uses: actions/upload-artifact
+        with:
+          name: workspace-archive
+          path: 'archive/**'
+
       - name: Upload Binaries to CI Cache
         if: github.ref == 'refs/heads/develop'
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -73,12 +73,11 @@ jobs:
           ls -hla
 
       - name: Upload Workspace Archive as CI Artifact
-        working-directory: ./workspace/saxpy/openmp/x86_64/workspace/
         if: always()
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:
           name: workspace-archive
-          path: 'archive/**'
+          path: './workspace/saxpy/openmp/x86_64/workspace/archive/**'
 
       - name: Upload Binaries to CI Cache
         if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -62,6 +62,7 @@ jobs:
             workspace analyze
 
       - name: Archive Experiment Workspace
+        working-directory: ./workspace/saxpy/openmp/x86_64/workspace/
         if: always()
         run: |
           ramble \
@@ -72,6 +73,7 @@ jobs:
           ls -hla
 
       - name: Upload Workspace Archive as CI Artifact
+        working-directory: ./workspace/saxpy/openmp/x86_64/workspace/
         if: always()
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -70,7 +70,6 @@ jobs:
             --disable-progress-bar \
             --disable-logger \
             workspace archive
-          ls -hla
 
       - name: Upload Workspace Archive as CI Artifact
         if: always()

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -69,10 +69,11 @@ jobs:
             --disable-progress-bar \
             --disable-logger \
             workspace archive
+          ls -hla
 
       - name: Upload Workspace Archive as CI Artifact
         if: always()
-        uses: actions/upload-artifact
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:
           name: workspace-archive
           path: 'archive/**'


### PR DESCRIPTION
- Added an additional set of steps in `run.yml` to upload an archive of the repository as a CI artifact. In the future we may be able to use this data to determine differences between failing/successful workspaces.