### PR TITLE
ci: rebuild docs on changes to bin/benchpark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           filters: |
             docs:
               - '.github/**'
+              - 'bin/**'
               - 'docs/**'
               - 'README.rst'
             style:


### PR DESCRIPTION
Adds a rule to rebuild the docs when `bin/benchpark` (or any future file in bin) changes in a PR.

Fixes #210 