### PR TITLE
updating fugaku site

### DIFF
--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/compilers.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/compilers.yaml
@@ -5,13 +5,13 @@
 
 compilers:
 - compiler:
-    spec: fj@4.8.1
+    spec: fj@4.10.0
     modules: []
     paths:
-      cc: /opt/FJSVxtclanga/tcsds-1.2.36/bin/fcc
-      cxx: /opt/FJSVxtclanga/tcsds-1.2.36/bin/FCC
-      f77: /opt/FJSVxtclanga/tcsds-1.2.36/bin/frt
-      fc: /opt/FJSVxtclanga/tcsds-1.2.36/bin/frt
+      cc: /opt/FJSVxtclanga/tcsds-1.2.38/bin/fcc
+      cxx: /opt/FJSVxtclanga/tcsds-1.2.38/bin/FCC
+      f77: /opt/FJSVxtclanga/tcsds-1.2.38/bin/frt
+      fc: /opt/FJSVxtclanga/tcsds-1.2.38/bin/frt
     flags: {}
     operating_system: rhel8
     target: aarch64
@@ -20,50 +20,51 @@ compilers:
         fcc_ENV: -Nclang
         FCC_ENV: -Nclang
       prepend_path:
-        PATH: /opt/FJSVxtclanga/tcsds-1.2.36/bin
-        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.36/lib64
+        PATH: /opt/FJSVxtclanga/tcsds-1.2.38/bin
+        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.38/lib64
     extra_rpaths: []
 - compiler:
-    spec: clang@15.0.3
+    spec: clang@17.0.2
     paths:
-      cc: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/clang
-      cxx: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/clang++
-      f77: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/flang
-      fc: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/flang
-    flags:
-      cflags: {"-msve-vector-bits=scalable"}
-      cxxflags: {"-msve-vector-bits=scalable"}
-      ldflags: {"-fuse-ld=lld -lelf -ldl"}
+      cc: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/clang
+      cxx: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/clang++
+      f77: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/flang
+      fc: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/flang
+    #flags:
+    #  cflags: {"-msve-vector-bits=scalable"}
+    #  cxxflags: {"-msve-vector-bits=scalable"}
+    #  fflags: {"-msve-vector-bits=scalable"}
+    #  ldflags: {"-fuse-ld=lld"}
     environment:
       set:
-        OMPI_CC: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/clang
-        OMPI_CXX: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/clang++
-        OMPI_FC: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/flang
-        OMPI_F77: /vol0004/apps/oss/llvm-v15.0.3/compute_node/bin/flang
+        OMPI_CC: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/clang
+        OMPI_CXX: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/clang++
+        OMPI_FC: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/flang
+        OMPI_F77: /vol0004/apps/oss/llvm-v17.0.2/compute_node/bin/flang
       append_path:
-        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.36/lib64
+        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.38/lib64
     operating_system: rhel8
     target: aarch64
     modules: []
     extra_rpaths: []
 - compiler:
-    spec: gcc@12.2.0
+    spec: gcc@13.2.0
     paths:
-      cc: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gcc
-      cxx: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/g++
-      f77: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gfortran
-      fc: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gfortran
+      cc: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gcc
+      cxx: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/g++
+      f77: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gfortran
+      fc: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gfortran
     flags:
       ldflags: {"-lelf -ldl"}
     environment:
       set:
-        OMPI_CC: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gcc
-        OMPI_CXX: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/g++
-        OMPI_FC: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gfortran
-        OMPI_F77: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-12.2.0-sxcx7kmt3qiktffgzzvrj2wmup3g32bc/bin/gfortran
+        OMPI_CC: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gcc
+        OMPI_CXX: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/g++
+        OMPI_FC: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gfortran
+        OMPI_F77: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/gcc-8.5.0/gcc-13.2.0-abihbe7ykvpedq54j6blfvfppy7ojbmd/bin/gfortran
         OPAL_PREFIX: /vol0004/apps/oss/mpigcc/fjmpi-gcc12
       append_path:
-        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.36/lib64
+        LD_LIBRARY_PATH: /opt/FJSVxtclanga/tcsds-1.2.38/lib64
     operating_system: rhel8
     target: aarch64
     modules: []

