### PR TITLE
Pin spack and ramble

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -215,11 +215,7 @@ def working_dir(location):
 
 
 def git_clone_commit(url, commit, destination):
-    run_command(
-        "git clone -c feature.manyFiles=true "
-        f"{url} "
-        f"{destination}"
-    )
+    run_command(f"git clone -c feature.manyFiles=true {url} {destination}")
 
     with working_dir(destination):
         run_command(f"git checkout {commit}")
@@ -314,7 +310,9 @@ def benchpark_setup_handler(args):
     if not ramble_location.exists():
         print(f"Cloning ramble into {ramble_location}")
         git_clone_commit(
-            "https://github.com/GoogleCloudPlatform/ramble.git", ramble_commit, ramble_location
+            "https://github.com/GoogleCloudPlatform/ramble.git",
+            ramble_commit,
+            ramble_location,
         )
 
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -6,12 +6,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+from contextlib import contextmanager
 import os
 import pathlib
 import shlex
 import shutil
 import subprocess
 import sys
+import yaml
 
 DEBUG = False
 
@@ -202,6 +204,27 @@ def symlink_tree(src, dst):
             os.symlink(src_file, dst_symlink)
 
 
+@contextmanager
+def working_dir(location):
+    initial_dir = os.getcwd()
+    try:
+        os.chdir(location)
+        yield
+    finally:
+        os.chdir(initial_dir)
+
+
+def git_clone_commit(url, commit, destination):
+    run_command(
+        "git clone -c feature.manyFiles=true "
+        f"{url} "
+        f"{destination}"
+    )
+
+    with working_dir(destination):
+        run_command(f"git checkout {commit}")
+
+
 def benchpark_setup_handler(args):
     """
     experiments_root/
@@ -269,12 +292,16 @@ def benchpark_setup_handler(args):
 
     initializer_script = experiments_root / "setup.sh"
 
+    checkout_versions_location = source_dir / "checkout-versions.yaml"
+    with open(checkout_versions_location, "r") as yaml_file:
+        data = yaml.safe_load(yaml_file)
+        ramble_commit = data["versions"]["ramble"]
+        spack_commit = data["versions"]["spack"]
+
     if not spack_location.exists():
         print(f"Cloning spack into {spack_location}")
-        run_command(
-            "git clone --depth=1 -c feature.manyFiles=true "
-            "https://github.com/spack/spack.git "
-            f"{spack_location}"
+        git_clone_commit(
+            "https://github.com/spack/spack.git", spack_commit, spack_location
         )
 
         env = {"SPACK_DISABLE_LOCAL_CONFIG": "1"}
@@ -286,10 +313,8 @@ def benchpark_setup_handler(args):
 
     if not ramble_location.exists():
         print(f"Cloning ramble into {ramble_location}")
-        run_command(
-            "git clone --depth=1 -c feature.manyFiles=true "
-            "https://github.com/GoogleCloudPlatform/ramble.git "
-            f"{ramble_location}"
+        git_clone_commit(
+            "https://github.com/GoogleCloudPlatform/ramble.git", ramble_commit, ramble_location
         )
 
         run_command(f"{ramble_exe} repo add --scope=site {source_dir}/repo")

--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -1,0 +1,8 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+versions:
+  ramble: 3d6d2670435c704ca815ae13abe49b10c5111638
+  spack: 31de670bd26beca979ebd75dcb0ce90c535a78c4


### PR DESCRIPTION
This pins the Spack/Ramble versions checked out by Benchpark so that users don't run into problems like https://github.com/LLNL/benchpark/pull/163 (where we should test with new Ramble versions before making them available).

In the future, we may want to distinguish in this file between what Ramble version we check out for experiments vs. which one we use for Benchpark operations (the latter kind of action doesn't exist but would be introduced by e.g. https://github.com/LLNL/benchpark/pull/110).