### PR TITLE
Tags command should use benchmarks not experiments

### DIFF
--- a/bin/benchpark
+++ b/bin/benchpark
@@ -483,7 +483,7 @@ Further steps are needed to build the experiments (ramble -P -D {ramble_workspac
     print(instructions)
 
 
-def helper_experiments_tags(ramble_exe, experiments):
+def helper_experiments_tags(ramble_exe, benchmarks):
     # find all tags in Ramble applications (both in Ramble built-in and in Benchpark/repo)
     (tags_stdout, tags_stderr) = run_command(f"{ramble_exe} attributes --tags --all")
     ramble_applications_tags = {}
@@ -494,20 +494,20 @@ def helper_experiments_tags(ramble_exe, experiments):
         ramble_applications_tags[key_value[0]] = key_value[1].strip().split(",")
 
     benchpark_experiments_tags = {}
-    for exp in experiments:
-        benchpark_experiments_tags[exp] = ramble_applications_tags[exp]
+    for benchmark in benchmarks:
+        benchpark_experiments_tags[benchmark] = ramble_applications_tags[benchmark]
     return benchpark_experiments_tags
 
 
 def benchpark_tags_handler(args):
     """
-    Filter ramble tags by benchpark experiments
+    Filter ramble tags by benchpark benchmarks
     """
     source_dir = source_location()
     experiments_root = pathlib.Path(os.path.abspath(args.experiments_root))
     ramble_location = experiments_root / "ramble"
     ramble_exe = ramble_location / "bin" / "ramble"
-    experiments = benchpark_experiments()
+    benchmarks = benchpark_benchmarks()
 
     if args.tag:
         if benchpark_check_tag(args.tag):
@@ -516,17 +516,17 @@ def benchpark_tags_handler(args):
             lines = tag_stdout.splitlines()
 
             for line in lines:
-                if line in experiments:
+                if line in benchmarks:
                     print(line)
 
     elif args.application:
-        if benchpark_check_experiment(args.application):
+        if benchpark_check_benchmark(args.application):
             benchpark_experiments_tags = helper_experiments_tags(
-                ramble_exe, experiments
+                ramble_exe, benchmarks
             )
             print(benchpark_experiments_tags[args.application])
     else:
-        benchpark_experiments_tags = helper_experiments_tags(ramble_exe, experiments)
+        benchpark_experiments_tags = helper_experiments_tags(ramble_exe, benchmarks)
         print("All tags that exist in Benchpark experiments:")
         for k, v in benchpark_experiments_tags.items():
             print(k)

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -521,9 +521,7 @@ def benchpark_tags_handler(args):
 
     elif args.application:
         if benchpark_check_benchmark(args.application):
-            benchpark_experiments_tags = helper_experiments_tags(
-                ramble_exe, benchmarks
-            )
+            benchpark_experiments_tags = helper_experiments_tags(ramble_exe, benchmarks)
             print(benchpark_experiments_tags[args.application])
     else:
         benchpark_experiments_tags = helper_experiments_tags(ramble_exe, benchmarks)

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -54,7 +54,7 @@ def main(workspace):
     for bmark in benchmarks:
         # call benchpark tags -a bmark workspace
         cmd = ["../bin/benchpark", "tags", "-a", bmark, workspace]
-        byte_data = subprocess.run(cmd, capture_output=True)
+        byte_data = subprocess.run(cmd, capture_output=True, check=True)
         tags = str(byte_data.stdout, "utf-8")
         tags = (
             tags.replace("[", "")


### PR DESCRIPTION
Bug introduced in #190 queried experiments not benchmarks to generate tags which resulted in invalid key errors when running the command and manifested as an empty table in the docs.