--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/packages.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/packages.yaml
@@ -1,3 +1,8 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 packages:
   all:
     compiler: [clang, fj, gcc]

--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/packages.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/auxiliary_software_files/packages.yaml
@@ -1,46 +1,46 @@
-# Copyright 2023 Lawrence Livermore National Security, LLC and other
-# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 packages:
   all:
-    compiler: [fj, clang, gcc]
+    compiler: [clang, fj, gcc]
     providers:
       mpi: [fujitsu-mpi, openmpi, mpich]
       blas: [fujitsu-ssl2, openblas]
       lapack: [fujitsu-ssl2, openblas]
       scalapack: [fujitsu-ssl2, netlib-scalapack]
-      fftw-api: [fujitsu-ssl2, fftw, rist-fftw]
+      fftw-api: [fujitsu-fftw, fftw, rist-fftw]
     permissions:
       write: group
   htslib:
     version: [1.12]
   python:
     externals:
-      - spec: "python@3.10.8%fj@4.8.1 +ssl+tkinter arch=linux-rhel8-a64fx"
-        prefix: /vol0004/apps/oss/spack-v0.19/opt/spack/linux-rhel8-a64fx/fj-4.8.1/python-3.10.8-5q3ncyl2my7oomopsmukduqo36u6pnkg
+      - spec: "python@3.11.6%fj@4.10.0 arch=linux-rhel8-a64fx"
+        prefix: /vol0004/apps/oss/spack-v0.21/opt/spack/linux-rhel8-a64fx/fj-4.10.0/python-3.11.6-qbmpmn2uxu4oe3qoawxbizp7awqlgkcq
   openssh:
     permissions:
       write: user
   fujitsu-mpi:
+    buildable: False
     externals:
-      - spec: "fujitsu-mpi@4.8.1%fj@4.8.1 arch=linux-rhel8-a64fx"
-        prefix: /opt/FJSVxtclanga/tcsds-mpi-1.2.36
-      - spec: "fujitsu-mpi@4.8.1%clang@15.0.3 arch=linux-rhel8-a64fx"
-        prefix: /opt/FJSVxtclanga/tcsds-mpi-1.2.36
-      - spec: "fujitsu-mpi@4.8.1%gcc@12.2.0 arch=linux-rhel8-a64fx"
+      - spec: "fujitsu-mpi@4.10.0%clang@17.0.2 arch=linux-rhel8-a64fx"
+        prefix: /opt/FJSVxtclanga/tcsds-mpi-1.2.38
+      - spec: "fujitsu-mpi@4.10.0%fj@4.10.0 arch=linux-rhel8-a64fx"
+        prefix: /opt/FJSVxtclanga/tcsds-mpi-1.2.38
+      - spec: "fujitsu-mpi@4.10.0%gcc@13.2.0 arch=linux-rhel8-a64fx"
         prefix: /vol0004/apps/oss/mpigcc/fjmpi-gcc12
-    buildable: False
   fujitsu-ssl2:
-    externals:
-      - spec: "fujitsu-ssl2@4.8.1%fj@4.8.1 arch=linux-rhel8-a64fx"
-        prefix: /opt/FJSVxtclanga/tcsds-ssl2-1.2.36
-      - spec: "fujitsu-ssl2@4.8.1%clang@15.0.3 arch=linux-rhel8-a64fx"
-        prefix: /opt/FJSVxtclanga/tcsds-ssl2-1.2.36
-      - spec: "fujitsu-ssl2@4.8.1%gcc@12.2.0 arch=linux-rhel8-a64fx"
-        prefix: /opt/FJSVxtclanga/tcsds-ssl2-1.2.36
     buildable: False
+    externals:
+      - spec: "fujitsu-ssl2@4.10.0%clang@17.0.2 arch=linux-rhel8-a64fx"
+        prefix: /vol0004/apps/oss/llvm-v17.0.2/compute_node
+      - spec: "fujitsu-ssl2@4.10.0%fj@4.10.0 arch=linux-rhel8-a64fx"
+        prefix: /opt/FJSVxtclanga/tcsds-ssl2-1.2.38
+      - spec: "fujitsu-ssl2@4.10.0%gcc@13.2.0 arch=linux-rhel8-a64fx"
+        prefix: /opt/FJSVxtclanga/tcsds-ssl2-1.2.38
+  rist-fftw:
+    buildable: False
+    externals:
+       - spec: "rist-fftw@3.3.9-272-g63d6bd70 arch=linux-rhel8-a64fx"
+         prefix: /vol0004/share/rist/fftw/gcc-10.3.0/3.3.9-272-g63d6bd70
   autoconf:
     externals:
       - spec: "autoconf@2.69 arch=linux-rhel8-a64fx"
