### PR TITLE
Clean up legacy manual workflow calls

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,5 @@
 name: Build & Deploy docs site to GitHub Pages
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,5 @@
 name: License Checks
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,7 +1,5 @@
 name: Run Benchpark and Simple Benchmark Suite
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,7 +1,5 @@
 name: Linting & Style Checks
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
I realized I never really meant to leave these in after testing. Removing them simplifies the actions tab for the repository.