### PR TITLE
remove step to remove gcc 13

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,10 +6,6 @@ jobs:
   saxpy:
     runs-on: ubuntu-latest
     steps:
-      - name: Remove gcc > 12 # to prevent Spack from picking a gcc without gfortan
-        run: |
-          sudo apt-get remove -y gcc-13
-
       - name: Checkout Benchpark
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
 


### PR DESCRIPTION
Trying to resolve CI failures like https://github.com/LLNL/benchpark/actions/runs/9130896803/job/25108882636?pr=246  in https://github.com/LLNL/benchpark/pull/246