@@ -57,6 +57,10 @@ packages:
     externals:
       - spec: "bzip2@1.0.6 arch=linux-rhel8-a64fx"
         prefix: /usr
+  cmake:
+    externals:
+      - spec: "cmake@3.20.2 arch=linux-rhel8-a64fx"
+        prefix: /usr
   curl:
     externals:
       - spec: "curl@7.61.1 arch=linux-rhel8-a64fx"
@@ -67,7 +71,10 @@ packages:
         prefix: /usr
   elfutils:
     externals:
-      - spec: "elfutils@0.188 arch=linux-rhel8-a64fx"
+      - spec: "elfutils@0.186 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "elfutils@0.182 arch=linux-rhel8-a64fx"
         prefix: /usr
   expat:
     externals:
@@ -105,6 +112,9 @@ packages:
     externals:
       - spec: "gnutls@3.6.16 arch=linux-rhel8-a64fx"
         prefix: /usr
+      # Dummy
+      - spec: "gnutls@3.6.14 arch=linux-rhel8-a64fx"
+        prefix: /usr
   hwloc:
     externals:
       - spec: "hwloc@2.2.0 arch=linux-rhel8-a64fx"
@@ -123,7 +133,10 @@ packages:
         prefix: /usr
   libdrm:
     externals:
-      - spec: "libdrm@2.4.114 arch=linux-rhel8-a64fx"
+      - spec: "libdrm@2.4.108 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "libdrm@2.4.103 arch=linux-rhel8-a64fx"
         prefix: /usr
   libedit:
     externals:
@@ -144,6 +157,13 @@ packages:
   libglvnd:
     externals:
       - spec: "libglvnd@1.3.4 arch=linux-rhel8-a64fx"
+        prefix: /usr
+  libibumad:
+    externals:
+      - spec: "libibumad@37.2 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "libibumad@32.0 arch=linux-rhel8-a64fx"
         prefix: /usr
   libpciaccess:
     externals:
@@ -189,17 +209,16 @@ packages:
     externals:
       - spec: "m4@1.4.18 arch=linux-rhel8-a64fx"
         prefix: /usr
-  ncurses:
-    externals:
-      - spec: "ncurses@6.1 arch=linux-rhel8-a64fx"
-        prefix: /usr
   nettle:
     externals:
       - spec: "nettle@3.4.1 arch=linux-rhel8-a64fx"
         prefix: /usr
   nspr:
     externals:
-      - spec: "nspr@4.34.0 arch=linux-rhel8-a64fx"
+      - spec: "nspr@4.32.0 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "nspr@4.25.0 arch=linux-rhel8-a64fx"
         prefix: /usr
   numactl:
     externals:
@@ -215,6 +234,9 @@ packages:
     externals:
       - spec: "openssl@1.1.1k arch=linux-rhel8-a64fx"
         prefix: /usr
+      # Dummy
+      - spec: "openssl@1.1.1g arch=linux-rhel8-a64fx"
+        prefix: /usr
   papi:
     externals:
       - spec: "papi@5.6.0 arch=linux-rhel8-a64fx"
@@ -222,6 +244,10 @@ packages:
   pcre:
     externals:
       - spec: "pcre@8.42 arch=linux-rhel8-a64fx"
+        prefix: /usr
+  pcre2:
+    externals:
+      - spec: "pcre2@10.32 arch=linux-rhel8-a64fx"
         prefix: /usr
   perl:
     externals:
@@ -247,20 +273,32 @@ packages:
     externals:
       - spec: "tcl@8.6.8 arch=linux-rhel8-a64fx"
         prefix: /usr
