### PR TITLE
Benchpark: use requirements.txt from Ramble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
               - '.github/**'
               - 'bin/**'
               - 'configs/**'
+              - 'checkout-versions.yaml'
               - 'experiments/**'
               - 'repo/**'
             license:

--- a/.github/workflows/requirements/docs.txt
+++ b/.github/workflows/requirements/docs.txt
@@ -5,3 +5,18 @@ codespell==2.2.6
 pandas==2.2.1
 pyyaml==6.0.1
 sphinxcontrib-programoutput==0.17
+# The remaining requirements are from Ramble
+pytest
+flake8
+google-cloud-storage # for gcs fetch test
+google-api-core # for gcs fetch error .exceptions
+coverage
+pre-commit
+graphlib-backport;python_version<"3.9"
+urllib3==1.26.18;python_version<="3.6"
+protobuf;python_version>"3.6"
+protobuf==3.19.4;python_version<="3.6"
+pyarrow==3.0.0;python_version<="3.6"
+google-cloud-bigquery
+tqdm
+deprecation

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout Benchpark
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
 
+      - name: Add needed Python libs
+        run: |
+          pip install -r ./requirements.txt
+
       - name: Build Saxpy Workspace
         run: |
           ./bin/benchpark setup saxpy/openmp nosite-x86_64 workspace/

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -238,9 +238,7 @@ def run_command(command_str, env=None):
     stdout, stderr = proc.communicate()
     if proc.returncode != 0:
         raise RuntimeError(
-            f"Failed command: {command_str}\n"
-            f"Output: {stdout}\n"
-            f"Error: {stderr}"
+            f"Failed command: {command_str}\nOutput: {stdout}\nError: {stderr}"
         )
 
     return (stdout, stderr)

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -228,16 +228,22 @@ def benchpark_setup(subparsers, actions_dict):
 
 
 def run_command(command_str, env=None):
-    result = subprocess.run(
+    proc = subprocess.Popen(
         shlex.split(command_str),
         env=env,
-        check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
-
-    return (result.stdout, result.stderr)
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed command: {command_str}\n"
+            f"Output: {stdout}\n"
+            f"Error: {stderr}"
+        )
+        
+    return (stdout, stderr)
 
 
 def benchpark_tags(subparsers, actions_dict):
@@ -348,6 +354,7 @@ def benchpark_setup_handler(args):
 
     ramble_workspace_dir = workspace_dir / "workspace"
     ramble_configs_dir = ramble_workspace_dir / "configs"
+    ramble_logs_dir = ramble_workspace_dir / "logs"
     ramble_spack_experiment_configs_dir = (
         ramble_configs_dir / "auxiliary_software_files"
     )
@@ -358,6 +365,7 @@ def benchpark_setup_handler(args):
     experiment_src_dir = source_dir / "experiments" / benchmark
     modifier_config_dir = source_dir / "modifiers" / modifier / "configs"
     ramble_configs_dir.mkdir(parents=True)
+    ramble_logs_dir.mkdir(parents=True)
     ramble_spack_experiment_configs_dir.mkdir(parents=True)
 
     def include_fn(fname):

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -242,7 +242,7 @@ def run_command(command_str, env=None):
             f"Output: {stdout}\n"
             f"Error: {stderr}"
         )
-        
+
     return (stdout, stderr)
 
 

--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 versions:
-  ramble: 3d6d2670435c704ca815ae13abe49b10c5111638
+  ramble: bb664f142b2cbdb2b2ea39e70a8535c9f27c1179
   spack: 31de670bd26beca979ebd75dcb0ce90c535a78c4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,16 @@
 pyyaml
+# The remaining requirements are from Ramble
+pytest
+flake8
+google-cloud-storage # for gcs fetch test
+google-api-core # for gcs fetch error .execptions
+coverage
+pre-commit
+graphlib-backport;python_version<"3.9"
+urllib3==1.26.18;python_version<="3.6"
+protobuf;python_version>"3.6"
+protobuf==3.19.4;python_version<="3.6"
+pyarrow==3.0.0;python_version<="3.6"
+google-cloud-bigquery
+tqdm
+deprecation

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pyyaml
 pytest
 flake8
 google-cloud-storage # for gcs fetch test
-google-api-core # for gcs fetch error .execptions
+google-api-core # for gcs fetch error .exceptions
 coverage
 pre-commit
 graphlib-backport;python_version<"3.9"


### PR DESCRIPTION
Update ramble version used by Benchpark (primarily to get `https://github.com/GoogleCloudPlatform/ramble/pull/452`); append requirements.txt for Ramble to benchpark requirements.txt

This means that users will automatically get everything they need to run Ramble instances created by Benchpark as part of installing the `requirements.txt` for Benchpark itself. If users explicitly update a Ramble instance to a later version, they may need to install additional dependencies.

As long as Ramble doesn't use deprecated library methods, the latest requirements.txt from Ramble should be sufficient for running older Ramble versions as well (if that starts happening, we'll need to change our strategy to maintain a Python venv for each Ramble instance that we use).