### PR TITLE
Remove site-specific details from Ramble config

### DIFF
--- a/configs/HPECray-zen3-MI250X-Slingshot/spack.yaml
+++ b/configs/HPECray-zen3-MI250X-Slingshot/spack.yaml
@@ -6,20 +6,20 @@
 spack:
   packages:
     default-compiler:
-      spack_spec: cce@16.0.0-rocm5.5.1
+      spack_spec: cce@16
     default-mpi:
-      spack_spec: cray-mpich@8.1.26%cce ~gtl
+      spack_spec: cray-mpich@8.1%cce ~gtl
     compiler-rocm:
-      spack_spec: cce@16.0.0-rocm5.5.1
+      spack_spec: cce@16
     blas-rocm:
-      spack_spec: rocblas@5.5.1
+      spack_spec: rocblas@5.5
     blas:
-      spack_spec: rocblas@5.5.1
+      spack_spec: rocblas@5.5
     lapack:
-      spack_spec: cray-libsci@23.05.1.4
+      spack_spec: cray-libsci@23
     mpi-rocm-gtl:
-      spack_spec: cray-mpich@8.1.26%cce +gtl
+      spack_spec: cray-mpich@8.1%cce +gtl
     mpi-rocm-no-gtl:
-      spack_spec: cray-mpich@8.1.26%cce ~gtl
+      spack_spec: cray-mpich@8.1%cce ~gtl
     mpi-gcc:
-      spack_spec: cray-mpich@8.1.26%gcc ~gtl
+      spack_spec: cray-mpich@8.1%gcc ~gtl


### PR DESCRIPTION
Remove version information at the degree of specificity that is likely to be constrained to a site: this is already enforced in the auxiliary-software-files.

This keeps major version info since that is likely to be useful across sites.

Similar changes could also be applied for the other Ramble configs