+  ucx:
+    externals:
+      - spec: "ucx@1.11.2 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "ucx@1.9.0 arch=linux-rhel8-a64fx"
+        prefix: /usr
   valgrind:
     externals:
-      - spec: "valgrind@3.19.0 arch=linux-rhel8-a64fx"
+      - spec: "valgrind@3.18.1 arch=linux-rhel8-a64fx"
+        prefix: /usr
+      # Dummy
+      - spec: "valgrind@3.16.0 arch=linux-rhel8-a64fx"
         prefix: /usr
   xz:
     externals:
       - spec: "xz@5.2.4 arch=linux-rhel8-a64fx"
         prefix: /usr
   zlib:
+    buildable: False
     externals:
       - spec: "zlib@1.2.11 arch=linux-rhel8-a64fx"
         prefix: /usr
-    buildable: False
+  # pmlib: had problems with spack. so far binary packages only. 2023/3/20 mikami
   pmlib:
+    buildable: False
     externals:
       - spec: "pmlib@9.0-clang-precise arch=linux-rhel8-a64fx"
         prefix: /vol0004/apps/oss/pmlib-v9.0/9.0-clang-precise
@@ -268,9 +306,3 @@ packages:
         prefix: /vol0004/apps/oss/pmlib-v9.0/9.0-clang-power
       - spec: "pmlib@9.0-trad-power arch=linux-rhel8-a64fx"
         prefix: /vol0004/apps/oss/pmlib-v9.0/9.0-trad-power
-    buildable: False
-  cmake:
-    externals:
-      - spec: "cmake@3.20.2 arch=linux-rhel8-a64fx"
-        prefix: /usr
-

--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/spack.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/spack.yaml
@@ -6,31 +6,15 @@
 spack:
   packages:
     default-compiler:
-      #spack_spec: fj@{default_fj_version}
-      #spack_spec: clang@{default_llvm_version}
-      spack_spec: gcc@{default_gnu_version}
+      spack_spec: "{default_comp} {sys_arch}"
     default-mpi:
-      spack_spec: fujitsu-mpi@{default_fj_version} arch=linux-rhel8-a64fx
-    compiler-fujitsu:
-      spack_spec: fj@{default_fj_version}
-    compiler-clang:
-      spack_spec: clang@{default_llvm_version}
-    compiler-gcc:
-      spack_spec: gcc@{default_gnu_version}
+      spack_spec: fujitsu-mpi@{fj_comp_version}%{default_comp} {sys_arch}
     blas:
-      spack_spec: fujitsu-ssl2@{default_fj_version} arch=linux-rhel8-a64fx
+      spack_spec: fujitsu-ssl2@{fj_comp_version}%{default_comp} {sys_arch}
     lapack:
-      spack_spec: fujitsu-ssl2@{default_fj_version} arch=linux-rhel8-a64fx
-    fftw:
-      spack_spec: fujitsu-ssl2@{default_fj_version} arch=linux-rhel8-a64fx
-    mpi-fujitsu:
-      spack_spec: fujitsu-mpi@{default_fj_version} arch=linux-rhel8-a64fx
-    mpi-clang:
-      spack_spec: fujitsu-mpi@{default_fj_version} arch=linux-rhel8-a64fx
-    mpi-gcc:
-      spack_spec: fujitsu-mpi@{default_fj_version} arch=linux-rhel8-a64fx
+      spack_spec: fujitsu-ssl2@{fj_comp_version}%{default_comp} {sys_arch}
     gmake:
-      spack_spec: gmake@4.2.1 arch=linux-rhel8-a64fx
+      spack_spec: gmake@4.2.1 {sys_arch}
     cmake:
-      spack_spec: cmake@3.20.2 arch=linux-rhel8-a64fx
+      spack_spec: cmake@3.20.2 {sys_arch}
 

--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/variables.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/variables.yaml
@@ -10,7 +10,9 @@ variables:
   batch_nodes: '#PJM -L "node={n_nodes}"'
   batch_ranks: '#PJM --mpi proc={n_ranks}'
   batch_timeout: '#PJM -L "elapse={batch_time}:00" -x PJM_LLIO_GFSCACHE="/vol0001:/vol0002:/vol0003:/vol0004:/vol0005:/vol0006"'
