### PR TITLE
Fix kripke openmp config

### DIFF
--- a/experiments/kripke/openmp/ramble.yaml
+++ b/experiments/kripke/openmp/ramble.yaml
@@ -28,11 +28,12 @@ ramble:
           variables:
             experiment_setup: ''
             n_nodes: '1'
+            n_ranks: ['1', '16']
             n_threads_per_proc: ['32', '2']
-            omp_num_threads: n_threads_per_proc
+            omp_num_threads: '{n_threads_per_proc}'
             arch: 'OpenMP'
           experiments:
-            kripke_omp_{n_nodes}_{omp_num_threads}_{ngroups}_{gs}_{nquad}_{ds}_{lorder}_{nzx}_{nzy}_{nzz}_{npx}_{npy}_{npz}:
+            kripke_omp_{n_nodes}_{n_ranks}_{omp_num_threads}_{ngroups}_{gs}_{nquad}_{ds}_{lorder}_{nzx}_{nzy}_{nzz}_{npx}_{npy}_{npz}:
               variables:
                 ngroups: 64
                 gs: 1

--- a/experiments/kripke/openmp/ramble.yaml
+++ b/experiments/kripke/openmp/ramble.yaml
@@ -22,9 +22,6 @@ ramble:
     kripke:
       workloads:
         kripke:
-          env_vars:
-            set:
-              OMP_NUM_THREADS: '{omp_num_threads}'
           variables:
             experiment_setup: ''
             n_nodes: '1'


### PR DESCRIPTION
Not defining `n_ranks` variable causes the allocation modifier to generate the wrong `execute_experiment.tpl` script