### PR TITLE
[WIP] Generate batch submission script at experiment run-time

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -300,6 +300,7 @@ def benchpark_setup_handler(args):
         ramble_spack_experiment_configs_dir,
         include_fn,
     )
+    shutil.copy(source_dir / "lib" / "scripts" / "generate-batch", ramble_workspace_dir)
 
     spack_location = experiments_root / "spack"
     ramble_location = experiments_root / "ramble"

--- a/configs/nosite-x86_64/variables.yaml
+++ b/configs/nosite-x86_64/variables.yaml
@@ -6,7 +6,8 @@
 variables:
   batch_time: ''
   mpi_command: 'mpirun'
-  batch_submit: 'sbatch'
+  scheduler: 'slurm'
+  batch_submit: '{execute_experiment}'
   batch_nodes: ''
   batch_ranks: ''
   batch_timeout: ''

--- a/configs/nosite-x86_64/variables.yaml
+++ b/configs/nosite-x86_64/variables.yaml
@@ -5,7 +5,7 @@
 
 variables:
   batch_time: ''
-  mpi_command: 'mpirun -n {n_nodes} -c {n_ranks} --oversubscribe'
+  mpi_command: 'mpirun'
   batch_submit: '{execute_experiment}'
   batch_nodes: ''
   batch_ranks: ''

--- a/configs/nosite-x86_64/variables.yaml
+++ b/configs/nosite-x86_64/variables.yaml
@@ -6,7 +6,7 @@
 variables:
   batch_time: ''
   mpi_command: 'mpirun'
-  batch_submit: '{execute_experiment}'
+  batch_submit: 'sbatch'
   batch_nodes: ''
   batch_ranks: ''
   batch_timeout: ''

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -6,15 +6,18 @@
 
 cd {experiment_run_dir}
 
-export N_TASKS={n_ranks}
-export N_NODES={n_nodes}
-export GPUS_PER_NODE={gpus_per_node}
-export EXPERIMENT_RUN_DIR={experiment_run_dir}
+export N_TASKS="{n_ranks}"
+export N_NODES="{n_nodes}"
+export GPUS_PER_NODE="{gpus_per_node}"
+export EXPERIMENT_RUN_DIR="{experiment_run_dir}"
+export BATCH_SUBMIT="{batch_submit}"
 
-output_script=`{workload_run_dir}/../../../generate-batch`
+export SETUP_AND_RUN={experiment_run_dir}/setup_and_run.txt
 
-cat <<EOF >> output_script
+cat <<EOF >> "$SETUP_AND_RUN"
 {command}
 EOF
 
-output_script
+{workload_run_dir}/../../../generate-batch
+chmod +x output_script
+#output_script

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -10,6 +10,7 @@ export N_TASKS="{n_ranks}"
 export N_NODES="{n_nodes}"
 export GPUS_PER_NODE="{gpus_per_node}"
 export CORES_PER_TASK="{cores_per_task}"
+export N_OMP_THREADS_PER_TASK="{n_omp_threads_per_task}"
 
 export SCHEDULER="{scheduler}"
 

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -16,10 +16,17 @@ export BATCH_SUBMIT="{batch_submit}"
 export EXPERIMENT_RUN_DIR="{experiment_run_dir}"
 export SETUP_AND_RUN={experiment_run_dir}/setup_and_run.txt
 
+echo "step 1"
+
 cat <<EOF >> "$SETUP_AND_RUN"
 {command}
 EOF
 
+echo "step 2"
+
 output_script=`{workload_run_dir}/../../../generate-batch`
+
+echo "step 3"
+
 chmod +x "$output_script"
 #{batch_submit} "$output_script"

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -11,7 +11,7 @@ export N_NODES="{n_nodes}"
 export GPUS_PER_NODE="{gpus_per_node}"
 export CORES_PER_TASK="{cores_per_task}"
 
-export BATCH_SUBMIT="{batch_submit}"
+export SCHEDULER="{scheduler}"
 
 export EXPERIMENT_RUN_DIR="{experiment_run_dir}"
 export SETUP_AND_RUN={experiment_run_dir}/setup_and_run.txt
@@ -24,9 +24,10 @@ EOF
 
 echo "step 2"
 