-  default_fj_version: '4.8.1'
-  default_llvm_version: '15.0.3'
-  default_gnu_version: '12.2.0'
+  default_comp: 'clang@17.0.2'
+  #default_comp: 'fj@4.10.0'
+  #default_comp: 'gcc@13.2.0'
+  fj_comp_version: '4.10.0'
+  sys_arch: 'arch=linux-rhel8-a64fx'
 

--- a/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/variables.yaml
+++ b/configs/RCCS-Fugaku-Fujitsu-A64FX-TofuD/variables.yaml
@@ -9,7 +9,7 @@ variables:
   batch_submit: 'pjsub {execute_experiment}'
   batch_nodes: '#PJM -L "node={n_nodes}"'
   batch_ranks: '#PJM --mpi proc={n_ranks}'
-  batch_timeout: '#PJM -L "elapse={batch_time}:00" -x PJM_LLIO_GFSCACHE="/vol0001:/vol0002:/vol0003:/vol0004:/vol0005:/vol0006"'
+  batch_timeout: '#PJM -L "elapse={batch_time}:00" -x PJM_LLIO_GFSCACHE="/vol0002:/vol0003:/vol0004:/vol0005:/vol0006"'
   default_comp: 'clang@17.0.2'
   #default_comp: 'fj@4.10.0'
   #default_comp: 'gcc@13.2.0'

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -53,6 +53,7 @@ Patch some files in various repos:
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku6/var/spack/repos/builtin/packages/hpcg/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpcg/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku10/var/spack/repos/builtin/packages/hpl/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpl/package.py
     #ONLY FOR CLANG BUILDS: sed -i -e 's@SYSTEM_PATHS = \[\(.*\)\]@SYSTEM_PATHS = [\1, "/opt/FJSVxtclanga/tcsds-mpi-1.2.38", "/opt/FJSVxtclanga/tcsds-ssl2-1.2.38"]@g' workspace/spack/lib/spack/spack/util/environment.py
     #ONLY FOR CLANG BUILDS: sed -i -e 's@%fj"):@%fj") or (spec.target == "a64fx" and spec.satisfies("%clang\@11:")):@g' workspace/spack/var/spack/repos/builtin/packages/cmake/package.py
 

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -13,10 +13,12 @@ Get in interactive shell
 
 Load newer python environment
 
+.. code:: bash
+
     if [ -f ~/spack/share/spack/setup-env.sh ]; then
-        source ~/spack/share/spack/setup-env.sh;
+        source ~/spack/share/spack/setup-env.sh
     else
-        source /vol0004/apps/oss/spack/share/spack/setup-env.sh;
+        source /vol0004/apps/oss/spack/share/spack/setup-env.sh
     fi
     spack load python@3.10.8 /mzi2ihx; spack load py-pip@23.1.2 /4hkqlma
 
@@ -24,11 +26,15 @@ Follow instructions in :doc:`1-getting-started`.
 
 Set up the directory structure for your experiment
 
+.. code:: bash
+
     export BM='saxpy/openmp'
     export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
     ./bin/benchpark setup ${BM} ${SYS} workspace
 
 Patch some files in various repos
+
+.. code:: bash
 
     sed -i -e "s@1280000000@160000000@g" -e 's@cflags=".*"@@g' experiments/streamc/openmp/ramble.yaml
     wget https://raw.githubusercontent.com/GoogleCloudPlatform/ramble/22db33d5f3728e015fcca6d5618a67014ca132c8/lib/ramble/ramble/spack_runner.py -O workspace/ramble/lib/ramble/ramble/spack_runner.py
@@ -39,6 +45,8 @@ Patch some files in various repos
 
 Build the benchmark
 
+.. code:: bash
+
     source ./workspace/setup.sh
     export TMP=/local
     export TMPDIR=/local
@@ -46,10 +54,12 @@ Build the benchmark
 
 Submit benchmarks from login node (not interactive shell)
 
+.. code:: bash
+
     if [ -f ~/spack/share/spack/setup-env.sh ]; then
-        source ~/spack/share/spack/setup-env.sh;
+        source ~/spack/share/spack/setup-env.sh
     else
