### PR TITLE
Run `isort` and `codespell` Against Repo & Add to CI

### DIFF
--- a/.github/workflows/bin/license
+++ b/.github/workflows/bin/license
@@ -9,8 +9,8 @@ from __future__ import print_function
 
 import os
 import re
-from collections import defaultdict
 import sys
+from collections import defaultdict
 
 #: SPDX license id must appear in the first <license_lines> lines of a file
 license_lines = 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,10 @@ jobs:
       run: |
         sphinx-build docs/ _build
 
+    - name: Check for Typos using Codespell
+      run: |
+        codespell
+
     - name: Upload artifact
       uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8
       if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/requirements/docs.txt
+++ b/.github/workflows/requirements/docs.txt
@@ -1,3 +1,4 @@
 # docs
 sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
+codespell==2.2.6

--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -1,2 +1,4 @@
 black==23.12.1
 flake8==7.0.0
+isort==5.13.2
+codespell==2.2.6

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,9 @@ jobs:
         run: |
           pip install -r .github/workflows/requirements/style.txt
 
-      - name: Lint and Format Check with Flake8 and Black
+      - name: Lint and Format Check
         run: |
           black --diff --check .
+          codespell
+          isort
           flake8

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -6,11 +6,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import subprocess
-import pathlib
 import os
-import shutil
+import pathlib
 import shlex
+import shutil
+import subprocess
 import sys
 
 DEBUG = False

--- a/docs/generate-sys-defs-list.py
+++ b/docs/generate-sys-defs-list.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import yaml
 import glob
+
 import pandas as pd
+import yaml
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ skip_gitignore = true
 color_output = true
 
 [tool.codespell]
-skip = 'docs/_build,docs/_static'
+skip = './_build,./docs/_static'
 ignore-words-list = 'fom'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,5 @@ skip_gitignore = true
 color_output = true
 
 [tool.codespell]
+skip = 'docs/_build'
 ignore-words-list = 'fom'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.8"
 
 [tool.black]
 line-length = 88
+color = true
 target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$|bin\/benchpark'
 exclude = '''
@@ -23,3 +24,12 @@ exclude = '''
   | repo
 )/
 '''
+
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+color_output = true
+
+[tool.codespell]
+skip = '*.rst'
+ignore-words-list = 'fom'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,4 @@ skip_gitignore = true
 color_output = true
 
 [tool.codespell]
-skip = '*.rst'
 ignore-words-list = 'fom'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ skip_gitignore = true
 color_output = true
 
 [tool.codespell]
-skip = 'docs/_build'
+skip = 'docs/_build,docs/_static'
 ignore-words-list = 'fom'

--- a/repo/amg2023/application.py
+++ b/repo/amg2023/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class Amg2023(SpackApplication):
     """AMG2023 benchmark"""

--- a/repo/cray-mpich/package.py
+++ b/repo/cray-mpich/package.py
@@ -6,6 +6,7 @@
 from spack.package import *
 from spack.pkg.builtin.cray_mpich import CrayMpich as BuiltinCM
 
+
 class CrayMpich(BuiltinCM):
 
     variant("gtl", default=False, description="enable GPU-aware mode")

--- a/repo/cublas/package.py
+++ b/repo/cublas/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Cublas(Package):
 
     provides("blas")

--- a/repo/hypre/package.py
+++ b/repo/hypre/package.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 from spack.package import *
 from spack.pkg.builtin.hypre import Hypre as BuiltinHypre
 
-import os
 
 class Hypre(BuiltinHypre):
     requires("+rocm", when="^rocblas")

--- a/repo/lapack-xl/package.py
+++ b/repo/lapack-xl/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class LapackXl(Package):
 
     provides("lapack")

--- a/repo/lbann/application.py
+++ b/repo/lbann/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class LBANN(SpackApplication):
     """LBANN benchmark"""

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class RajaPerf(SpackApplication):
     """RAJA Performance suite"""

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -3,15 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import socket
 import glob
+import os
 import re
-
+import socket
 from os import environ as env
 from os.path import join as pjoin
 
 from spack import *
+
 
 def spec_uses_toolchain(spec):
     gcc_toolchain_regex = re.compile(".*gcc-toolchain.*")

--- a/repo/rocblas/package.py
+++ b/repo/rocblas/package.py
@@ -6,6 +6,7 @@
 from spack.package import *
 from spack.pkg.builtin.rocblas import Rocblas as BuiltinRocblas
 
+
 class Rocblas(BuiltinRocblas):
 
     provides("blas")

--- a/repo/rocsolver/package.py
+++ b/repo/rocsolver/package.py
@@ -6,6 +6,7 @@
 from spack.package import *
 from spack.pkg.builtin.rocsolver import Rocsolver as BuiltinRocsolver
 
+
 class Rocsolver(BuiltinRocsolver):
 
     provides("lapack")

--- a/repo/saxpy/application.py
+++ b/repo/saxpy/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class Saxpy(SpackApplication):
     """saxpy benchmark"""

--- a/repo/saxpy/package.py
+++ b/repo/saxpy/package.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from spack.package import *
 import os
 import shutil
+
 import spack.repo
+from spack.package import *
+
 
 class Saxpy(CMakePackage, CudaPackage, ROCmPackage):
     """Test saxpy problem."""


### PR DESCRIPTION
- Add `isort` to list of style checks to keep files in line with Spack formatting requirements. (This'll save us later on when we want to upstream stuff to Spack/Ramble.)
- Add `codespell` to style checks to alert us to (likely my) typos.