-output_script=`{workload_run_dir}/../../../generate-batch`
+result=`{workload_run_dir}/../../../generate-batch`
+read invoke_with output_script <<< "$result"
 
 echo "step 3"
 
 chmod +x "$output_script"
-#{batch_submit} "$output_script"
+#"$invoke_with" "$output_script"

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -9,9 +9,11 @@ cd {experiment_run_dir}
 export N_TASKS="{n_ranks}"
 export N_NODES="{n_nodes}"
 export GPUS_PER_NODE="{gpus_per_node}"
-export EXPERIMENT_RUN_DIR="{experiment_run_dir}"
+export CORES_PER_TASK="{cores_per_task}"
+
 export BATCH_SUBMIT="{batch_submit}"
 
+export EXPERIMENT_RUN_DIR="{experiment_run_dir}"
 export SETUP_AND_RUN={experiment_run_dir}/setup_and_run.txt
 
 cat <<EOF >> "$SETUP_AND_RUN"

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -20,6 +20,6 @@ cat <<EOF >> "$SETUP_AND_RUN"
 {command}
 EOF
 
-{workload_run_dir}/../../../generate-batch
-chmod +x output_script
-#output_script
+output_script=`{workload_run_dir}/../../../generate-batch`
+chmod +x "$output_script"
+{batch_submit} "$output_script"

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -4,10 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{batch_nodes}
-{batch_ranks}
-{batch_timeout}
-
 cd {experiment_run_dir}
 
+export N_TASKS={n_ranks}
+export N_NODES={n_nodes}
+export GPUS_PER_NODE={gpus_per_node}
+export EXPERIMENT_RUN_DIR={experiment_run_dir}
+
+output_script=`{workload_run_dir}/../../../generate-batch`
+
+cat <<EOF >> output_script
 {command}
+EOF
+
+output_script

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -9,8 +9,9 @@ cd {experiment_run_dir}
 export N_TASKS="{n_ranks}"
 export N_NODES="{n_nodes}"
 export GPUS_PER_NODE="{gpus_per_node}"
-export CORES_PER_TASK="{cores_per_task}"
+export N_CORES_PER_TASK="{n_cores_per_task}"
 export N_OMP_THREADS_PER_TASK="{n_omp_threads_per_task}"
+export N_TASKS_PER_NODE="{processes_per_node}"
 
 export SCHEDULER="{scheduler}"
 

--- a/experiments/saxpy/openmp/execute_experiment.tpl
+++ b/experiments/saxpy/openmp/execute_experiment.tpl
@@ -22,4 +22,4 @@ EOF
 
 output_script=`{workload_run_dir}/../../../generate-batch`
 chmod +x "$output_script"
-{batch_submit} "$output_script"
+#{batch_submit} "$output_script"

--- a/experiments/saxpy/openmp/ramble.yaml
+++ b/experiments/saxpy/openmp/ramble.yaml
@@ -19,22 +19,19 @@ ramble:
     saxpy:
       workloads:
         problem:
-          env_vars:
-            set:
-              OMP_NUM_THREADS: '{n_threads}'
           variables:
             n_ranks: '8'
           experiments:
-            saxpy_{n}_{n_nodes}_{n_ranks}_{n_threads}:
+            saxpy_{n}_{n_nodes}_{n_ranks}_{n_omp_threads_per_task}:
               variables:
                 processes_per_node: ['8', '4']
                 n_nodes: ['1', '2']
-                n_threads: ['2', '4']
+                n_omp_threads_per_task: ['2', '4']
                 n: ['512', '1024']
               matrices:
                 - size_threads:
                   - n
-                  - n_threads
+                  - n_omp_threads_per_task
 
   spack:
     concretized: true

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -1,15 +1,52 @@
 #!/usr/bin/env python3
 
 import os
+from enum import Enum
 from pathlib import Path