-        source /vol0004/apps/oss/spack/share/spack/setup-env.sh;
+        source /vol0004/apps/oss/spack/share/spack/setup-env.sh
     fi
     spack load python@3.11.6 /yjlixq5
     export BM='saxpy/openmp'

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -49,11 +49,11 @@ Patch some files in various repos:
 .. code:: bash
 
     sed -i -e "s@1280000000@160000000@g" -e 's@cflags=".*"@@g' experiments/streamc/openmp/ramble.yaml
-    wget https://raw.githubusercontent.com/GoogleCloudPlatform/ramble/22db33d5f3728e015fcca6d5618a67014ca132c8/lib/ramble/ramble/spack_runner.py -O workspace/ramble/lib/ramble/ramble/spack_runner.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku5/lib/spack/spack/util/libc.py -O workspace/spack/lib/spack/spack/util/libc.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku6/var/spack/repos/builtin/packages/hpcg/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpcg/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+    #ONLY FOR CLANG BUILDS: sed -i -e 's@SYSTEM_PATHS = \[\(.*\)\]@SYSTEM_PATHS = [\1, "/opt/FJSVxtclanga/tcsds-mpi-1.2.38", "/opt/FJSVxtclanga/tcsds-ssl2-1.2.38"]@g' workspace/spack/lib/spack/spack/util/environment.py
 
 
 Build the benchmark:
@@ -80,4 +80,10 @@ Go back to login node and submit benchmarks:
     export BM='saxpy/openmp'
     export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
     ./workspace/ramble/bin/ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) on
+
+Finding the benchmark output (Fujitsu MPI does not write to STDOUT):
+
+.. code:: bash
+
+   find workspace/${BM}/${SYS}/workspace -name 'output.*'
 

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -52,8 +52,8 @@ Patch some files in various repos:
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku5/lib/spack/spack/util/libc.py -O workspace/spack/lib/spack/spack/util/libc.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku6/var/spack/repos/builtin/packages/hpcg/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpcg/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
-    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku10/var/spack/repos/builtin/packages/hpl/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpl/package.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku11/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
     #ONLY FOR CLANG BUILDS: sed -i -e 's@SYSTEM_PATHS = \[\(.*\)\]@SYSTEM_PATHS = [\1, "/opt/FJSVxtclanga/tcsds-mpi-1.2.38", "/opt/FJSVxtclanga/tcsds-ssl2-1.2.38"]@g' workspace/spack/lib/spack/spack/util/environment.py
     #ONLY FOR CLANG BUILDS: sed -i -e 's@%fj"):@%fj") or (spec.target == "a64fx" and spec.satisfies("%clang\@11:")):@g' workspace/spack/var/spack/repos/builtin/packages/cmake/package.py
 

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -7,11 +7,22 @@
 Running benchpark on Fugaku
 ==============================
 
+Git is needed to clone Benchpark, and Python 3.8+ is needed to run Benchpark:
+
+.. code:: bash
+
+    git clone https://github.com/LLNL/benchpark.git
+    cd benchpark
+
+
 Get in interactive shell
+
+.. code:: bash
 
     pjsub --interact ...
 
-Load newer python environment
+
+Load newer python environment and install dependencies:
 
 .. code:: bash
 
@@ -21,10 +32,10 @@ Load newer python environment
         source /vol0004/apps/oss/spack/share/spack/setup-env.sh
     fi
     spack load python@3.10.8 /mzi2ihx; spack load py-pip@23.1.2 /4hkqlma
+    pip install -r requirements.txt
 
-Follow instructions in :doc:`1-getting-started`.
 
-Set up the directory structure for your experiment
+Set up the directory structure for your experiment:
 
 .. code:: bash
 
@@ -32,7 +43,8 @@ Set up the directory structure for your experiment
     export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
     ./bin/benchpark setup ${BM} ${SYS} workspace
 
-Patch some files in various repos
+
+Patch some files in various repos:
 
 .. code:: bash
 
@@ -43,7 +55,8 @@ Patch some files in various repos
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
 
-Build the benchmark
+
+Build the benchmark:
 
 .. code:: bash
 
@@ -52,7 +65,8 @@ Build the benchmark
     export TMPDIR=/local
     ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) workspace setup
 
