### PR TITLE
Fix artifact upload for CI docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
       if: github.ref == 'refs/heads/develop'
       with:
-        path: ./_build
+        path: ./docs/_build
 
   deploy:
     needs: build


### PR DESCRIPTION
In the tagging PR we'd updated the method of generation to use the makefile inside the `docs/` directory. This outputs the build docs into `docs/_build` instead of `_build`. We'd forgotten to update the location that GitHub Actions expects to grab the build docs from in the publish step. This PR updates that location so hopefully we should now be able to publish the new site.