### PR TITLE
Create script to bundle 3 instructions into 1

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,7 @@ jobs:
 
       - name: Setup Ramble & Spack
         run: |
-          . workspace/spack/share/spack/setup-env.sh
-          . workspace/ramble/share/ramble/setup-env.sh
+          . workspace/setup.sh
 
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
           spack config add "packages:all:target:[x86_64_v3]"

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -284,8 +284,12 @@ def benchpark_setup_handler(args):
         )
 
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
-        run_command(f"{ramble_exe} config --scope=site add \"config:disable_progress_bar:true\"")
-        run_command(f"{ramble_exe} config --scope=site add \"config:spack:global:args:'-d'\"")
+        run_command(
+            f'{ramble_exe} config --scope=site add "config:disable_progress_bar:true"'
+        )
+        run_command(
+            f"{ramble_exe} config --scope=site add \"config:spack:global:args:'-d'\""
+        )
 
     if not initializer_script.exists():
         with open(initializer_script, "w") as f:

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -258,6 +258,8 @@ def benchpark_setup_handler(args):
     ramble_exe = ramble_location / "bin" / "ramble"
     spack_cache_location = spack_location / "misc-cache"
 
+    initializer_script = experiments_root / "setup.sh"
+
     if not spack_location.exists():
         print(f"Cloning spack into {spack_location}")
         run_command(
@@ -283,13 +285,25 @@ def benchpark_setup_handler(args):
 
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
 
+    if not initializer_script.exists():
+        with open(initializer_script, 'w') as f:
+            f.write(f"""\
+if [ -n "${{!_BENCHPARK_INITIALIZED}}" ]; then
+    exit 0
+fi
+
+. {spack_location}/share/spack/setup-env.sh
+. {ramble_location}/share/ramble/setup-env.sh
+
+export SPACK_DISABLE_LOCAL_CONFIG=1
+
+export _BENCHPARK_INITIALIZED=1
+""")
+
     instructions = f"""\
 To complete the benchpark setup, do the following:
 
-    . {spack_location}/share/spack/setup-env.sh
-    . {ramble_location}/share/ramble/setup-env.sh
-
-    export SPACK_DISABLE_LOCAL_CONFIG=1
+    . {initializer_script}
 
 Further steps are needed to build the experiments (ramble -P -D {ramble_workspace_dir} workspace setup) and run them (ramble -P -D {ramble_workspace_dir} on)
 """

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -289,8 +289,8 @@ def benchpark_setup_handler(args):
         with open(initializer_script, "w") as f:
             f.write(
                 f"""\
-if [ -n "${{!_BENCHPARK_INITIALIZED}}" ]; then
-    exit 0
+if [ -n "${{_BENCHPARK_INITIALIZED:-}}" ]; then
+    return 0
 fi
 
 . {spack_location}/share/spack/setup-env.sh
@@ -298,7 +298,7 @@ fi
 
 export SPACK_DISABLE_LOCAL_CONFIG=1
 
-export _BENCHPARK_INITIALIZED=1
+export _BENCHPARK_INITIALIZED=true
 """
             )
 

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -284,6 +284,8 @@ def benchpark_setup_handler(args):
         )
 
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
+        run_command(f"{ramble_exe} config --scope=site add \"config:disable_progress_bar:true\"")
+        run_command(f"{ramble_exe} config --scope=site add \"config:spack:global:args:'-d'\"")
 
     if not initializer_script.exists():
         with open(initializer_script, "w") as f:

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -286,8 +286,9 @@ def benchpark_setup_handler(args):
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")
 
     if not initializer_script.exists():
-        with open(initializer_script, 'w') as f:
-            f.write(f"""\
+        with open(initializer_script, "w") as f:
+            f.write(
+                f"""\
 if [ -n "${{!_BENCHPARK_INITIALIZED}}" ]; then
     exit 0
 fi
@@ -298,7 +299,8 @@ fi
 export SPACK_DISABLE_LOCAL_CONFIG=1
 
 export _BENCHPARK_INITIALIZED=1
-""")
+"""
+            )
 
     instructions = f"""\
 To complete the benchpark setup, do the following:


### PR DESCRIPTION
After running `benchpark setup`, it usually tells the user to start with:

```
$ benchpark setup amg2023/rocm HPECray-zen3-MI250X-Slingshot `pwd`/w1
Setting up configs for Ramble workspace
...
To complete the benchpark setup, do the following:

    . .../w1/spack/share/spack/setup-env.sh
    . .../w1/ramble/share/ramble/setup-env.sh

    export SPACK_DISABLE_LOCAL_CONFIG=1
```

With this PR that reduces to

```
$ benchpark setup amg2023/rocm HPECray-zen3-MI250X-Slingshot `pwd`/w1
Setting up configs for Ramble workspace
...
To complete the benchpark setup, do the following:

    . .../w1/setup.sh
```