-Submit benchmarks from login node (not interactive shell)
+
+Go back to login node and submit benchmarks:
 
 .. code:: bash
 
@@ -61,8 +75,9 @@ Submit benchmarks from login node (not interactive shell)
     else
         source /vol0004/apps/oss/spack/share/spack/setup-env.sh
     fi
-    spack load python@3.11.6 /yjlixq5
+    spack load python@3.11.6 /yjlixq5; spack load py-pip@23.1.2 /sa5bbab
+    pip install -r requirements.txt
     export BM='saxpy/openmp'
     export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
-    ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) on
+    ./workspace/ramble/bin/ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) on
 

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -54,6 +54,7 @@ Patch some files in various repos:
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
     wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
     #ONLY FOR CLANG BUILDS: sed -i -e 's@SYSTEM_PATHS = \[\(.*\)\]@SYSTEM_PATHS = [\1, "/opt/FJSVxtclanga/tcsds-mpi-1.2.38", "/opt/FJSVxtclanga/tcsds-ssl2-1.2.38"]@g' workspace/spack/lib/spack/spack/util/environment.py
+    #ONLY FOR CLANG BUILDS: sed -i -e 's@%fj"):@%fj") or (spec.target == "a64fx" and spec.satisfies("%clang\@11:")):@g' workspace/spack/var/spack/repos/builtin/packages/cmake/package.py
 
 
 Build the benchmark:

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -1,0 +1,58 @@
+.. Copyright 2023 Lawrence Livermore National Security, LLC and other
+   Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: Apache-2.0
+
+==============================
+Running benchpark on Fugaku
+==============================
+
+Get in interactive shell
+
+    pjsub --interact ...
+
+Load newer python environment
+
+    if [ -f ~/spack/share/spack/setup-env.sh ]; then
+        source ~/spack/share/spack/setup-env.sh;
+    else
+        source /vol0004/apps/oss/spack/share/spack/setup-env.sh;
+    fi
+    spack load python@3.10.8 /mzi2ihx; spack load py-pip@23.1.2 /4hkqlma
+
+Follow instructions in :doc:`1-getting-started`.
+
+Set up the directory structure for your experiment
+
+    export BM='saxpy/openmp'
+    export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
+    ./bin/benchpark setup ${BM} ${SYS} workspace
+
+Patch some files in various repos
+
+    sed -i -e "s@1280000000@160000000@g" -e 's@cflags=".*"@@g' experiments/streamc/openmp/ramble.yaml
+    wget https://raw.githubusercontent.com/GoogleCloudPlatform/ramble/22db33d5f3728e015fcca6d5618a67014ca132c8/lib/ramble/ramble/spack_runner.py -O workspace/ramble/lib/ramble/ramble/spack_runner.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku5/lib/spack/spack/util/libc.py -O workspace/spack/lib/spack/spack/util/libc.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku6/var/spack/repos/builtin/packages/hpcg/package.py -O workspace/spack/var/spack/repos/builtin/packages/hpcg/package.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku8/var/spack/repos/builtin/packages/fujitsu-mpi/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+    wget https://raw.githubusercontent.com/jdomke/spack/RIKEN_CCS_fugaku9/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py -O workspace/spack/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+
+Build the benchmark
+
+    source ./workspace/setup.sh
+    export TMP=/local
+    export TMPDIR=/local
+    ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) workspace setup
+
+Submit benchmarks from login node (not interactive shell)
+
+    if [ -f ~/spack/share/spack/setup-env.sh ]; then
+        source ~/spack/share/spack/setup-env.sh;
+    else
+        source /vol0004/apps/oss/spack/share/spack/setup-env.sh;
+    fi
+    spack load python@3.11.6 /yjlixq5
+    export BM='saxpy/openmp'
+    export SYS='RCCS-Fugaku-Fujitsu-A64FX-TofuD'
+    ramble -P -D $(readlink -f $(pwd)/workspace/${BM}/${SYS}/workspace) on
+


### PR DESCRIPTION
- verified multiple benchmarks against latest benchpark checkout
- moving to newer fujitsu and clang compilers (spack was updated in fugaku)
- dropping /vol0001 from submission whiuch isnt allowed to be used by users
- adding a howto for our fugaku snowflake