### PR TITLE
ci: rebuild docs on new experiments, applications, and systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
             docs:
               - '.github/**'
               - 'bin/**'
+              - 'configs/**'
               - 'docs/**'
+              - 'experiments/**'
+              - 'repo/**'
               - 'README.rst'
             style:
               - '.github/**'


### PR DESCRIPTION
Now that we list the experiments, applications, and system configs in the docs we should trigger a docs run in CI.