+
+def _maybe_int_opt(optname, optvalue):
+    try:
+        int_val = int(optvalue)
+        return [optname, f"{optvalue}"]
+    except ValueError:
+        return []
+
+class AllocOpt(Enum):
+    N_TASKS = 1
+    N_NODES = 2
+    GPUS_PER_NODE = 3
+    CORES_PER_TASK = 4
+
+def defined_allocation_options():
+    """For each possible allocation option, check if it was filled in by
+       Ramble: in that case it will be an integer; if not, it will remain
+       a string with "{}".
+    """
+    defined = {}
+    for alloc_opt in AllocOpt:
+        env_def = os.environ[alloc_opt.name]
+        try:
+            int_val = int(env_def)
+        except ValueError:
+            continue
+        defined[alloc_opt] = env_def
+    return defined
+
+def sbatch_directives(opts):
+    # TODO: this is incomplete, it is intended that this would be able to
+    # accommodate the possibility that N_NODES is unset, and we could calculate
+    # N_NODES from N_GPUS and GPUS_PER_NODE, for example
+    n_nodes = opts[AllocOpt.N_NODES]
+
+    directives = [
+        f"SBATCH -N {n_nodes}"
+    ]
 
 def main():
     experiment_run_dir = os.environ["EXPERIMENT_RUN_DIR"]
     setup_and_run = os.environ["SETUP_AND_RUN"]
 
-    n_tasks = os.environ["N_TASKS"]
-    n_nodes = os.environ["N_NODES"]
-    gpus_per_node = os.environ["GPUS_PER_NODE"]
+    allocation_options = defined_allocation_options()
 
     batch_submit = os.environ["BATCH_SUBMIT"]
 
@@ -18,16 +55,22 @@ def main():
 
     output_script = Path(experiment_run_dir) / "generated.sh"
 
-    run_command = "mpirun -n {n_tasks} -c {cores_per_task}"
-
     original_run_command = commands[-1]
     original_run_args = list(original_run_command.split())
-    new_run_command = ["mpirun", "-n", f"{n_tasks}", "-c", f"{cores_per_task}"] + original_run_args[2:]
 
+    # TODO: incomplete - Ramble wants to generate the mpirun command, but I
+    # want to do that myself in this script, so I pull it apart and put it
+    # back together with the options I want to set. Depending on the system
+    # this could be an srun or flux run
+    new_run_command = ["mpirun"] + original_run_args[2:]
+
+    batch_directives = []
+    if batch_submit == "sbatch":
+        batch_directives = sbatch_directives(allocation_options)
     header_comments = [
         f"#Expanded variables: {n_tasks}/{n_nodes}/{gpus_per_node}",
     ]
-    new_commands = header_comments + commands[:-1] + [" ".join(new_run_command)]
+    new_commands = batch_directives + header_comments + commands[:-1] + [" ".join(new_run_command)]
 
     with open(output_script, "w") as f:
         f.write("\n".join(new_commands))

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -9,6 +9,7 @@ class AllocOpt(Enum):
     N_NODES = 2
     GPUS_PER_NODE = 3
     CORES_PER_TASK = 4
