### PR TITLE
ROCm packages: externals consistency

### DIFF
--- a/configs/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/auxiliary_software_files/packages.yaml
+++ b/configs/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/auxiliary_software_files/packages.yaml
@@ -187,6 +187,27 @@ packages:
       prefix: /opt/rocm-5.4.3/
     - spec: hipblas@5.5.1
       prefix: /opt/rocm-5.5.1/
+  hsakmt-roct:
+    buildable: false
+    externals:
+    - spec: hsakmt-roct@5.4.3
+      prefix: /opt/rocm-5.4.3/
+    - spec: hsakmt-roct@5.5.1
+      prefix: /opt/rocm-5.5.1/
+  roctracer-dev-api:
+    buildable: false
+    externals:
+    - spec: roctracer-dev-api@5.4.3
+      prefix: /opt/rocm-5.4.3/
+    - spec: roctracer-dev-api@5.5.1
+      prefix: /opt/rocm-5.5.1/
+  rocminfo:
+    buildable: false
+    externals:
+    - spec: rocminfo@5.4.3
+      prefix: /opt/rocm-5.4.3/
+    - spec: rocminfo@5.5.1
+      prefix: /opt/rocm-5.5.1/
   llvm-amdgpu:
     externals:
     - spec: llvm-amdgpu@5.4.3

--- a/experiments/gromacs/rocm/ramble.yaml
+++ b/experiments/gromacs/rocm/ramble.yaml
@@ -53,10 +53,6 @@ ramble:
     environments:
       gromacs:
         packages:
-        - hip543
-        - hsa-rocr-dev543
-        - blas-rocm543
-        - lapack-rocm543
         - mpi-rocm-no-gtl
         - hipsycl
         - fftw

--- a/repo/gromacs/package.py
+++ b/repo/gromacs/package.py
@@ -8,9 +8,10 @@ import os
 import llnl.util.filesystem as fs
 
 from spack.package import *
+from spack.pkg.benchpark.rocm_consistency import RocmConsistency as RocmConsistency
 
 
-class Gromacs(CMakePackage, CudaPackage, ROCmPackage):
+class Gromacs(CMakePackage, CudaPackage, ROCmPackage, RocmConsistency):
     """GROMACS is a molecular dynamics package primarily designed for simulations
     of proteins, lipids and nucleic acids. It was originally developed in
     the Biophysical Chemistry department of University of Groningen, and is now

--- a/repo/rocm-consistency/package.py
+++ b/repo/rocm-consistency/package.py
@@ -28,6 +28,7 @@ class RocmConsistency(PackageBase):
             "6.0.0",
             "6.0.2",
         ]:
+            depends_on(f"hip@{ver}", when=f"%rocmcc@{ver} ^hip")
             depends_on(f"hsakmt-roct@{ver}", when=f"^hip@{ver}")
             depends_on(f"hsa-rocr-dev@{ver}", when=f"^hip@{ver}")
             depends_on(f"comgr@{ver}", when=f"^hip@{ver}")

--- a/repo/rocm-consistency/package.py
+++ b/repo/rocm-consistency/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack.package_base import PackageBase
+
+
+class RocmConsistency(PackageBase):
+    with when("+rocm"):
+        for ver in [
+            "5.1.0",
+            "5.1.3",
+            "5.2.0",
+            "5.2.1",
+            "5.2.3",
+            "5.3.0",
+            "5.3.3",
+            "5.4.0",
+            "5.4.3",
+            "5.5.0",
+            "5.5.1",
+            "5.6.0",
+            "5.6.1",
+            "5.7.0",
+            "5.7.1",
+            "6.0.0",
+            "6.0.2",
+        ]:
+            depends_on(f"hsakmt-roct@{ver}", when=f"^hip@{ver}")
+            depends_on(f"hsa-rocr-dev@{ver}", when=f"^hip@{ver}")
+            depends_on(f"comgr@{ver}", when=f"hip@{ver}")
+            depends_on(f"llvm-amdgpu@{ver} +rocm-device-libs", when=f"hip@{ver}")
+            depends_on(f"rocminfo@{ver}", when=f"hip@{ver}")
+            depends_on(f"roctracer-dev-api@{ver}", when=f"hip@{ver}")

--- a/repo/rocm-consistency/package.py
+++ b/repo/rocm-consistency/package.py
@@ -30,7 +30,7 @@ class RocmConsistency(PackageBase):
         ]:
             depends_on(f"hsakmt-roct@{ver}", when=f"^hip@{ver}")
             depends_on(f"hsa-rocr-dev@{ver}", when=f"^hip@{ver}")
-            depends_on(f"comgr@{ver}", when=f"hip@{ver}")
-            depends_on(f"llvm-amdgpu@{ver} +rocm-device-libs", when=f"hip@{ver}")
-            depends_on(f"rocminfo@{ver}", when=f"hip@{ver}")
-            depends_on(f"roctracer-dev-api@{ver}", when=f"hip@{ver}")
+            depends_on(f"comgr@{ver}", when=f"^hip@{ver}")
+            depends_on(f"llvm-amdgpu@{ver} +rocm-device-libs", when=f"^hip@{ver}")
+            depends_on(f"rocminfo@{ver}", when=f"^hip@{ver}")
+            depends_on(f"roctracer-dev-api@{ver}", when=f"^hip@{ver}")


### PR DESCRIPTION
@rfhaque  

(This PR targets another PR: https://github.com/LLNL/benchpark/pull/61)

When ROCm components are added as externals, we can't enforce consistency among the versions because externals do not consider dependencies (so even though the Spack `hip` builtin package enforces version locking for all dependencies, that is lost when it is external).

This creates a mixin `rocm-consistency` package we can use to enforce a consistent choice of versions among rocm components. This avoids the addition of version-aware Ramble identifiers in the experiments (those are removed here).