+    N_OMP_THREADS_PER_TASK = 5
 
 def defined_allocation_options():
     """For each possible allocation option, check if it was filled in by
@@ -35,6 +36,12 @@ def sbatch_directives(opts):
         f"#SBATCH -N {n_nodes}"
     ]
     return directives
+
+def openmp_settings(opts):
+    if AllocOpt.N_OMP_THREADS_PER_TASK in opts:
+        return [f"export OMP_NUM_THREADS={opts[AllocOpt.N_OMP_THREADS_PER_TASK]}"]
+    else:
+        return []
 
 def main():
     experiment_run_dir = os.environ["EXPERIMENT_RUN_DIR"]
@@ -68,7 +75,10 @@ def main():
     header_comments = [
         f"#Expanded variables: {str(allocation_options)}",
     ]
-    new_commands = batch_directives + header_comments + commands[:-1] + [new_run_command]
+    new_commands = (
+        batch_directives + header_comments + commands[:-1]
+        + openmp_settings(allocation_options) + [new_run_command]
+    )
 
     with open(output_script, "w") as f:
         f.write("\n".join(new_commands))

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -62,7 +62,9 @@ def main():
     # want to do that myself in this script, so I pull it apart and put it
     # back together with the options I want to set. Depending on the system
     # this could be an srun or flux run
-    new_run_command = ["mpirun"] + original_run_args[2:]
+    new_run_args = ["mpirun"] + original_run_args[2:]
+    # TODO: Don't actually run anything for now (prepend "#" to make it a comment)
+    new_run_command = "#" + " ".join(new_run_args)
 
     batch_directives = []
     if batch_submit == "sbatch":
@@ -70,7 +72,7 @@ def main():
     header_comments = [
         f"#Expanded variables: {n_tasks}/{n_nodes}/{gpus_per_node}",
     ]
-    new_commands = batch_directives + header_comments + commands[:-1] + [" ".join(new_run_command)]
+    new_commands = batch_directives + header_comments + commands[:-1] + new_run_command]
 
     with open(output_script, "w") as f:
         f.write("\n".join(new_commands))

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -4,13 +4,6 @@ import os
 from enum import Enum
 from pathlib import Path
 
-def _maybe_int_opt(optname, optvalue):
-    try:
-        int_val = int(optvalue)
-        return [optname, f"{optvalue}"]
-    except ValueError:
-        return []
-
 class AllocOpt(Enum):
     N_TASKS = 1
     N_NODES = 2

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -39,8 +39,9 @@ def sbatch_directives(opts):
     n_nodes = opts[AllocOpt.N_NODES]
 
     directives = [
-        f"SBATCH -N {n_nodes}"
+        f"#SBATCH -N {n_nodes}"
     ]
+    return directives
 
 def main():
     experiment_run_dir = os.environ["EXPERIMENT_RUN_DIR"]
@@ -70,9 +71,9 @@ def main():
     if batch_submit == "sbatch":
         batch_directives = sbatch_directives(allocation_options)
     header_comments = [
-        f"#Expanded variables: {n_tasks}/{n_nodes}/{gpus_per_node}",
+        f"#Expanded variables: {str(allocation_options)}",
     ]
-    new_commands = batch_directives + header_comments + commands[:-1] + new_run_command]
+    new_commands = batch_directives + header_comments + commands[:-1] + [new_run_command]
 
     with open(output_script, "w") as f:
         f.write("\n".join(new_commands))

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os
+
+def main():
+    print("batch-generateor")
+    print(os.environ["EXPERIMENT_RUN_DIR"])
+
+if __name__ == "__main__":
+    main()

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -10,7 +10,6 @@ def main():
     n_nodes = os.environ["N_NODES"]
     gpus_per_node = os.environ["GPUS_PER_NODE"]
 
-
     batch_submit = os.environ["BATCH_SUBMIT"]
 
     with open(setup_and_run, "r") as f:

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+from pathlib import Path
 
 def main():
     experiment_run_dir = os.environ["EXPERIMENT_RUN_DIR"]

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -8,8 +8,9 @@ class AllocOpt(Enum):
     N_TASKS = 1
     N_NODES = 2
     GPUS_PER_NODE = 3
-    CORES_PER_TASK = 4
+    N_CORES_PER_TASK = 4
     N_OMP_THREADS_PER_TASK = 5
+    N_TASKS_PER_NODE = 6
 
 def defined_allocation_options():
     """For each possible allocation option, check if it was filled in by
@@ -64,7 +65,9 @@ def main():
     # srun). This logic could pull it apart and put it back together with the
     # options I want to set. Depending on the system this could be an srun,
     # flux run, or mpirun
-    app_runner_opts = []
+    app_runner_opts = [
+        "-n", allocation_options[AllocOpt.N_TASKS]
+    ]
     new_run_args = [original_run_args[0]] + app_runner_opts  + original_run_args[1:]
     # TODO: Don't actually run anything for now (prepend "#" to make it a comment)
     new_run_command = "#" + " ".join(new_run_args)

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -49,7 +49,7 @@ def main():
 
     allocation_options = defined_allocation_options()
 
-    batch_submit = os.environ["BATCH_SUBMIT"]
+    scheduler = os.environ["SCHEDULER"]
 
     with open(setup_and_run, "r") as f:
         commands = list(x.strip() for x in f.readlines())
@@ -68,7 +68,9 @@ def main():
     new_run_command = "#" + " ".join(new_run_args)
 
     batch_directives = []
-    if batch_submit == "sbatch":
+    invoke_with = "bash"
+    if scheduler == "slurm":
+        invoke_with = "sbatch"
         batch_directives = sbatch_directives(allocation_options)
     header_comments = [
         f"#Expanded variables: {str(allocation_options)}",
@@ -78,7 +80,7 @@ def main():
     with open(output_script, "w") as f:
         f.write("\n".join(new_commands))
 
-    print(output_script)
+    print(f"{invoke_with} {output_script}")
 
 if __name__ == "__main__":
     main()

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -60,10 +60,12 @@ def main():
     original_run_args = list(original_run_command.split())
 
     # TODO: incomplete - Ramble wants to generate the mpirun command, but I
-    # want to do that myself in this script, so I pull it apart and put it
-    # back together with the options I want to set. Depending on the system
-    # this could be an srun or flux run
-    new_run_args = ["mpirun"] + original_run_args[2:]
+    # want to do that myself in this script (e.g. to set allocation options for
+    # srun). This logic could pull it apart and put it back together with the
+    # options I want to set. Depending on the system this could be an srun,
+    # flux run, or mpirun
+    app_runner_opts = []
+    new_run_args = [original_run_args[0]] + app_runner_opts  + original_run_args[1:]
     # TODO: Don't actually run anything for now (prepend "#" to make it a comment)
     new_run_command = "#" + " ".join(new_run_args)
 

--- a/lib/scripts/generate-batch
+++ b/lib/scripts/generate-batch
@@ -3,8 +3,36 @@
 import os
 
 def main():
-    print("batch-generateor")
-    print(os.environ["EXPERIMENT_RUN_DIR"])
+    experiment_run_dir = os.environ["EXPERIMENT_RUN_DIR"]
+    setup_and_run = os.environ["SETUP_AND_RUN"]
+
+    n_tasks = os.environ["N_TASKS"]
+    n_nodes = os.environ["N_NODES"]
+    gpus_per_node = os.environ["GPUS_PER_NODE"]
+
+
+    batch_submit = os.environ["BATCH_SUBMIT"]
+
+    with open(setup_and_run, "r") as f:
+        commands = list(x.strip() for x in f.readlines())
+
+    output_script = Path(experiment_run_dir) / "generated.sh"
+
+    run_command = "mpirun -n {n_tasks} -c {cores_per_task}"
+
+    original_run_command = commands[-1]
+    original_run_args = list(original_run_command.split())
+    new_run_command = ["mpirun", "-n", f"{n_tasks}", "-c", f"{cores_per_task}"] + original_run_args[2:]
+
+    header_comments = [
+        f"#Expanded variables: {n_tasks}/{n_nodes}/{gpus_per_node}",
+    ]
+    new_commands = header_comments + commands[:-1] + [" ".join(new_run_command)]
+
+    with open(output_script, "w") as f:
+        f.write("\n".join(new_commands))
+
+    print(output_script)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
On `develop`, Benchpark generates batch scripts directly using Ramble's templating system.

This PR alters `execute_experiment` to generate the sbatch submission: `execute_experiment` now calls out to a Python script which generates the batch script (e.g. for sbatch); this Python script takes as input:

* The resource requests for the experiment (e.g. from `experiments/saxpy/openmp/ramble.yaml`
* The system description (e.g. from `configs/.../variables.yaml`)

and can combine them to generate an appropriate request. For example given:

`./bin/benchpark setup saxpy/openmp nosite-x86_64 `pwd`/test-saxpy-oslic`

`<root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/experiments/saxpy/problem/saxpy_512_1_8_2/execute_experiment` will contain

```
...
result=`<root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/experiments/saxpy/problem/../../../generate-batch`
read invoke_with output_script <<< "$result"

echo "step 3"

chmod +x "$output_script"
"$invoke_with" "$output_script"
```

and `$output_script` contains:

```
#SBATCH -N 1
#Expanded variables: {<AllocOpt.N_TASKS: 1>: '8', <AllocOpt.N_NODES: 2>: '1', <AllocOpt.N_OMP_THREADS_PER_TASK: 5>: '2', <AllocOpt.N_TASKS_PER_NODE: 6>: '8'}
rm -f "<root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/experiments/saxpy/problem/saxpy_512_1_8_2/saxpy_512_1_8_2.out"
touch "<root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/experiments/saxpy/problem/saxpy_512_1_8_2/saxpy_512_1_8_2.out"
. <root>/test-saxpy-oslic/spack/share/spack/setup-env.sh
spack env activate <root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/software/saxpy.problem
export OMP_NUM_THREADS=2
#mpirun -n 8 saxpy -n 512 >> "<root>/test-saxpy-oslic/saxpy/openmp/nosite-x86_64/workspace/experiments/saxpy/problem/saxpy_512_1_8_2/saxpy_512_1_8_2.out
```