### PR TITLE
[WIP] Repos, experiment objects, and experiment specs

### DIFF
--- a/bin/benchpark-python
+++ b/bin/benchpark-python
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# benchpark-python
+#
+# If you want to write your own executable Python script that uses Benchpark
+# modules, on Mac OS or maybe some others, you may be able to do it like
+# this:
+#
+#   #!/usr/bin/env benchpark-python
+#
+# This is compatible across platforms.
+#
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export PYTHONPATH="${SCRIPT_DIR}/../lib"
+exec python -i "$@"

--- a/bin/benchpark-python
+++ b/bin/benchpark-python
@@ -18,4 +18,4 @@
 #
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export PYTHONPATH="${SCRIPT_DIR}/../lib"
-exec python -i "$@"
+exec python3 -i "$@"

--- a/bin/benchpark-python
+++ b/bin/benchpark-python
@@ -17,5 +17,5 @@
 # This is compatible across platforms.
 #
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export PYTHONPATH="${SCRIPT_DIR}/../lib"
+export PYTHONPATH="${SCRIPT_DIR}/../lib":$PYTHONPATH
 exec python3 -i "$@"

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Uni
 import re
 
 import llnl.util.lang
-import benchpark.experiment_spec
+import benchpark.spec
 import benchpark.variant
 
 """This package contains directives that can be used within an experiment.
@@ -324,7 +324,7 @@ def variant(
     description = str(description).strip()
 
     def _execute_variant(pkg):
-        if not re.match(benchpark.experiment_spec.IDENTIFIER, name):
+        if not re.match(benchpark.spec.IDENTIFIER, name):
             directive = "variant"
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -1,0 +1,339 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+import collections.abc
+import functools
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Union
+import re
+
+import llnl.util.lang
+import benchpark.experiment_spec
+import benchpark.variant
+
+"""This package contains directives that can be used within an experiment.
+
+Directives are functions that can be called inside an experiment
+definition to modify the package, for example:
+
+    class OpenMpi(Experiment):
+        variant("ranks")
+        ...
+
+``variant`` is a benchpark directive.
+
+The available directives are:
+
+  * ``variant``
+
+"""
+
+__all__ = [
+    "DirectiveError",
+    "DirectiveMeta",
+    "variant",
+]
+
+#: Names of possible directives. This list is mostly populated using the @directive decorator.
+#: Some directives leverage others and in that case are not automatically added.
+directive_names = []
+
+
+class DirectiveMeta(type):
+    """Flushes the directives that were temporarily stored in the staging
+    area into the package.
+    """
+
+    # Set of all known directives
+    _directive_dict_names: Set[str] = set()
+    _directives_to_be_executed: List[str] = []
+    _default_args: List[dict] = []
+
+    def __new__(cls, name, bases, attr_dict):
+        # Initialize the attribute containing the list of directives
+        # to be executed. Here we go reversed because we want to execute
+        # commands:
+        # 1. in the order they were defined
+        # 2. following the MRO
+        attr_dict["_directives_to_be_executed"] = []
+        for base in reversed(bases):
+            try:
+                directive_from_base = base._directives_to_be_executed
+                attr_dict["_directives_to_be_executed"].extend(directive_from_base)
+            except AttributeError:
+                # The base class didn't have the required attribute.
+                # Continue searching
+                pass
+
+        # De-duplicates directives from base classes
+        attr_dict["_directives_to_be_executed"] = [
+            x for x in llnl.util.lang.dedupe(attr_dict["_directives_to_be_executed"])
+        ]
+
+        # Move things to be executed from module scope (where they
+        # are collected first) to class scope
+        if DirectiveMeta._directives_to_be_executed:
+            attr_dict["_directives_to_be_executed"].extend(
+                DirectiveMeta._directives_to_be_executed
+            )
+            DirectiveMeta._directives_to_be_executed = []
+
+        return super(DirectiveMeta, cls).__new__(cls, name, bases, attr_dict)
+
+    def __init__(cls, name, bases, attr_dict):
+        # The instance is being initialized: if it is an experiment we must ensure
+        # that the directives are called to set it up.
+
+        if "benchpark.experiment" in cls.__module__:
+            # Ensure the presence of the dictionaries associated with the directives.
+            # All dictionaries are defaultdicts that create lists for missing keys.
+            for d in DirectiveMeta._directive_dict_names:
+                setattr(cls, d, {})
+
+            # Lazily execute directives
+            for directive in cls._directives_to_be_executed:
+                directive(cls)
+
+            # Ignore any directives executed *within* top-level
+            # directives by clearing out the queue they're appended to
+            DirectiveMeta._directives_to_be_executed = []
+
+        super(DirectiveMeta, cls).__init__(name, bases, attr_dict)
+
+    @staticmethod
+    def push_default_args(default_args):
+        """Push default arguments"""
+        DirectiveMeta._default_args.append(default_args)
+
+    @staticmethod
+    def pop_default_args():
+        """Pop default arguments"""
+        return DirectiveMeta._default_args.pop()
+
+    @staticmethod
+    def directive(dicts=None):
+        """Decorator for Benchpark directives.
+
+        Benchpark directives allow you to modify an experiment while it is being
+        defined, e.g. to add a variant.  Directives
+        are one of the key pieces of Benchpark's experiment "language", which is
+        embedded in python.
+
+        Here's an example directive:
+
+        .. code-block:: python
+
+            @directive(dicts='variant')
+            variant(expr, ...):
+                ...
+
+        This directive allows you write:
+
+        .. code-block:: python
+
+            class Foo(Experiment):
+                variant(...)
+
+        The ``@directive`` decorator handles a couple things for you:
+
+          1. Adds the class scope (expr) as an initial parameter when
+             called, like a class method would.  This allows you to modify
+             an experiment from within a directive, while the package is still
+             being defined.
+
+          2. It automatically adds a dictionary called "variants" to the
+             experiment so that you can refer to expr.variants.
+
+        The ``(dicts='variant')`` part ensures that ALL experiments in Benchpark
+        will have a ``variants`` attribute after they're constructed, and
+        that if no directive actually modified it, it will just be an
+        empty dict.
+
+        This is just a modular way to add storage attributes to the
+        Experiment class, and it's how Benchpark gets information from the
+        experiments to the core.
+        """
+        global directive_names
+
+        if isinstance(dicts, str):
+            dicts = (dicts,)
+
+        if not isinstance(dicts, collections.abc.Sequence):
+            message = "dicts arg must be list, tuple, or string. Found {0}"
+            raise TypeError(message.format(type(dicts)))
+
+        # Add the dictionary names if not already there
+        DirectiveMeta._directive_dict_names |= set(dicts)
+
+        # This decorator just returns the directive functions
+        def _decorator(decorated_function):
+            directive_names.append(decorated_function.__name__)
+
+            @functools.wraps(decorated_function)
+            def _wrapper(*args, **_kwargs):
+                # First merge default args with kwargs
+                kwargs = dict()
+                for default_args in DirectiveMeta._default_args:
+                    kwargs.update(default_args)
+                kwargs.update(_kwargs)
+
+                # Inject when arguments from the context
+                if DirectiveMeta._when_constraints_from_context:
+                    # Check that directives not yet supporting the when= argument
+                    # are not used inside the context manager
+                    if decorated_function.__name__ == "version":
+                        msg = (
+                            'directive "{0}" cannot be used within a "when"'
+                            ' context since it does not support a "when=" '
+                            "argument"
+                        )
+                        msg = msg.format(decorated_function.__name__)
+                        raise DirectiveError(msg)
+
+                # If any of the arguments are executors returned by a
+                # directive passed as an argument, don't execute them
+                # lazily. Instead, let the called directive handle them.
+                # This allows nested directive calls in packages.  The
+                # caller can return the directive if it should be queued.
+                def remove_directives(arg):
+                    directives = DirectiveMeta._directives_to_be_executed
+                    if isinstance(arg, (list, tuple)):
+                        # Descend into args that are lists or tuples
+                        for a in arg:
+                            remove_directives(a)
+                    else:
+                        # Remove directives args from the exec queue
+                        remove = next((d for d in directives if d is arg), None)
+                        if remove is not None:
+                            directives.remove(remove)
+
+                # Nasty, but it's the best way I can think of to avoid
+                # side effects if directive results are passed as args
+                remove_directives(args)
+                remove_directives(list(kwargs.values()))
+
+                # A directive returns either something that is callable on a
+                # package or a sequence of them
+                result = decorated_function(*args, **kwargs)
+
+                # ...so if it is not a sequence make it so
+                values = result
+                if not isinstance(values, collections.abc.Sequence):
+                    values = (values,)
+
+                DirectiveMeta._directives_to_be_executed.extend(values)
+
+                # wrapped function returns same result as original so
+                # that we can nest directives
+                return result
+
+            return _wrapper
+
+        return _decorator
+
+
+SubmoduleCallback = Callable[["benchpark.experiment.Experiment"], Union[str, List[str], bool]]
+directive = DirectiveMeta.directive
+
+
+@directive("variants")
+def variant(
+    name: str,
+    default: Optional[Any] = None,
+    description: str = "",
+    values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+    multi: Optional[bool] = None,
+    validator: Optional[Callable[[str, str, Tuple[Any, ...]], None]] = None,
+    when: Optional[Union[str, bool]] = None,
+    sticky: bool = False,
+):
+    """Define a variant for the experiment.
+
+    Experimentizer can specify a default value as well as a text description.
+
+    Args:
+        name: Name of the variant
+        default: Default value for the variant, if not specified otherwise the default will be
+            False for a boolean variant and 'nothing' for a multi-valued variant
+        description: Description of the purpose of the variant
+        values: Either a tuple of strings containing the allowed values, or a callable accepting
+            one value and returning True if it is valid
+        multi: If False only one value per spec is allowed for this variant
+        validator: Optional group validator to enforce additional logic. It receives the experiment
+            name, the variant name and a tuple of values and should raise an instance of BenchparkError
+            if the group doesn't meet the additional constraints
+        when: Optional condition on which the variant applies
+        sticky: The variant should not be changed by the concretizer to find a valid concrete spec
+
+    Raises:
+        DirectiveError: If arguments passed to the directive are invalid
+    """
+
+    def format_error(msg, pkg):
+        msg += " @*r{{[{0}, variant '{1}']}}"
+        return msg.format(pkg.name, name)
+
+    # Ensure we have a sequence of allowed variant values, or a
+    # predicate for it.
+    if values is None:
+        if str(default).upper() in ("TRUE", "FALSE"):
+            values = (True, False)
+        else:
+            values = lambda x: True
+
+    # The object defining variant values might supply its own defaults for
+    # all the other arguments. Ensure we have no conflicting definitions
+    # in place.
+    for argument in ("default", "multi", "validator"):
+        # TODO: we can consider treating 'default' differently from other
+        # TODO: attributes and let a packager decide whether to use the fluent
+        # TODO: interface or the directive argument
+        if hasattr(values, argument) and locals()[argument] is not None:
+
+            def _raise_argument_error(pkg):
+                msg = (
+                    "Remove specification of {0} argument: it is handled "
+                    "by an attribute of the 'values' argument"
+                )
+                raise DirectiveError(format_error(msg.format(argument), pkg))
+
+            return _raise_argument_error
+
+    # Allow for the object defining the allowed values to supply its own
+    # default value and group validator, say if it supports multiple values.
+    default = getattr(values, "default", default)
+    validator = getattr(values, "validator", validator)
+    multi = getattr(values, "multi", bool(multi))
+
+    # Here we sanitize against a default value being either None
+    # or the empty string, as the former indicates that a default
+    # was not set while the latter will make the variant unparsable
+    # from the command line
+    if default is None or default == "":
+
+        def _raise_default_not_set(pkg):
+            if default is None:
+                msg = "either a default was not explicitly set, or 'None' was used"
+            elif default == "":
+                msg = "the default cannot be an empty string"
+            raise DirectiveError(format_error(msg, pkg))
+
+        return _raise_default_not_set
+
+    description = str(description).strip()
+
+    def _execute_variant(pkg):
+        if not re.match(benchpark.experiment_spec.spec.IDENTIFIER_RE, name):
+            directive = "variant"
+            msg = "Invalid variant name in {0}: '{1}'"
+            raise DirectiveError(directive, msg.format(pkg.name, name))
+
+        pkg.variants[name] = (
+            benchpark.variant.Variant(name, default, description, values, multi, validator, sticky),
+        )
+
+    return _execute_variant
+
+
+class DirectiveError(benchpark.error.BenchparkError):
+    """This is raised when something is wrong with a package directive."""

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -83,8 +83,7 @@ class DirectiveMeta(type):
     def __init__(cls, name, bases, attr_dict):
         # The instance is being initialized: if it is an experiment we must ensure
         # that the directives are called to set it up.
-
-        if "benchpark.experiment" in cls.__module__:
+        if "benchpark.expr" in cls.__module__:
             # Ensure the presence of the dictionaries associated with the directives.
             # All dictionaries are defaultdicts that create lists for missing keys.
             for d in DirectiveMeta._directive_dict_names:
@@ -177,18 +176,18 @@ class DirectiveMeta(type):
                     kwargs.update(default_args)
                 kwargs.update(_kwargs)
 
-                # Inject when arguments from the context
-                if DirectiveMeta._when_constraints_from_context:
-                    # Check that directives not yet supporting the when= argument
-                    # are not used inside the context manager
-                    if decorated_function.__name__ == "version":
-                        msg = (
-                            'directive "{0}" cannot be used within a "when"'
-                            ' context since it does not support a "when=" '
-                            "argument"
-                        )
-                        msg = msg.format(decorated_function.__name__)
-                        raise DirectiveError(msg)
+                # # Inject when arguments from the context
+                # if DirectiveMeta._when_constraints_from_context:
+                #     # Check that directives not yet supporting the when= argument
+                #     # are not used inside the context manager
+                #     if decorated_function.__name__ == "version":
+                #         msg = (
+                #             'directive "{0}" cannot be used within a "when"'
+                #             ' context since it does not support a "when=" '
+                #             "argument"
+                #         )
+                #         msg = msg.format(decorated_function.__name__)
+                #         raise DirectiveError(msg)
 
                 # If any of the arguments are executors returned by a
                 # directive passed as an argument, don't execute them
@@ -232,7 +231,9 @@ class DirectiveMeta(type):
         return _decorator
 
 
-SubmoduleCallback = Callable[["benchpark.experiment.Experiment"], Union[str, List[str], bool]]
+SubmoduleCallback = Callable[
+    ["benchpark.experiment.Experiment"], Union[str, List[str], bool]
+]
 directive = DirectiveMeta.directive
 
 
@@ -323,13 +324,13 @@ def variant(
     description = str(description).strip()
 
     def _execute_variant(pkg):
-        if not re.match(benchpark.experiment_spec.spec.IDENTIFIER_RE, name):
+        if not re.match(benchpark.experiment_spec.IDENTIFIER, name):
             directive = "variant"
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
-        pkg.variants[name] = (
-            benchpark.variant.Variant(name, default, description, values, multi, validator, sticky),
+        pkg.variants[name] = benchpark.variant.Variant(
+            name, default, description, values, multi, validator, sticky
         )
 
     return _execute_variant

--- a/lib/benchpark/error.py
+++ b/lib/benchpark/error.py
@@ -1,0 +1,81 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import sys
+
+#: at what level we should write stack traces or short error messages
+#: this is module-scoped because it needs to be set very early
+debug = 0
+
+
+class BenchparkError(Exception):
+    """This is the superclass for all Benchpark errors.
+    Subclasses can be found in the modules they have to do with.
+    """
+
+    def __init__(self, message, long_message=None):
+        super().__init__()
+        self.message = message
+        self._long_message = long_message
+
+        # for exceptions raised from child build processes, we save the
+        # traceback as a string and print it in the parent.
+        self.traceback = None
+
+        # we allow exceptions to print debug info via print_context()
+        # before they are caught at the top level. If they *haven't*
+        # printed context early, we do it by default when die() is
+        # called, so we need to remember whether it's been called.
+        self.printed = False
+
+    @property
+    def long_message(self):
+        return self._long_message
+
+    def print_context(self):
+        """Print extended debug information about this exception.
+
+        This is usually printed when the top-level Spack error handler
+        calls ``die()``, but it can be called separately beforehand if a
+        lower-level error handler needs to print error context and
+        continue without raising the exception to the top level.
+        """
+        if self.printed:
+            return
+
+        # basic debug message
+        if self.long_message:
+            sys.stderr.write(self.long_message)
+            sys.stderr.write("\n")
+
+        # stack trace, etc. in debug mode.
+        if debug:
+            if self.traceback:
+                # exception came from a build child, already got
+                # traceback in child, so print it.
+                sys.stderr.write(self.traceback)
+            else:
+                # run parent exception hook.
+                sys.excepthook(*sys.exc_info())
+
+        sys.stderr.flush()
+        self.printed = True
+
+    def die(self):
+        self.print_context()
+        sys.exit(1)
+
+    def __str__(self):
+        msg = self.message
+        if self._long_message:
+            msg += "\n    %s" % self._long_message
+        return msg
+
+    def __repr__(self):
+        args = [repr(self.message), repr(self.long_message)]
+        args = ",".join(args)
+        qualified_name = inspect.getmodule(self).__name__ + "." + type(self).__name__
+        return qualified_name + "(" + args + ")"

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -6,6 +6,7 @@
 from typing import Dict, Tuple
 import os
 import inspect
+import yaml  # TODO: some way to ensure yaml available
 
 import benchpark.directives
 import benchpark.repo
@@ -214,3 +215,48 @@ class Experiment(metaclass=ExperimentMeta):
             return False
         s = self.extendee_spec
         return s and spec.satisfies(s)
+
+    def compute_include_section(self):
+        # include the config directory
+        # TODO: does this need to change to interop with System class
+        return ["./configs"]
+
+    def compute_config_section(self):
+        # default configs for all experiments
+        return {
+            "deprecated": True,
+            "spack_flags": {"install": "--add --keep-stage", "concretize": "-U -f"},
+        }
+
+    def compute_modifiers_section(self):
+        # by default we use the allocation modifier and no others
+        return [{"name": "allocation"}]
+
+    def compute_applications_section(self):
+        # TODO: is there some reasonable default?
+        raise NotImplementedError(
+            "Each experiment must implement compute_applications_section"
+        )
+
+    def compute_spack_section(self):
+        # TODO: is there some reasonable default based on known variable names?
+        raise NotImplementedError(
+            "Each experiment must implement compute_spack_section"
+        )
+
+    def compute_ramble_dict(self):
+        # This can be overridden by any subclass that needs more flexibility
+        return {
+            "ramble": {
+                "include": self.compute_include_section(),
+                "config": self.compute_config_section(),
+                "modifiers": self.compute_modifiers_section(),
+                "applications": self.compute_applications_section(),
+                "spack": self.compute_spack_section(),
+            }
+        }
+
+    def write_ramble_dict(self, filepath):
+        ramble_dict = self.compute_ramble_dict()
+        with open(filepath, "w") as f:
+            yaml.dump(ramble_dict, f)

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -14,6 +14,10 @@ import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.language.shared_language
 import yaml  # TODO: some way to ensure yaml available
+
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper.bootstrap()
+
 from llnl.util.lang import classproperty, memoized
 from ramble.language.language_base import DirectiveError
 

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -1,0 +1,212 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Tuple
+import os
+import inspect
+
+import benchpark.directives
+import benchpark.repo
+from llnl.util.lang import classproperty, memoized
+
+
+class ExperimentMeta(
+    benchpark.directives.DirectiveMeta,
+):
+    """
+    Package metaclass for supporting directives (e.g., depends_on) and phases
+    """
+
+    def __new__(cls, name, bases, attr_dict):
+        """
+        FIXME: REWRITE
+        Instance creation is preceded by phase attribute transformations.
+
+        Conveniently transforms attributes to permit extensible phases by
+        iterating over the attribute 'phases' and creating / updating private
+        InstallPhase attributes in the class that will be initialized in
+        __init__.
+        """
+        attr_dict["_name"] = None
+
+        return super(ExperimentMeta, cls).__new__(cls, name, bases, attr_dict)
+
+
+class Experiment(metaclass=ExperimentMeta):
+    """This is the superclass for all benchpark experiments.
+
+    ***The Experiment class***
+
+    Experiments are written in pure Python.
+
+    There are two main parts of a Benchpark experiment:
+
+      1. **The experiment class**.  Classes contain ``directives``, which are
+         special functions, that add metadata (variants) to packages (see
+         ``directives.py``).
+
+      2. **Experiment instances**. Once instantiated, a package is
+         essentially a software installer.  Spack calls methods like
+         ``do_install()`` on the ``Package`` object, and it uses those to
+         drive user-implemented methods like ``patch()``, ``install()``, and
+         other build steps.  To install software, an instantiated package
+         needs a *concrete* spec, which guides the behavior of the various
+         install methods.
+
+    Experiments are imported from repos (see ``repo.py``).
+
+    **Package DSL**
+
+    Look in ``lib/spack/docs`` or check https://spack.readthedocs.io for
+    the full documentation of the package domain-specific language.  That
+    used to be partially documented here, but as it grew, the docs here
+    became increasingly out of date.
+
+    **Package Lifecycle**
+
+    A package's lifecycle over a run of Spack looks something like this:
+
+    .. code-block:: python
+
+       p = Package()             # Done for you by spack
+
+       p.do_fetch()              # downloads tarball from a URL (or VCS)
+       p.do_stage()              # expands tarball in a temp directory
+       p.do_patch()              # applies patches to expanded source
+       p.do_install()            # calls package's install() function
+       p.do_uninstall()          # removes install directory
+
+    although packages that do not have code have nothing to fetch so omit
+    ``p.do_fetch()``.
+
+    There are also some other commands that clean the build area:
+
+    .. code-block:: python
+
+       p.do_clean()              # removes the stage directory entirely
+       p.do_restage()            # removes the build directory and
+                                 # re-expands the archive.
+
+    The convention used here is that a ``do_*`` function is intended to be
+    called internally by Spack commands (in ``spack.cmd``).  These aren't for
+    package writers to override, and doing so may break the functionality
+    of the Package class.
+
+    Package creators have a lot of freedom, and they could technically
+    override anything in this class.  That is not usually required.
+
+    For most use cases.  Package creators typically just add attributes
+    like ``homepage`` and, for a code-based package, ``url``, or functions
+    such as ``install()``.
+    There are many custom ``Package`` subclasses in the
+    ``spack.build_systems`` package that make things even easier for
+    specific build systems.
+
+    """
+
+    #
+    # These are default values for instance variables.
+    #
+
+    # This allows analysis tools to correctly interpret the class attributes.
+    variants: Dict[str, Tuple["benchpark.variant.Variant", "benchpark.experiment_spec.ConcreteSpec"]]
+
+    def __init__(self, spec):
+        self.spec: "benchpark.experiment_spec.ConcreteSpec" = spec
+        super().__init__()
+
+    @classproperty
+    def package_dir(cls):
+        """Directory where the package.py file lives."""
+        return os.path.abspath(os.path.dirname(cls.module.__file__))
+
+    @classproperty
+    def module(cls):
+        """Module object (not just the name) that this package is defined in.
+
+        We use this to add variables to package modules.  This makes
+        install() methods easier to write (e.g., can call configure())
+        """
+        return __import__(cls.__module__, fromlist=[cls.__name__])
+
+    @classproperty
+    def namespace(cls):
+        """Spack namespace for the package, which identifies its repo."""
+        return benchpark.repo.namespace_from_fullname(cls.__module__)
+
+    @classproperty
+    def fullname(cls):
+        """Name of this package, including the namespace"""
+        return f"{cls.namespace}.{cls.name}"
+
+    @classproperty
+    def fullnames(cls):
+        """Fullnames for this package and any packages from which it inherits."""
+        fullnames = []
+        for cls in inspect.getmro(cls):
+            namespace = getattr(cls, "namespace", None)
+            if namespace:
+                fullnames.append(f"{namespace}.{cls.name}")
+            if namespace == "builtin":
+                # builtin packages cannot inherit from other repos
+                break
+        return fullnames
+
+    @classproperty
+    def name(cls):
+        """The name of this package.
+
+        The name of a package is the name of its Python module, without
+        the containing module names.
+        """
+        if cls._name is None:
+            cls._name = cls.module.__name__
+            if "." in cls._name:
+                cls._name = cls._name[cls._name.rindex(".") + 1 :]
+        return cls._name
+
+    # TODO: allow more than one active extendee.
+    @property
+    def extendee_spec(self):
+        """
+        Spec of the extendee of this package, or None if it is not an extension
+        """
+        if not self.extendees:
+            return None
+
+        # if the spec is concrete already, then it extends something
+        # that is an *optional* dependency, and the dep isn't there.
+        if isinstance(self.spec, benchpark.experiment_spec.ConcreteSpec):
+            return None
+        else:
+            # If it's not concrete, then return the spec from the
+            # extends() directive since that is all we know so far.
+            spec_str = next(iter(self.extendees))
+            return benchpark.experiment_spec.Spec(spec_str)
+
+    @property
+    def is_extension(self):
+        # if it is concrete, it's only an extension if it actually
+        # dependes on the extendee.
+        if isinstance(self.spec, benchpark.experiment_spec.ConcreteSpec):
+            return self.extendee_spec is not None
+        else:
+            # If not, then it's an extension if it *could* be an extension
+            return bool(self.extendees)
+
+    def extends(self, spec):
+        """
+        Returns True if this package extends the given spec.
+
+        If ``self.spec`` is concrete, this returns whether this package extends
+        the given spec.
+
+        If ``self.spec`` is not concrete, this returns whether this package may
+        extend the given spec.
+        """
+        if spec.name not in self.extendees:
+            return False
+        s = self.extendee_spec
+        return s and spec.satisfies(s)

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -111,7 +111,10 @@ class Experiment(metaclass=ExperimentMeta):
     #
 
     # This allows analysis tools to correctly interpret the class attributes.
-    variants: Dict[str, Tuple["benchpark.variant.Variant", "benchpark.experiment_spec.ConcreteSpec"]]
+    variants: Dict[
+        str,
+        Tuple["benchpark.variant.Variant", "benchpark.experiment_spec.ConcreteSpec"],
+    ]
 
     def __init__(self, spec):
         self.spec: "benchpark.experiment_spec.ConcreteSpec" = spec
@@ -134,7 +137,8 @@ class Experiment(metaclass=ExperimentMeta):
     @classproperty
     def namespace(cls):
         """Spack namespace for the package, which identifies its repo."""
-        return benchpark.repo.namespace_from_fullname(cls.__module__)
+        parts = cls.__module__.split(".")
+        return ".".join(parts[2:-1])
 
     @classproperty
     def fullname(cls):

--- a/lib/benchpark/experiment_spec.py
+++ b/lib/benchpark/experiment_spec.py
@@ -216,10 +216,13 @@ class ConcreteExperimentSpec(ExperimentSpec):
         for name, variant in self.experiment_class.variants.items():
             if name not in self.variants:
                 self._variants[name] = variant.default
-            else:
-                # raise if the value is invalid
-                ## TODO interface combination ##
-                variant.validate(self.variants[name])
+
+        for name, values in self.variants.items():
+            if name not in self.experiment_class.variants:
+                raise Exception
+
+            variant = self.experiment_class.variants[name]
+            variant.validate_values(self.variants[name])
 
         # Convert to immutable type
         self._variants = ConcreteVariantMap(self.variants)

--- a/lib/benchpark/experiment_spec.py
+++ b/lib/benchpark/experiment_spec.py
@@ -8,6 +8,11 @@ repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
 
 
 class VariantMap(llnl.util.lang.HashableMap):
+    def __init__(self, init: "VariantMap" = None):
+        super().__init__()
+        if init:
+            self.dict = init.dict.copy()
+
     def __setitem__(self, name: str, values: Union[str, Iterable]):
         if name in self.dict:
             raise Exception(f"Cannot specify variant {name} twice")

--- a/lib/benchpark/experiment_spec.py
+++ b/lib/benchpark/experiment_spec.py
@@ -1,9 +1,10 @@
+from typing import Iterable, Union
 import llnl.util.lang
 import benchpark.repo
 
 
 class VariantMap(llnl.util.lang.HashableMap):
-    def __setitem__(self, name, values):
+    def __setitem__(self, name: str, values: Union[str, Iterable]):
         if name in self.dict:
             raise Exception(f"Cannot specify variant {name} twice")
         if isinstance(values, str):
@@ -12,16 +13,24 @@ class VariantMap(llnl.util.lang.HashableMap):
             values = tuple(*values)
         super().__setitem__(name, values)
 
-    def intersects(self, other):
-        # TODO implement
-        pass
+    def intersects(self, other: VariantMap) -> bool:
+        if isinstance(other, ConcreteVariantMap):
+            return other.intersects(self)
 
-    def satisfies(self, other):
-        # TODO implement
-        pass
+        # always possible to constrain since abstract variants are multi-value
+        return True
+
+    def satisfies(self, other: VariantMap) -> bool:
+        if isinstance(other, ConcreteVariantMap):
+            self == other
+
+        return all(
+            name in self and set(self[name]) >= set(other[name])
+            for name in other
+        )
 
     @staticmethod
-    def stringify(name, values):
+    def stringify(name: str, values: tuple) -> str:
         if len(values) == 1:
             if values[0].lower() == "true":
                 return f"+{name}"
@@ -37,20 +46,15 @@ class VariantMap(llnl.util.lang.HashableMap):
 
 
 class ConcreteVariantMap(VariantMap):
-    def __setitem__(self, name, variant_spec):
+    def __setitem__(self, name, values):
         raise TypeError(f"{self.__class__} is immutable.")
 
-    def intersects(self, other):
-        # TODO implement
-        pass
-
-    def satisfies(self, other):
-        # TODO implement
-        pass
+    def intersects(self, other: VariantMap) -> bool:
+        return self.satisfies(other)
 
 
-class ExperimentSpec(ExperimentSpec):
-    def __init__(self, str_or_spec):
+class ExperimentSpec(object):
+    def __init__(self, str_or_spec: Optional[Union[str, ExperimentSpec]] = None):
         self._name = None
         self._namespace = None
         self._variants = VariantMap()
@@ -59,9 +63,9 @@ class ExperimentSpec(ExperimentSpec):
             self._dup(str_or_spec)
         elif isinstance(str_or_spec, str):
             self._parse(str_or_spec)
-        else:
+        elif str_or_spec is not None:
             msg = f"{self.__class__} can only be instantiated from {self.__class__} or str, "
-            msg += f"not from {type(str_or_spec)}".
+            msg += f"not from {type(str_or_spec)}."
             raise NotImplementedError(msg)
 
     ### getter/setter for each attribute so that ConcreteExperimentSpec can be immutable ###
@@ -70,7 +74,7 @@ class ExperimentSpec(ExperimentSpec):
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @property
@@ -78,7 +82,7 @@ class ExperimentSpec(ExperimentSpec):
         return self._namespace
 
     @namespace.setter
-    def namespace(self, value):
+    def namespace(self, value: str):
         self._namespace = value
 
     @property
@@ -87,33 +91,45 @@ class ExperimentSpec(ExperimentSpec):
 
     # This one is probably unnecessary, but here for completeness
     @variants.setter
-    def variants(self, value):
-        self._variants = value  # value is an entire dict
+    def variants(self, value: VariantMap):
+        self._variants = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: ExperimentSpec):
         return (
             self.name == other.name and
             (self.namespace is None or other.namespace is None or self.namespace == other.namespace) and
             self.variants == other.variants
         )
 
-    def _dup(self, other):
+    def _dup(self, other: ExperimentSpec):
         # operate on underlying types so it can be called on ConcreteExperimentSpec
         self._name = other.name
         self._namespace = other.namespace
         self._variants = other.variants
 
-    def _parse(self, str):
-        # TODO implement
-        pass
+    def _parse(self, string: str):
+        specs = ExperimentSpecParser(string).all_specs()
+        assert len(specs) == 1, f"{string} does not parse to one spec"
 
-    def intersects(self, other):
-        # TODO implement
-        pass
+        self._dup(specs[0])
 
-    def satisfies(self, other):
-        # TODO implement
-        pass
+    def intersects(self, other: Union[str, ExperimentSpec]) -> bool:
+        if not isinstance(other, ExperimentSpec):
+            other = ExperimentSpec(other)
+        return (
+            (self.name is None or other.name is None or self.name == other.name) and
+            (self.namespace is None or other.namespace is None or self.namespace == other.namespace) and
+            self.variants.intersects(other.variants)
+        )
+
+    def satisfies(self, other: Union[str, ExperimentSpec]) -> bool:
+        if not isinstance(other, ExperimentSpec):
+            other = ExperimentSpec(other)
+        return (
+            (other.name is None or self.name == other.name) and
+            (other.namespace is None or self.namespace == other.namespace) and
+            self.variants.satisfies(other.variants)
+        )
 
     def concretize(self):
         return ConcreteExperimentSpec(self)
@@ -125,7 +141,7 @@ class ExperimentSpec(ExperimentSpec):
 
 
 class ConcreteExperimentSpec(ExperimentSpec):
-    def __init__(self, str_or_spec):
+    def __init__(self, str_or_spec: Union[str, ExperimentSpec]):
         super().__init__(*args, **kwargs)
         self._concretize()
 
@@ -133,15 +149,15 @@ class ConcreteExperimentSpec(ExperimentSpec):
         return hash((self.name, self.namespace, self.variants))
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         raise TypeError(f"{self.__class__} is immutable")
 
     @namespace.setter
-    def namespace(self, value)
+    def namespace(self, value: str):
         raise TypeError(f"{self.__class__} is immutable")
 
     @variants.setter
-    def variants(self, value):
+    def variants(self, value: str):
         raise TypeError(f"{self.__class__} is immutable")
 
     def _concretize(self):
@@ -164,18 +180,234 @@ class ConcreteExperimentSpec(ExperimentSpec):
         # Convert to immutable type
         self._variants = ConcreteVariantMap(self.variants)
 
-    def intersects(self, other):
-        # TODO implement
-        pass
-
-    def satisfies(self, other):
-        # TODO implement
-        pass
-
     @property
-    def experiment(self):
+    def experiment(self) -> "benchpark.Experiment":
         return self.experiment_class(self)
 
 
+# PARSING STUFF BELOW HERE
+
+#: Valid name for specs and variants. Here we are not using
+#: the previous "w[\w.-]*" since that would match most
+#: characters that can be part of a word in any language
+IDENTIFIER = r"(?:[a-zA-Z_0-9][a-zA-Z_0-9\-]*)"
+DOTTED_IDENTIFIER = rf"(?:{IDENTIFIER}(?:\.{IDENTIFIER})+)"
+NAME = r"[a-zA-Z_0-9][a-zA-Z_0-9\-.]*"
+
+#: These are legal values that *can* be parsed bare, without quotes on the command line.
+VALUE = r"(?:[a-zA-Z_0-9\-+\*.,:=\~\/\\]+)"
+
+#: Regex with groups to use for splitting (optionally propagated) key-value pairs
+SPLIT_KVP = re.compile(rf"^({NAME})=(.*)$")
+
+
+class TokenBase(enum.Enum):
+    """Base class for an enum type with a regex value"""
+
+    def __new__(cls, *args, **kwargs):
+        # See
+        value = len(cls.__members__) + 1
+        obj = object.__new__(cls)
+        obj._value_ = value
+        return obj
+
+    def __init__(self, regex):
+        self.regex = regex
+
+    def __str__(self):
+        return f"{self._name_}"
+
+
+class TokenType(TokenBase):
+    """Enumeration of the different token kinds in the spec grammar.
+
+    Order of declaration is extremely important, since text containing specs is parsed with a
+    single regex obtained by ``"|".join(...)`` of all the regex in the order of declaration.
+    """
+    # variants
+    BOOL_VARIANT = rf"(?:[~+-]\s*{NAME})"
+    KEY_VALUE_PAIR = rf"(?:{NAME}=(?:{VALUE}))"
+    # Package name
+    FULLY_QUALIFIED_PACKAGE_NAME = rf"(?:{DOTTED_IDENTIFIER})"
+    UNQUALIFIED_PACKAGE_NAME = rf"(?:{IDENTIFIER})"
+    # White spaces
+    WS = r"(?:\s+)"
+
+
+class ErrorTokenType(TokenBase):
+    """Enum with regexes for error analysis"""
+
+    # Unexpected character
+    UNEXPECTED = r"(?:.[\s]*)"
+
+
+class Token:
+    """Represents tokens; generated from input by lexer and fed to parse()."""
+
+    __slots__ = "kind", "value", "start", "end"
+
+    def __init__(
+        self, kind: TokenBase, value: str, start: Optional[int] = None, end: Optional[int] = None
+    ):
+        self.kind = kind
+        self.value = value
+        self.start = start
+        self.end = end
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return f"({self.kind}, {self.value})"
+
+    def __eq__(self, other):
+        return (self.kind == other.kind) and (self.value == other.value)
+
+
+#: List of all the regexes used to match spec parts, in order of precedence
+TOKEN_REGEXES = [rf"(?P<{token}>{token.regex})" for token in TokenType]
+#: List of all valid regexes followed by error analysis regexes
+ERROR_HANDLING_REGEXES = TOKEN_REGEXES + [
+    rf"(?P<{token}>{token.regex})" for token in ErrorTokenType
+]
+#: Regex to scan a valid text
+ALL_TOKENS = re.compile("|".join(TOKEN_REGEXES))
+#: Regex to analyze an invalid text
+ANALYSIS_REGEX = re.compile("|".join(ERROR_HANDLING_REGEXES))
+
+
+def tokenize(text: str) -> Iterator[Token]:
+    """Return a token generator from the text passed as input.
+
+    Raises:
+        SpecTokenizationError: if we can't tokenize anymore, but didn't reach the
+            end of the input text.
+    """
+    scanner = ALL_TOKENS.scanner(text)  # type: ignore[attr-defined]
+    match: Optional[Match] = None
+    for match in iter(scanner.match, None):
+        # The following two assertions are to help mypy
+        msg = (
+            "unexpected value encountered during parsing. Please submit a bug report "
+        )
+        assert match is not None, msg
+        assert match.lastgroup is not None, msg
+        yield Token(
+            TokenType.__members__[match.lastgroup], match.group(), match.start(), match.end()
+        )
+
+    if match is None and not text:
+        # We just got an empty string
+        return
+
+    if match is None or match.end() != len(text):
+        error_scanner = ANALYSIS_REGEX.scanner(text)
+        matches = [m for m in iter(error_scanner.match, None)]
+        raise SpecTokenizationError(matches, text)
+
+
+class TokenContext:
+    """Token context passed around by parsers"""
+
+    __slots__ = "token_stream", "current_token", "next_token"
+
+    def __init__(self, token_stream: Iterator[Token]):
+        self.token_stream = token_stream
+        self.current_token = None
+        self.next_token = None
+        self.advance()
+
+    def advance(self):
+        """Advance one token"""
+        self.current_token, self.next_token = self.next_token, next(self.token_stream, None)
+
+    def accept(self, kind: TokenType):
+        """If the next token is of the specified kind, advance the stream and return True.
+        Otherwise return False.
+        """
+        if self.next_token and self.next_token.kind == kind:
+            self.advance()
+            return True
+        return False
+
+    def expect(self, *kinds: TokenType):
+        return self.next_token and self.next_token.kind in kinds
+
+
+class ExperimentSpecParser(object):
+    __slots__  = "literal_str", "ctx"
+    def __init__(self, literal_str: str):
+        self.literal_str = literal_str
+        self.ctx = TokenContext(filter(lambda x: x.kind != TokenType.WS, tokenize(literal_str)))
+
+    def tokens(self) -> List[Token]:
+        """Return the entire list of token from the initial text. White spaces are
+        filtered out.
+        """
+        return list(filter(lambda x: x.kind != TokenType.WS, tokenize(self.literal_str)))
+
+    def next_spec(self) -> Optional[ExperimentSpec]:
+        """Return the next spec parsed from text.
+
+        Args:
+            initial_spec: object where to parse the spec. If None a new one
+                will be created.
+
+        Return
+            The spec that was parsed
+        """
+        if not self.ctx.next_token:
+            return None
+
+        spec = ExperimentSpec()
+
+        if self.ctx.accept(TokenType.UNQUALIFIED_PACKAGE_NAME):
+            spec.name = self.ctx.current_token.value
+        elif self.ctx.accept(TokenType.FULLY_QUALIFIED_PACKAGE_NAME):
+            parts = self.ctx.current_token.value.split(".")
+            name = parts[-1]
+            namespace = ".".join(parts[:-1])
+            spec.name = name
+            spec.namespace = namespace
+
+        while True:
+            if self.ctx.accept(TokenType.BOOL_VARIANT):
+                name = self.ctx.current_token.value[1:].strip()
+                value = self.ctx.current_token.value[0] == "+"
+                spec.variants[name] = str(value).lower()
+            elif self.ctx.accept(TokenType.KEY_VALUE_PAIR):
+                match = SPLIT_KVP.match(self.ctx.current_token.value)
+                assert match, f"SPLIT_KVP cannot split pair {self.ctx.current_token.value}"
+
+                name, value = match.groups()
+                spec[name] = value
+            else:
+                break
+
+        return spec
+
+    def all_specs(self): -> List[ExperimentSpec]:
+        return list(iter(self.next_spec, None))
+
+
+# ERROR HANDLING BELOW HERE
+
 class AnonymousSpecError(Exception):
     pass
+
+class SpecTokenizationError(Exception):
+    """Syntax error in a spec string"""
+
+    def __init__(self, matches, text):
+        message = "unexpected tokens in the spec string\n"
+        message += f"{text}"
+
+        underline = "\n"
+        for match in matches:
+            if match.lastgroup == str(ErrorTokenType.UNEXPECTED):
+                underline += f"{'^' * (match.end() - match.start())}"
+                continue
+            underline += f"{' ' * (match.end() - match.start())}"
+
+        message += color.colorize(f"@*r{{{underline}}}")
+        super().__init__(message)

--- a/lib/benchpark/experiment_spec.py
+++ b/lib/benchpark/experiment_spec.py
@@ -219,7 +219,7 @@ class ConcreteExperimentSpec(ExperimentSpec):
 
         for name, values in self.variants.items():
             if name not in self.experiment_class.variants:
-                raise Exception
+                raise Exception(f"{name} is not a valid variant of {self.name}")
 
             variant = self.experiment_class.variants[name]
             variant.validate_values(self.variants[name])

--- a/lib/benchpark/experiment_spec.py
+++ b/lib/benchpark/experiment_spec.py
@@ -1,0 +1,181 @@
+import llnl.util.lang
+import benchpark.repo
+
+
+class VariantMap(llnl.util.lang.HashableMap):
+    def __setitem__(self, name, values):
+        if name in self.dict:
+            raise Exception(f"Cannot specify variant {name} twice")
+        if isinstance(values, str):
+            values = (values,)
+        else:
+            values = tuple(*values)
+        super().__setitem__(name, values)
+
+    def intersects(self, other):
+        # TODO implement
+        pass
+
+    def satisfies(self, other):
+        # TODO implement
+        pass
+
+    @staticmethod
+    def stringify(name, values):
+        if len(values) == 1:
+            if values[0].lower() == "true":
+                return f"+{name}"
+            if values[0].lower() == "false":
+                return f"~{name}"
+        return f"{name}={','.join(values)}"
+
+    def __str__(self):
+        ' '.join(
+            self.stringify(name, values)
+            for name, values in self.dict.items()
+        )
+
+
+class ConcreteVariantMap(VariantMap):
+    def __setitem__(self, name, variant_spec):
+        raise TypeError(f"{self.__class__} is immutable.")
+
+    def intersects(self, other):
+        # TODO implement
+        pass
+
+    def satisfies(self, other):
+        # TODO implement
+        pass
+
+
+class ExperimentSpec(ExperimentSpec):
+    def __init__(self, str_or_spec):
+        self._name = None
+        self._namespace = None
+        self._variants = VariantMap()
+
+        if isinstance(str_or_spec, ExperimentSpec):
+            self._dup(str_or_spec)
+        elif isinstance(str_or_spec, str):
+            self._parse(str_or_spec)
+        else:
+            msg = f"{self.__class__} can only be instantiated from {self.__class__} or str, "
+            msg += f"not from {type(str_or_spec)}".
+            raise NotImplementedError(msg)
+
+    ### getter/setter for each attribute so that ConcreteExperimentSpec can be immutable ###
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def namespace(self):
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, value):
+        self._namespace = value
+
+    @property
+    def variants(self):
+        return self._variants
+
+    # This one is probably unnecessary, but here for completeness
+    @variants.setter
+    def variants(self, value):
+        self._variants = value  # value is an entire dict
+
+    def __eq__(self, other):
+        return (
+            self.name == other.name and
+            (self.namespace is None or other.namespace is None or self.namespace == other.namespace) and
+            self.variants == other.variants
+        )
+
+    def _dup(self, other):
+        # operate on underlying types so it can be called on ConcreteExperimentSpec
+        self._name = other.name
+        self._namespace = other.namespace
+        self._variants = other.variants
+
+    def _parse(self, str):
+        # TODO implement
+        pass
+
+    def intersects(self, other):
+        # TODO implement
+        pass
+
+    def satisfies(self, other):
+        # TODO implement
+        pass
+
+    def concretize(self):
+        return ConcreteExperimentSpec(self)
+
+    @property
+    def experiment_class(self):
+        ## TODO interface combination ##
+        return benchpark.repo.get_experiment_class(self.name)
+
+
+class ConcreteExperimentSpec(ExperimentSpec):
+    def __init__(self, str_or_spec):
+        super().__init__(*args, **kwargs)
+        self._concretize()
+
+    def __hash__(self):
+        return hash((self.name, self.namespace, self.variants))
+
+    @name.setter
+    def name(self, value):
+        raise TypeError(f"{self.__class__} is immutable")
+
+    @namespace.setter
+    def namespace(self, value)
+        raise TypeError(f"{self.__class__} is immutable")
+
+    @variants.setter
+    def variants(self, value):
+        raise TypeError(f"{self.__class__} is immutable")
+
+    def _concretize(self):
+        if not self.name:
+            raise AnonymousSpecError(f"Cannot concretize anonymous ExperimentSpec {self}")
+
+        if not self.namespace:
+            ## TODO interface combination ##
+            self._namespace = benchpark.repo.namespace_for_experiment(self.name)
+
+        ## TODO interface combination ##
+        for name, variant in self.experiment_class.variants.items():
+            if name not in self.variants:
+                self._variants[name] = variant.default
+            else:
+                # raise if the value is invalid
+                ## TODO interface combination ##
+                variant.validate(self.variants[name])
+
+        # Convert to immutable type
+        self._variants = ConcreteVariantMap(self.variants)
+
+    def intersects(self, other):
+        # TODO implement
+        pass
+
+    def satisfies(self, other):
+        # TODO implement
+        pass
+
+    @property
+    def experiment(self):
+        return self.experiment_class(self)
+
+
+class AnonymousSpecError(Exception):
+    pass

--- a/lib/benchpark/naming.py
+++ b/lib/benchpark/naming.py
@@ -1,0 +1,269 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Need this because of ramble.util.string
+from __future__ import absolute_import
+import io
+import string
+import itertools
+import re
+
+import benchpark.error
+
+__all__ = [
+    "mod_to_class",
+    "benchpark_module_to_python_module",
+    "valid_module_name",
+    "valid_fully_qualified_module_name",
+    "validate_fully_qualified_module_name",
+    "validate_module_name",
+    "possible_benchpark_module_names",
+    "simplify_name",
+    "NamespaceTrie",
+]
+
+# Valid module names can contain '-' but can't start with it.
+_valid_module_re = r"^\w[\w-]*$"
+
+# Valid module names can contain '-' but can't start with it.
+_valid_fully_qualified_module_re = r"^(\w[\w-]*)(\.\w[\w-]*)*$"
+
+
+def mod_to_class(mod_name):
+    """Convert a name from module style to class name style.  Benchpark mostly
+    follows `PEP-8 <http://legacy.python.org/dev/peps/pep-0008/>`_:
+
+       * Module and package names use lowercase_with_underscores.
+       * Class names use the CapWords convention.
+
+    Regular source code follows these conventions.  Ramble is a bit
+    more liberal with its Application names:
+
+       * They can contain '-' as well as '_', but cannot start with '-'.
+       * They can start with numbers, e.g. "3proxy".
+
+    This function converts from the module convention to the class
+    convention by removing _ and - and converting surrounding
+    lowercase text to CapWords.  If mod_name starts with a number,
+    the class name returned will be prepended with '_' to make a
+    valid Python identifier.
+    """
+    validate_module_name(mod_name)
+
+    class_name = re.sub(r"[-_]+", "-", mod_name)
+    class_name = string.capwords(class_name, "-")
+    class_name = class_name.replace("-", "")
+
+    # If a class starts with a number, prefix it with Number_ to make it
+    # a valid Python class name.
+    if re.match(r"^[0-9]", class_name):
+        class_name = "_%s" % class_name
+
+    return class_name
+
+
+def benchpark_module_to_python_module(mod_name):
+    """Given a Ramble module name, returns the name by which it can be
+    imported in Python.
+    """
+    if re.match(r"[0-9]", mod_name):
+        mod_name = "num" + mod_name
+
+    return mod_name.replace("-", "_")
+
+
+def possible_benchpark_module_names(python_mod_name):
+    """Given a Python module name, return a list of all possible ramble module
+    names that could correspond to it."""
+    mod_name = re.sub(r"^num(\d)", r"\1", python_mod_name)
+
+    parts = re.split(r"(_)", mod_name)
+    options = [["_", "-"]] * mod_name.count("_")
+
+    results = []
+    for subs in itertools.product(*options):
+        s = list(parts)
+        s[1::2] = subs
+        results.append("".join(s))
+
+    return results
+
+
+def simplify_name(name):
+    """Simplify package name to only lowercase, digits, and dashes.
+
+    Simplifies a name which may include uppercase letters, periods,
+    underscores, and pluses. In general, we want our package names to
+    only contain lowercase letters, digits, and dashes.
+
+    Args:
+        name (str): The original name of the package
+
+    Returns:
+        str: The new name of the package
+    """
+    # Convert CamelCase to Dashed-Names
+    # e.g. ImageMagick -> Image-Magick
+    # e.g. SuiteSparse -> Suite-Sparse
+    # name = re.sub('([a-z])([A-Z])', r'\1-\2', name)
+
+    # Rename Intel downloads
+    # e.g. l_daal, l_ipp, l_mkl -> daal, ipp, mkl
+    if name.startswith("l_"):
+        name = name[2:]
+
+    # Convert UPPERCASE to lowercase
+    # e.g. SAMRAI -> samrai
+    name = name.lower()
+
+    # Replace '_' and '.' with '-'
+    # e.g. backports.ssl_match_hostname -> backports-ssl-match-hostname
+    name = name.replace("_", "-")
+    name = name.replace(".", "-")
+
+    # Replace "++" with "pp" and "+" with "-plus"
+    # e.g. gtk+   -> gtk-plus
+    # e.g. voro++ -> voropp
+    name = name.replace("++", "pp")
+    name = name.replace("+", "-plus")
+
+    # Simplify Lua package names
+    # We don't want "lua" to occur multiple times in the name
+    name = re.sub("^(lua)([^-])", r"\1-\2", name)
+
+    # Simplify Bio++ package names
+    name = re.sub("^(bpp)([^-])", r"\1-\2", name)
+
+    return name
+
+
+def valid_module_name(mod_name):
+    """Return whether mod_name is valid for use in Ramble."""
+    return bool(re.match(_valid_module_re, mod_name))
+
+
+def valid_fully_qualified_module_name(mod_name):
+    """Return whether mod_name is a valid namespaced module name."""
+    return bool(re.match(_valid_fully_qualified_module_re, mod_name))
+
+
+def validate_module_name(mod_name):
+    """Raise an exception if mod_name is not valid."""
+    if not valid_module_name(mod_name):
+        raise InvalidModuleNameError(mod_name)
+
+
+def validate_fully_qualified_module_name(mod_name):
+    """Raise an exception if mod_name is not a valid namespaced module name."""
+    if not valid_fully_qualified_module_name(mod_name):
+        raise InvalidFullyQualifiedModuleNameError(mod_name)
+
+
+class InvalidModuleNameError(benchpark.error.BenchparkError):
+    """Raised when we encounter a bad module name."""
+
+    def __init__(self, name):
+        super(InvalidModuleNameError, self).__init__("Invalid module name: " + name)
+        self.name = name
+
+
+class InvalidFullyQualifiedModuleNameError(benchpark.error.BenchparkError):
+    """Raised when we encounter a bad full package name."""
+
+    def __init__(self, name):
+        super(InvalidFullyQualifiedModuleNameError, self).__init__(
+            "Invalid fully qualified package name: " + name
+        )
+        self.name = name
+
+
+class NamespaceTrie(object):
+
+    class Element(object):
+
+        def __init__(self, value):
+            self.value = value
+
+    def __init__(self, separator="."):
+        self._subspaces = {}
+        self._value = None
+        self._sep = separator
+
+    def __setitem__(self, namespace, value):
+        first, sep, rest = namespace.partition(self._sep)
+
+        if not first:
+            self._value = NamespaceTrie.Element(value)
+            return
+
+        if first not in self._subspaces:
+            self._subspaces[first] = NamespaceTrie()
+
+        self._subspaces[first][rest] = value
+
+    def _get_helper(self, namespace, full_name):
+        first, sep, rest = namespace.partition(self._sep)
+        if not first:
+            if not self._value:
+                raise KeyError("Can't find namespace '%s' in trie" % full_name)
+            return self._value.value
+        elif first not in self._subspaces:
+            raise KeyError("Can't find namespace '%s' in trie" % full_name)
+        else:
+            return self._subspaces[first]._get_helper(rest, full_name)
+
+    def __getitem__(self, namespace):
+        return self._get_helper(namespace, namespace)
+
+    def is_prefix(self, namespace):
+        """True if the namespace has a value, or if it's the prefix of one that
+        does."""
+        first, sep, rest = namespace.partition(self._sep)
+        if not first:
+            return True
+        elif first not in self._subspaces:
+            return False
+        else:
+            return self._subspaces[first].is_prefix(rest)
+
+    def is_leaf(self, namespace):
+        """True if this namespace has no children in the trie."""
+        first, sep, rest = namespace.partition(self._sep)
+        if not first:
+            return bool(self._subspaces)
+        elif first not in self._subspaces:
+            return False
+        else:
+            return self._subspaces[first].is_leaf(rest)
+
+    def has_value(self, namespace):
+        """True if there is a value set for the given namespace."""
+        first, sep, rest = namespace.partition(self._sep)
+        if not first:
+            return self._value is not None
+        elif first not in self._subspaces:
+            return False
+        else:
+            return self._subspaces[first].has_value(rest)
+
+    def __contains__(self, namespace):
+        """Returns whether a value has been set for the namespace."""
+        return self.has_value(namespace)
+
+    def _str_helper(self, stream, level=0):
+        indent = level * "    "
+        for name in sorted(self._subspaces):
+            stream.write(indent + name + "\n")
+            if self._value:
+                stream.write(indent + "  " + repr(self._value.value))
+            stream.write(self._subspaces[name]._str_helper(stream, level + 1))
+
+    def __str__(self):
+        stream = io.StringIO()
+        self._str_helper(stream)
+        return stream.getvalue()

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -1,0 +1,1013 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import abc
+import collections
+import os
+import sys
+import traceback
+import types
+import functools
+import contextlib
+import re
+import importlib
+import importlib.machinery
+import importlib.util
+import inspect
+import stat
+import shutil
+import errno
+import benchpark.naming as nm
+
+try:
+    from collections.abc import Mapping  # novm
+except ImportError:
+    from collections import Mapping
+
+
+from enum import Enum
+
+import llnl.util.lang
+import benchpark.experiment_spec
+
+global_namespace = "benchpark"
+
+#: Guaranteed unused default value for some functions.
+NOT_PROVIDED = object()
+
+
+####
+# Implement type specific functionality between here, and
+#     END TYPE SPECIFIC FUNCTIONALITY
+####
+ObjectTypes = Enum("ObjectTypes", ["experiments"])
+
+OBJECT_NAMES = [obj.name for obj in ObjectTypes]
+
+default_type = ObjectTypes.experiments
+
+type_definitions = {
+    ObjectTypes.experiments: {
+        "file_name": "experiment.py",
+        "dir_name": "experiments",
+        "abbrev": "expr",
+        "config_section": "repos",
+        "accepted_configs": ["repo.yaml"],
+        "singular": "experiment",
+    },
+}
+
+
+# Experiments
+def _exprs(repo_dirs=None):
+    """Get the singleton RepoPath instance for Ramble.
+
+    Create a RepoPath, add it to sys.meta_path, and return it.
+
+    TODO: consider not making this a singleton.
+    """
+    repo_dirs = repo_dirs
+    if not repo_dirs:
+        raise NoRepoConfiguredError("Benchpark configuration contains no experiment repositories.")
+
+    path = RepoPath(*repo_dirs, object_type=ObjectTypes.experiments)
+    sys.meta_path.append(path)
+    return path
+
+
+paths = {
+    ObjectTypes.experiments: llnl.util.lang.Singleton(_exprs),
+}
+
+#####################################
+#     END TYPE SPECIFIC FUNCTIONALITY
+#####################################
+
+
+def all_object_names(object_type=default_type):
+    """Convenience wrapper around ``ramble.repository.all_object_names()``."""  # noqa: E501
+    return paths[object_type].all_object_names()
+
+
+def get(spec, object_type=default_type):
+    """Convenience wrapper around ``ramble.repository.get()``."""
+    return paths[object_type].get(spec)
+
+
+def set_path(repo, object_type=default_type):
+    """Set the path singleton to a specific value.
+
+    Overwrite ``path`` and register it as an importer in
+    ``sys.meta_path`` if it is a ``Repo`` or ``RepoPath``.
+    """
+    global paths
+    paths[object_type] = repo
+
+    # make the new repo_path an importer if needed
+    append = isinstance(repo, (Repo, RepoPath))
+    if append:
+        sys.meta_path.append(repo)
+    return append
+
+
+@contextlib.contextmanager
+def additional_repository(repository, object_type=default_type):
+    """Adds temporarily a repository to the default one.
+
+    Args:
+        repository: repository to be added
+    """
+    paths[object_type].put_first(repository)
+    yield
+    paths[object_type].remove(repository)
+
+
+@contextlib.contextmanager
+def use_repositories(*paths_and_repos, object_type=default_type):
+    """Use the repositories passed as arguments within the context manager.
+
+    Args:
+        *paths_and_repos: paths to the repositories to be used, or
+            already constructed Repo objects
+
+    Returns:
+        Corresponding RepoPath object
+    """
+    global paths
+
+    # Construct a temporary RepoPath object from
+    temporary_repositories = RepoPath(*paths_and_repos, object_type=object_type)
+
+    # Swap the current repository out
+    saved = paths[object_type]
+    remove_from_meta = set_path(temporary_repositories, object_type=object_type)
+
+    yield temporary_repositories
+
+    # Restore _path and sys.meta_path
+    if remove_from_meta:
+        sys.meta_path.remove(temporary_repositories)
+    paths[object_type] = saved
+
+
+def autospec(function):
+    """Decorator that automatically converts the first argument of a
+    function to a Spec.
+    """
+
+    @functools.wraps(function)
+    def converter(self, spec_like, *args, **kwargs):
+        if not isinstance(spec_like, benchpark.experiment_spec.Spec):
+            spec_like = benchpark.experiment_spec.Spec(spec_like)
+        return function(self, spec_like, *args, **kwargs)
+
+    return converter
+
+
+class ObjectNamespace(types.ModuleType):
+    """Allow lazy loading of modules."""
+
+    def __init__(self, namespace):
+        super(ObjectNamespace, self).__init__(namespace)
+        self.__file__ = "(benchpark namespace)"
+        self.__path__ = []
+        self.__name__ = namespace
+        self.__experiment__ = namespace
+        self.__modules = {}
+
+    def __getattr__(self, name):
+        """Getattr lazily loads modules if they're not already loaded."""
+        submodule = self.__experiment__ + "." + name
+        setattr(self, name, __import__(submodule))
+        return getattr(self, name)
+
+
+class RepoPath(object):
+    """A RepoPath is a list of repos that function as one.
+
+    It functions exactly like a Repo, but it operates on the combined
+    results of the Repos in its list instead of on a single object
+    repository.
+
+    Args:
+        repos (list): list Repo objects or paths to put in this RepoPath
+    """
+
+    def __init__(self, *repos, object_type=default_type):
+        self.repos = []
+        self.by_namespace = nm.NamespaceTrie()
+        self.object_abbrev = type_definitions[object_type]["abbrev"]
+
+        self.base_namespace = f"{global_namespace}.{self.object_abbrev}"
+
+        self._all_object_names = None
+
+        # Add each repo to this path.
+        for repo in repos:
+            try:
+                if isinstance(repo, str):
+                    repo = Repo(repo, object_type=object_type)
+                self.put_last(repo)
+            except RepoError as e:
+                logger.warn(
+                    "Failed to initialize repository: '%s'." % repo,
+                    e.message,
+                    "To remove the bad repository, run this command:",
+                    "    ramble repo rm %s" % repo,
+                )
+
+    def put_first(self, repo):
+        """Add repo first in the search path."""
+        if isinstance(repo, RepoPath):
+            for r in reversed(repo.repos):
+                self.put_first(r)
+            return
+
+        self.repos.insert(0, repo)
+        self.by_namespace[repo.full_namespace] = repo
+
+    def put_last(self, repo):
+        """Add repo last in the search path."""
+        if isinstance(repo, RepoPath):
+            for r in repo.repos:
+                self.put_last(r)
+            return
+
+        self.repos.append(repo)
+
+        # don't mask any higher-precedence repos with same namespace
+        if repo.full_namespace not in self.by_namespace:
+            self.by_namespace[repo.full_namespace] = repo
+
+    def remove(self, repo):
+        """Remove a repo from the search path."""
+        if repo in self.repos:
+            self.repos.remove(repo)
+
+    def get_full_namespace(self, namespace):
+        """Returns the full namespace of a repository, given its relative one."""
+        return f"{self.base_namespace}.{namespace}"
+
+    def get_repo(self, namespace, default=NOT_PROVIDED):
+        """Get a repository by namespace.
+
+        Arguments:
+
+            namespace:
+
+                Look up this namespace in the RepoPath, and return it if found.
+
+        Optional Arguments:
+
+            default:
+
+                If default is provided, return it when the namespace
+                isn't found.  If not, raise an UnknownNamespaceError.
+        """
+        full_namespace = self.get_full_namespace(namespace)
+        if full_namespace not in self.by_namespace:
+            if default == NOT_PROVIDED:
+                raise UnknownNamespaceError(namespace)
+            return default
+        return self.by_namespace[full_namespace]
+
+    def first_repo(self):
+        """Get the first repo in precedence order."""
+        return self.repos[0] if self.repos else None
+
+    def all_object_names(self):
+        """Return all unique object names in all repositories."""
+        if self._all_object_names is None:
+            all_objs = set()
+            for repo in self.repos:
+                for name in repo.all_object_names():
+                    all_objs.add(name)
+            self._all_object_names = sorted(all_objs, key=lambda n: n.lower())
+        return self._all_object_names
+
+    def objects_with_tags(self, *tags):
+        r = set()
+        for repo in self.repos:
+            r |= set(repo.objects_with_tags(*tags))
+        return sorted(r)
+
+    def all_objects(self):
+        for name in self.all_object_names():
+            yield self.get(name)
+
+    def all_object_classes(self):
+        for name in self.all_object_names():
+            yield self.get_obj_class(name)
+
+    def find_module(self, fullname, path=None):
+        """Implements precedence for overlaid namespaces.
+
+        Loop checks each namespace in self.repos for objects, and
+        also handles loading empty containing namespaces.
+
+        """
+        # namespaces are added to repo, and object modules are leaves.
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        # If it's a module in some repo, or if it is the repo's
+        # namespace, let the repo handle it.
+        for repo in self.repos:
+            if namespace == repo.full_namespace:
+                if repo.real_name(module_name):
+                    return repo
+            elif fullname == repo.full_namespace:
+                return repo
+
+        # No repo provides the namespace, but it is a valid prefix of
+        # something in the RepoPath.
+        if self.by_namespace.is_prefix(fullname):
+            return self
+
+        return None
+
+    def load_module(self, fullname):
+        """Handles loading container namespaces when necessary.
+
+        See ``Repo`` for how actual object modules are loaded.
+        """
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        if not self.by_namespace.is_prefix(fullname):
+            raise ImportError("No such benchpark repo: %s" % fullname)
+
+        module = ObjectNamespace(fullname)
+        module.__loader__ = self
+        sys.modules[fullname] = module
+        return module
+
+    def last_mtime(self):
+        """Time a object file in this repo was last updated."""
+        return max(repo.last_mtime() for repo in self.repos)
+
+    def repo_for_obj(self, spec):
+        """Given a spec, get the repository for its object."""
+        # We don't @_autospec this function b/c it's called very frequently
+        # and we want to avoid parsing str's into Specs unnecessarily.
+        logger.debug(f"Getting repo for obj {spec}")
+        namespace = None
+        if isinstance(spec, benchpark.experiment_spec.Spec):
+            namespace = spec.namespace
+            name = spec.name
+        else:
+            # handle strings directly for speed instead of @_autospec'ing
+            namespace, _, name = spec.rpartition(".")
+
+        logger.debug(f" Name and namespace = {namespace} - {name}")
+        # If the spec already has a namespace, then return the
+        # corresponding repo if we know about it.
+        if namespace:
+            fullspace = self.get_full_namespace(namespace)
+            if fullspace not in self.by_namespace:
+                raise UnknownNamespaceError(spec.namespace)
+            return self.by_namespace[fullspace]
+
+        # If there's no namespace, search in the RepoPath.
+        for repo in self.repos:
+            if name in repo:
+                logger.debug("Found repo...")
+                return repo
+
+        # If the object isn't in any repo, return the one with
+        # highest precedence.  This is for commands like `ramble edit`
+        # that can operate on objects that don't exist yet.
+        return self.first_repo()
+
+    @autospec
+    def get(self, spec):
+        """Returns the object associated with the supplied spec."""
+        return self.repo_for_obj(spec).get(spec)
+
+    def get_obj_class(self, obj_name):
+        """Find a class for the spec's object and return the class object."""  # noqa: E501
+        return self.repo_for_obj(obj_name).get_obj_class(obj_name)
+
+    @autospec
+    def dump_provenance(self, spec, path):
+        """Dump provenance information for a spec to a particular path.
+
+        This dumps the object file and any associated patch files.
+        Raises UnknownObjectError if not found.
+        """
+        return self.repo_for_obj(spec).dump_provenance(spec, path)
+
+    def dirname_for_object_name(self, obj_name):
+        return self.repo_for_obj(obj_name).dirname_for_object_name(obj_name)
+
+    def filename_for_object_name(self, obj_name):
+        return self.repo_for_obj(obj_name).filename_for_object_name(obj_name)
+
+    def exists(self, obj_name):
+        """Whether object with the give name exists in the path's repos.
+
+        Note that virtual objects do not "exist".
+        """
+        return any(repo.exists(obj_name) for repo in self.repos)
+
+    # TODO: DWJ - Maybe we don't need this? Are we going to have virtual
+    #             objects
+    # def is_virtual(self, obj_name, use_index=True):
+    #     """True if the object with this name is virtual,
+    #        False otherwise.
+    #
+    #     Set `use_index` False when calling from a code block that could
+    #     be run during the computation of the provider index."""
+    #     have_name = obj_name is not None
+    #     if have_name and not isinstance(obj_name, str):
+    #         raise ValueError(
+    #             "is_virtual(): expected object name, got %s" %
+    #             type(obj_name))
+    #     if use_index:
+    #         return have_name and app_name in self.provider_index
+    #     else:
+    #         return have_name and (not self.exists(app_name) or
+    #                               self.get_app_class(app_name).virtual)
+
+    def __contains__(self, obj_name):
+        return self.exists(obj_name)
+
+
+class Repo(object):
+    """Class representing a object repository in the filesystem.
+
+    Each object repository must have a top-level configuration file
+    called `repo.yaml`.
+
+    Currently, `repo.yaml` this must define:
+
+    `namespace`:
+        A Python namespace where the repository's objects should live.
+
+    """
+
+    def __init__(self, root, object_type=default_type):
+        """Instantiate an object repository from a filesystem path.
+
+        Args:
+            root: the root directory of the repository
+        """
+        # Root directory, containing _repo.yaml and object dirs
+        # Allow roots to be ramble-relative by starting with '$ramble'
+        self.root = ramble.util.path.canonicalize_path(root)
+        self.object_file_name = type_definitions[object_type]["file_name"]
+        self.object_type = object_type
+        self.object_abbrev = type_definitions[object_type]["abbrev"]
+        self.base_namespace = f"{global_namespace}.{self.object_abbrev}"
+
+        # check and raise BadRepoError on fail.
+        def check(condition, msg):
+            if not condition:
+                raise BadRepoError(msg)
+
+        # Validate repository layout.
+        self.config_name = None
+        self.config_file = None
+        for config in type_definitions[object_type]["accepted_configs"]:
+            config_file = os.path.join(self.root, config)
+            if os.path.exists(config_file):
+                self.config_name = config
+                self.config_file = config_file
+        check(os.path.isfile(self.config_file), "No %s found in '%s'" % (self.config_name, root))
+
+        # Read configuration and validate namespace
+        config = self._read_config()
+        check(
+            "namespace" in config,
+            "%s must define a namespace." % os.path.join(root, self.config_name),
+        )
+
+        self.namespace = config["namespace"]
+        check(
+            re.match(r"[a-zA-Z][a-zA-Z0-9_.]+", self.namespace),
+            ("Invalid namespace '%s' in repo '%s'. " % (self.namespace, self.root))
+            + "Namespaces must be valid python identifiers separated by '.'",
+        )
+
+        objects_dir = (
+            config["subdirectory"]
+            if "subdirectory" in config
+            else type_definitions[object_type]["dir_name"]
+        )
+
+        self.objects_path = os.path.join(self.root, objects_dir)
+        check(
+            os.path.isdir(self.objects_path),
+            "No directory '%s' found in '%s'" % (objects_dir, root),
+        )
+
+        # Set up 'full_namespace' to include the super-namespace
+        self.full_namespace = f"{self.base_namespace}.{self.namespace}"
+
+        # Keep name components around for checking prefixes.
+        self._names = self.full_namespace.split(".")
+
+        # These are internal cache variables.
+        self._modules = {}
+        self._classes = {}
+        self._instances = {}
+
+        # Maps that goes from object name to corresponding file stat
+        self._fast_object_checker = None
+
+        # Indexes for this repository, computed lazily
+        self._repo_index = None
+
+        # make sure the namespace for objects in this repo exists.
+        self._create_namespace()
+
+    def _create_namespace(self):
+        """Create this repo's namespace module and insert it into sys.modules.
+
+        Ensures that modules loaded via the repo have a home, and that
+        we don't get runtime warnings from Python's module system.
+
+        """
+        parent = None
+        for i in range(1, len(self._names) + 1):
+            ns = ".".join(self._names[:i])
+
+            if ns not in sys.modules:
+                module = ObjectNamespace(ns)
+                module.__loader__ = self
+                sys.modules[ns] = module
+
+                # TODO: DWJ - Do we need this?
+                # Ensure the namespace is an attribute of its parent,
+                # if it has not been set by something else already.
+                #
+                # This ensures that we can do things like:
+                #    import ramble.app.builtin.mpich as mpich
+                if parent:
+                    modname = self._names[i - 1]
+                    setattr(parent, modname, module)
+            else:
+                # no need to set up a module
+                module = sys.modules[ns]
+
+            # but keep track of the parent in this loop
+            parent = module
+
+    def real_name(self, import_name):
+        """Allow users to import Ramble objects using Python identifiers.
+
+        A python identifier might map to many different Ramble object
+        names due to hyphen/underscore ambiguity.
+
+        Easy example:
+            num3proxy   -> 3proxy
+
+        Ambiguous:
+            foo_bar -> foo_bar, foo-bar
+
+        More ambiguous:
+            foo_bar_baz -> foo_bar_baz, foo-bar-baz, foo_bar-baz, foo-bar_baz
+        """
+        if import_name in self:
+            return import_name
+
+        options = nm.possible_ramble_module_names(import_name)
+        options.remove(import_name)
+        for name in options:
+            if name in self:
+                return name
+        return None
+
+    def is_prefix(self, fullname):
+        """True if fullname is a prefix of this Repo's namespace."""
+        parts = fullname.split(".")
+        return self._names[: len(parts)] == parts
+
+    def find_module(self, fullname, path=None):
+        """Python find_module import hook.
+
+        Returns this Repo if it can load the module; None if not.
+        """
+        if self.is_prefix(fullname):
+            return self
+
+        namespace, dot, module_name = fullname.rpartition(".")
+        if namespace == self.full_namespace:
+            if self.real_name(module_name):
+                return self
+
+        return None
+
+    def load_module(self, fullname):
+        """Python importer load hook.
+
+        Tries to load the module; raises an ImportError if it can't.
+        """
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        if self.is_prefix(fullname):
+            module = ObjectNamespace(fullname)
+
+        elif namespace == self.full_namespace:
+            real_name = self.real_name(module_name)
+            if not real_name:
+                raise ImportError("No module %s in %s" % (module_name, self))
+            module = self._get_obj_module(real_name)
+
+        else:
+            raise ImportError("No module %s in %s" % (fullname, self))
+
+        module.__loader__ = self
+        sys.modules[fullname] = module
+        if namespace != fullname:
+            parent = sys.modules[namespace]
+            if not hasattr(parent, module_name):
+                setattr(parent, module_name, module)
+
+        return module
+
+
+
+    @autospec
+    def get(self, spec):
+        """Returns the object associated with the supplied spec."""
+        # NOTE: we only check whether the object is None here, not whether
+        # it actually exists, because we have to load it anyway, and that ends
+        # up checking for existence. We avoid constructing
+        # FastObjectChecker, which will stat all objects.
+        logger.debug(f"Getting obj {spec} from repo")
+        if spec.name is None:
+            raise UnknownObjectError(None, self)
+
+        if spec.namespace and spec.namespace != self.namespace:
+            raise UnknownObjectError(spec.name, self.namespace)
+
+        object_class = self.get_obj_class(spec.name)
+        try:
+            return object_class(self.object_path(spec))
+        except ramble.error.RambleError:
+            # pass these through as their error messages will be fine.
+            raise
+        except Exception as e:
+            logger.debug(e)
+
+            # Make sure other errors in constructors hit the error
+            # handler by wrapping them
+            if ramble.config.get("config:debug"):
+                sys.excepthook(*sys.exc_info())
+            raise FailedConstructorError(spec.fullname, *sys.exc_info())
+
+    @autospec
+    def dump_provenance(self, spec, path):
+        """Dump provenance information for a spec to a particular path.
+
+        This dumps the object file.
+        Raises UnknownObjectError if not found.
+        """
+        if spec.namespace and spec.namespace != self.namespace:
+            raise UnknownObjectError(
+                f"Repository {self.namespace} does not "
+                f"contain {self.object_type.name} {spec.fullname}."
+            )
+
+        # Install the object's .py file itself.
+        fs.install(self.filename_for_object_name(spec.name), path)
+
+    def purge(self):
+        """Clear entire object instance cache."""
+        self._instances.clear()
+
+    @property
+    def index(self):
+        """Construct the index for this repo lazily."""
+        if self._repo_index is None:
+            self._repo_index = RepoIndex(self._obj_checker, self.namespace, self.object_type)
+            self._repo_index.add_indexer("tags", TagIndexer(self.object_type))
+        return self._repo_index
+
+    @property
+    def tag_index(self):
+        """Index of tags and which objects they're defined on."""
+        return self.index["tags"]
+
+    def dirname_for_object_name(self, obj_name):
+        """Get the directory name for a particular object.  This is the
+        directory that contains its object.py file."""
+        return os.path.join(self.objects_path, obj_name)
+
+    def filename_for_object_name(self, obj_name):
+        """Get the filename for the module we should load for a particular
+        object.  objects for a Repo live in
+        ``$root/<object_name>/<object_type>.py``
+
+        This will return a proper <object_type>.py path even if the
+        object doesn't exist yet, so callers will need to ensure
+        the object exists before importing.
+        """
+        obj_dir = self.dirname_for_object_name(obj_name)
+        return os.path.join(obj_dir, self.object_file_name)
+
+    @autospec
+    def object_path(self, spec):
+        return os.path.join(
+            self.objects_path,
+            self.dirname_for_object_name(spec.name),
+            self.filename_for_object_name(spec.name),
+        )
+
+    def all_object_names(self):
+        """Returns a sorted list of all object names in the Repo."""
+        names = sorted(self._obj_checker.keys())
+        return names
+
+    def objects_with_tags(self, *tags):
+        v = set(self.all_object_names())
+        index = self.tag_index
+
+        for t in tags:
+            t = t.lower()
+            v &= set(index[t])
+
+        return sorted(v)
+
+    def all_objects(self):
+        """Iterator over all objects in the repository.
+
+        Use this with care, because loading objects is slow.
+
+        """
+        for name in self.all_object_names():
+            yield self.get(name)
+
+    def all_object_classes(self):
+        """Iterator over all object *classes* in the repository.
+
+        Use this with care, because loading objects is slow.
+        """
+        for name in self.all_object_names():
+            yield self.get_obj_class(name)
+
+    def exists(self, obj_name):
+        """Whether a object with the supplied name exists."""
+        if obj_name is None:
+            return False
+
+        # if the FastObjectChecker is already constructed, use it
+        if self._fast_object_checker:
+            return obj_name in self._obj_checker
+
+        # if not, check for the object.py file
+        path = self.filename_for_object_name(obj_name)
+        return os.path.exists(path)
+
+    def last_mtime(self):
+        """Time a object file in this repo was last updated."""
+        return self._obj_checker.last_mtime()
+
+    def _get_obj_module(self, obj_name):
+        """Create a module for a particular object.
+
+        This caches the module within this Repo *instance*.  It does
+        *not* add it to ``sys.modules``.  So, you can construct
+        multiple Repos for testing and ensure that the module will be
+        loaded once per repo.
+
+        """
+        if obj_name not in self._modules:
+            file_path = self.filename_for_object_name(obj_name)
+
+            if not os.path.exists(file_path):
+                raise UnknownObjectError(obj_name, self)
+
+            if not os.path.isfile(file_path):
+                logger.die(f"Something's wrong. '{file_path}' is not a file!")
+
+            if not os.access(file_path, os.R_OK):
+                logger.die(f"Cannot read '{file_path}'!")
+
+            # e.g., ramble.app.builtin.mpich
+            fullname = "%s.%s" % (self.full_namespace, obj_name)
+
+            try:
+                module = ramble.util.imp.load_source(fullname, file_path)
+            except SyntaxError as e:
+                # SyntaxError strips the path from the filename so we need to
+                # manually construct the error message in order to give the
+                # user the correct .py where the syntax error is
+                # located
+                raise SyntaxError("invalid syntax in {0:}, line {1:}".format(file_path, e.lineno))
+
+            module.__object__ = self.full_namespace
+            module.__loader__ = self
+            self._modules[obj_name] = module
+
+        return self._modules[obj_name]
+
+    def get_obj_class(self, obj_name):
+        """Get the class for the object out of its module.
+
+        First loads (or fetches from cache) a module for the
+        object. Then extracts the object class from the module
+        according to Ramble's naming convention.
+        """
+        namespace, _, obj_name = obj_name.rpartition(".")
+        if namespace and (namespace != self.namespace):
+            raise InvalidNamespaceError(
+                "Invalid namespace for %s repo: %s" % (self.namespace, namespace)
+            )
+
+        class_name = nm.mod_to_class(obj_name)
+        logger.debug(f" Class name = {class_name}")
+        module = self._get_obj_module(obj_name)
+
+        cls = getattr(module, class_name)
+        if not inspect.isclass(cls):
+            logger.die(f"{obj_name}.{class_name} is not a class")
+
+        return cls
+
+    def __str__(self):
+        return "[Repo '%s' at '%s']" % (self.namespace, self.root)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __contains__(self, obj_name):
+        return self.exists(obj_name)
+
+
+class RepositoryNamespace(types.ModuleType):
+    """Allow lazy loading of modules."""
+
+    def __init__(self, namespace):
+        super(RepositoryNamespace, self).__init__(namespace)
+        self.__file__ = "(repository namespace)"
+        self.__path__ = []
+        self.__name__ = namespace
+        self.__package__ = namespace
+        self.__modules = {}
+
+    def __getattr__(self, name):
+        """Getattr lazily loads modules if they're not already loaded."""
+        submodule = self.__package__ + "." + name
+        try:
+            setattr(self, name, __import__(submodule))
+        except ImportError:
+            msg = "'{0}' object has no attribute {1}"
+            raise AttributeError(msg.format(type(self), name))
+        return getattr(self, name)
+
+
+class RepoLoader(importlib.machinery.SourceFileLoader):
+    """Loads a Python module associated with a object in specific repository"""
+
+    #: Code in ``_object_prepend`` is prepended to imported objects.
+    _object_prepend = "from __future__ import absolute_import;"
+
+    def __init__(self, fullname, repo, object_name):
+        self.repo = repo
+        self.object_name = object_name
+        self.object_py = repo.filename_for_object_name(object_name)
+        self.fullname = fullname
+        super(RepoLoader, self).__init__(
+            self.fullname, self.object_py, prepend=self._object_prepend
+        )
+
+
+class RepositoryNamespaceLoader(object):
+    def create_module(self, spec):
+        return RepositoryNamespace(spec.name)
+
+    def exec_module(self, module):
+        module.__loader__ = self
+
+
+class ReposFinder(object):
+    """MetaPathFinder class that loads a Python module corresponding to an object
+
+    Return a loader based on the inspection of the current global repository list.
+    """
+
+    def __init__(self, object_type=default_type):
+        self.object_type = object_type
+
+    def find_spec(self, fullname, python_path, target=None):
+        # "target" is not None only when calling importlib.reload()
+        if target is not None:
+            raise RuntimeError('cannot reload module "{0}"'.format(fullname))
+
+        # Preferred API from https://peps.python.org/pep-0451/
+        if not fullname.startswith("ramble."):
+            return None
+
+        loader = self.compute_loader(fullname)
+        if loader is None:
+            return None
+        return importlib.util.spec_from_loader(fullname, loader)
+
+    def compute_loader(self, fullname):
+        # namespaces are added to repo, and object modules are leaves.
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        # If it's a module in some repo, or if it is the repo's
+        # namespace, let the repo handle it.
+        for repo in paths[self.object_type].repos:
+            # We are using the namespace of the repo and the repo contains the object
+            if namespace == repo.full_namespace:
+                # With 2 nested conditionals we can call "repo.real_name" only once
+                object_name = repo.real_name(module_name)
+                if object_name:
+                    return RepoLoader(fullname, repo, object_name)
+
+            # We are importing a full namespace like 'spack.pkg.builtin'
+            if fullname == repo.full_namespace:
+                return RepositoryNamespaceLoader()
+
+        # No repo provides the namespace, but it is a valid prefix of
+        # something in the RepoPath.
+        if paths[self.object_type].by_namespace.is_prefix(fullname):
+            return RepositoryNamespaceLoader()
+
+        return None
+
+
+# Add the finder to sys.meta_path
+REPOS_FINDER = ReposFinder()
+sys.meta_path.append(REPOS_FINDER)
+
+
+class RepoError(benchpark.error.BenchparkError):
+    """Superclass for repository-related errors."""
+
+
+class NoRepoConfiguredError(RepoError):
+    """Raised when there are no repositories configured."""
+
+
+class InvalidNamespaceError(RepoError):
+    """Raised when an invalid namespace is encountered."""
+
+
+class BadRepoError(RepoError):
+    """Raised when repo layout is invalid."""
+
+
+class UnknownEntityError(RepoError):
+    """Raised when we encounter a object ramble doesn't have."""
+
+
+class IndexError(RepoError):
+    """Raised when there's an error with an index."""
+
+
+class UnknownObjectError(UnknownEntityError):
+    """Raised when we encounter an object ramble doesn't have."""
+
+    def __init__(self, name, repo=None, object_type="Object"):
+        msg = None
+        long_msg = None
+
+        if name:
+            if repo:
+                msg = f"{object_type} '{name}' not found in repository '{repo.root}'"
+            else:
+                msg = f"{object_type} '{name}' not found."
+
+            # Special handling for specs that may have been intended as
+            # filenames: prompt the user to ask whether they intended to write
+            # './<name>'.
+            if name.endswith(".yaml"):
+                long_msg = "Did you mean to specify a filename with './{0}'?"
+                long_msg = long_msg.format(name)
+        else:
+            msg = f"Attempting to retrieve anonymous {object_type}."
+
+        super(UnknownObjectError, self).__init__(msg, long_msg)
+        self.name = name
+
+
+class UnknownNamespaceError(UnknownEntityError):
+    """Raised when we encounter an unknown namespace"""
+
+    def __init__(self, namespace):
+        super(UnknownNamespaceError, self).__init__("Unknown namespace: %s" % namespace)
+
+
+class FailedConstructorError(RepoError):
+    """Raised when an object's class constructor fails."""
+
+    def __init__(self, name, exc_type, exc_obj, exc_tb, object_type=None):
+        super(FailedConstructorError, self).__init__(
+            f"Class constructor failed for {object_type} '%s'." % name,
+            "\nCaused by:\n"
+            + ("%s: %s\n" % (exc_type.__name__, exc_obj))
+            + "".join(traceback.format_tb(exc_tb)),
+        )
+        self.name = name

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -815,7 +815,9 @@ class Repo(object):
             fullname = "%s.%s" % (self.full_namespace, obj_name)
 
             try:
-                module = ramble.util.imp.load_source(fullname, file_path)
+                loader = importlib.machinery.SourceFileLoader(fullname, file_path)
+                module = types.ModuleType(loader.name)
+                loader.exec_module(module)
             except SyntaxError as e:
                 # SyntaxError strips the path from the filename so we need to
                 # manually construct the error message in order to give the

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -73,20 +73,13 @@ def _exprs():
     """
     filename = os.getcwd()  # gross way to work around file for interactive testing
     repo_dirs = [os.path.join(filename, "test_repo")]
-    print(repo_dirs)
     if not repo_dirs:
         raise NoRepoConfiguredError(
             "Benchpark configuration contains no experiment repositories."
         )
 
-    print("BEFORE PATH")
-    try:
-        path = RepoPath(*repo_dirs, object_type=ObjectTypes.experiments)
-    except BaseException as e:
-        print("EXCEPTION", e)
-    print("AFTER PATH")
+    path = RepoPath(*repo_dirs, object_type=ObjectTypes.experiments)
     sys.meta_path.append(path)
-    print("RETURNING", path)
     return path
 
 

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -33,7 +33,7 @@ except ImportError:
 from enum import Enum
 
 import llnl.util.lang
-import benchpark.experiment_spec
+import benchpark.spec
 
 global_namespace = "benchpark"
 
@@ -165,8 +165,8 @@ def autospec(function):
 
     @functools.wraps(function)
     def converter(self, spec_like, *args, **kwargs):
-        if not isinstance(spec_like, benchpark.experiment_spec.ExperimentSpec):
-            spec_like = benchpark.experiment_spec.ExperimentSpec(spec_like)
+        if not isinstance(spec_like, benchpark.spec.ExperimentSpec):
+            spec_like = benchpark.spec.ExperimentSpec(spec_like)
         return function(self, spec_like, *args, **kwargs)
 
     return converter
@@ -360,7 +360,7 @@ class RepoPath(object):
         # and we want to avoid parsing str's into Specs unnecessarily.
         # logger.debug(f"Getting repo for obj {spec}")
         namespace = None
-        if isinstance(spec, benchpark.experiment_spec.ExperimentSpec):
+        if isinstance(spec, benchpark.spec.ExperimentSpec):
             namespace = spec.namespace
             name = spec.name
         else:

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -73,7 +73,9 @@ def _exprs(repo_dirs=None):
     """
     repo_dirs = repo_dirs
     if not repo_dirs:
-        raise NoRepoConfiguredError("Benchpark configuration contains no experiment repositories.")
+        raise NoRepoConfiguredError(
+            "Benchpark configuration contains no experiment repositories."
+        )
 
     path = RepoPath(*repo_dirs, object_type=ObjectTypes.experiments)
     sys.meta_path.append(path)
@@ -162,8 +164,8 @@ def autospec(function):
 
     @functools.wraps(function)
     def converter(self, spec_like, *args, **kwargs):
-        if not isinstance(spec_like, benchpark.experiment_spec.Spec):
-            spec_like = benchpark.experiment_spec.Spec(spec_like)
+        if not isinstance(spec_like, benchpark.experiment_spec.ExperimentSpec):
+            spec_like = benchpark.experiment_spec.ExperimentSpec(spec_like)
         return function(self, spec_like, *args, **kwargs)
 
     return converter
@@ -356,7 +358,7 @@ class RepoPath(object):
         # and we want to avoid parsing str's into Specs unnecessarily.
         logger.debug(f"Getting repo for obj {spec}")
         namespace = None
-        if isinstance(spec, benchpark.experiment_spec.Spec):
+        if isinstance(spec, benchpark.experiment_spec.ExperimentSpec):
             namespace = spec.namespace
             name = spec.name
         else:
@@ -477,7 +479,10 @@ class Repo(object):
             if os.path.exists(config_file):
                 self.config_name = config
                 self.config_file = config_file
-        check(os.path.isfile(self.config_file), "No %s found in '%s'" % (self.config_name, root))
+        check(
+            os.path.isfile(self.config_file),
+            "No %s found in '%s'" % (self.config_name, root),
+        )
 
         # Read configuration and validate namespace
         config = self._read_config()
@@ -633,8 +638,6 @@ class Repo(object):
 
         return module
 
-
-
     @autospec
     def get(self, spec):
         """Returns the object associated with the supplied spec."""
@@ -688,7 +691,9 @@ class Repo(object):
     def index(self):
         """Construct the index for this repo lazily."""
         if self._repo_index is None:
-            self._repo_index = RepoIndex(self._obj_checker, self.namespace, self.object_type)
+            self._repo_index = RepoIndex(
+                self._obj_checker, self.namespace, self.object_type
+            )
             self._repo_index.add_indexer("tags", TagIndexer(self.object_type))
         return self._repo_index
 
@@ -802,7 +807,9 @@ class Repo(object):
                 # manually construct the error message in order to give the
                 # user the correct .py where the syntax error is
                 # located
-                raise SyntaxError("invalid syntax in {0:}, line {1:}".format(file_path, e.lineno))
+                raise SyntaxError(
+                    "invalid syntax in {0:}, line {1:}".format(file_path, e.lineno)
+                )
 
             module.__object__ = self.full_namespace
             module.__loader__ = self
@@ -904,7 +911,7 @@ class ReposFinder(object):
             raise RuntimeError('cannot reload module "{0}"'.format(fullname))
 
         # Preferred API from https://peps.python.org/pep-0451/
-        if not fullname.startswith("ramble."):
+        if not fullname.startswith("benchpark."):
             return None
 
         loader = self.compute_loader(fullname)

--- a/lib/benchpark/repository.py
+++ b/lib/benchpark/repository.py
@@ -1,0 +1,1013 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import abc
+import collections
+import os
+import sys
+import traceback
+import types
+import functools
+import contextlib
+import re
+import importlib
+import importlib.machinery
+import importlib.util
+import inspect
+import stat
+import shutil
+import errno
+import benchpark.naming as nm
+
+try:
+    from collections.abc import Mapping  # novm
+except ImportError:
+    from collections import Mapping
+
+
+from enum import Enum
+
+import llnl.util.lang
+import benchpark.experiment_spec
+
+global_namespace = "benchpark"
+
+#: Guaranteed unused default value for some functions.
+NOT_PROVIDED = object()
+
+
+####
+# Implement type specific functionality between here, and
+#     END TYPE SPECIFIC FUNCTIONALITY
+####
+ObjectTypes = Enum("ObjectTypes", ["experiments"])
+
+OBJECT_NAMES = [obj.name for obj in ObjectTypes]
+
+default_type = ObjectTypes.experiments
+
+type_definitions = {
+    ObjectTypes.applications: {
+        "file_name": "experiment.py",
+        "dir_name": "experiments",
+        "abbrev": "expr",
+        "config_section": "repos",
+        "accepted_configs": ["repo.yaml"],
+        "singular": "experiment",
+    },
+}
+
+
+# Experiments
+def _exprs(repo_dirs=None):
+    """Get the singleton RepoPath instance for Ramble.
+
+    Create a RepoPath, add it to sys.meta_path, and return it.
+
+    TODO: consider not making this a singleton.
+    """
+    repo_dirs = repo_dirs
+    if not repo_dirs:
+        raise NoRepoConfiguredError("Benchpark configuration contains no experiment repositories.")
+
+    path = RepoPath(*repo_dirs, object_type=ObjectTypes.experiments)
+    sys.meta_path.append(path)
+    return path
+
+
+paths = {
+    ObjectTypes.applications: llnl.util.lang.Singleton(_exprs),
+}
+
+#####################################
+#     END TYPE SPECIFIC FUNCTIONALITY
+#####################################
+
+
+def all_object_names(object_type=default_type):
+    """Convenience wrapper around ``ramble.repository.all_object_names()``."""  # noqa: E501
+    return paths[object_type].all_object_names()
+
+
+def get(spec, object_type=default_type):
+    """Convenience wrapper around ``ramble.repository.get()``."""
+    return paths[object_type].get(spec)
+
+
+def set_path(repo, object_type=default_type):
+    """Set the path singleton to a specific value.
+
+    Overwrite ``path`` and register it as an importer in
+    ``sys.meta_path`` if it is a ``Repo`` or ``RepoPath``.
+    """
+    global paths
+    paths[object_type] = repo
+
+    # make the new repo_path an importer if needed
+    append = isinstance(repo, (Repo, RepoPath))
+    if append:
+        sys.meta_path.append(repo)
+    return append
+
+
+@contextlib.contextmanager
+def additional_repository(repository, object_type=default_type):
+    """Adds temporarily a repository to the default one.
+
+    Args:
+        repository: repository to be added
+    """
+    paths[object_type].put_first(repository)
+    yield
+    paths[object_type].remove(repository)
+
+
+@contextlib.contextmanager
+def use_repositories(*paths_and_repos, object_type=default_type):
+    """Use the repositories passed as arguments within the context manager.
+
+    Args:
+        *paths_and_repos: paths to the repositories to be used, or
+            already constructed Repo objects
+
+    Returns:
+        Corresponding RepoPath object
+    """
+    global paths
+
+    # Construct a temporary RepoPath object from
+    temporary_repositories = RepoPath(*paths_and_repos, object_type=object_type)
+
+    # Swap the current repository out
+    saved = paths[object_type]
+    remove_from_meta = set_path(temporary_repositories, object_type=object_type)
+
+    yield temporary_repositories
+
+    # Restore _path and sys.meta_path
+    if remove_from_meta:
+        sys.meta_path.remove(temporary_repositories)
+    paths[object_type] = saved
+
+
+def autospec(function):
+    """Decorator that automatically converts the first argument of a
+    function to a Spec.
+    """
+
+    @functools.wraps(function)
+    def converter(self, spec_like, *args, **kwargs):
+        if not isinstance(spec_like, benchpark.experiment_spec.Spec):
+            spec_like = benchpark.experiment_spec.Spec(spec_like)
+        return function(self, spec_like, *args, **kwargs)
+
+    return converter
+
+
+class ObjectNamespace(types.ModuleType):
+    """Allow lazy loading of modules."""
+
+    def __init__(self, namespace):
+        super(ObjectNamespace, self).__init__(namespace)
+        self.__file__ = "(benchpark namespace)"
+        self.__path__ = []
+        self.__name__ = namespace
+        self.__experiment__ = namespace
+        self.__modules = {}
+
+    def __getattr__(self, name):
+        """Getattr lazily loads modules if they're not already loaded."""
+        submodule = self.__application__ + "." + name
+        setattr(self, name, __import__(submodule))
+        return getattr(self, name)
+
+
+class RepoPath(object):
+    """A RepoPath is a list of repos that function as one.
+
+    It functions exactly like a Repo, but it operates on the combined
+    results of the Repos in its list instead of on a single object
+    repository.
+
+    Args:
+        repos (list): list Repo objects or paths to put in this RepoPath
+    """
+
+    def __init__(self, *repos, object_type=default_type):
+        self.repos = []
+        self.by_namespace = nm.NamespaceTrie()
+        self.object_abbrev = type_definitions[object_type]["abbrev"]
+
+        self.base_namespace = f"{global_namespace}.{self.object_abbrev}"
+
+        self._all_object_names = None
+
+        # Add each repo to this path.
+        for repo in repos:
+            try:
+                if isinstance(repo, str):
+                    repo = Repo(repo, object_type=object_type)
+                self.put_last(repo)
+            except RepoError as e:
+                logger.warn(
+                    "Failed to initialize repository: '%s'." % repo,
+                    e.message,
+                    "To remove the bad repository, run this command:",
+                    "    ramble repo rm %s" % repo,
+                )
+
+    def put_first(self, repo):
+        """Add repo first in the search path."""
+        if isinstance(repo, RepoPath):
+            for r in reversed(repo.repos):
+                self.put_first(r)
+            return
+
+        self.repos.insert(0, repo)
+        self.by_namespace[repo.full_namespace] = repo
+
+    def put_last(self, repo):
+        """Add repo last in the search path."""
+        if isinstance(repo, RepoPath):
+            for r in repo.repos:
+                self.put_last(r)
+            return
+
+        self.repos.append(repo)
+
+        # don't mask any higher-precedence repos with same namespace
+        if repo.full_namespace not in self.by_namespace:
+            self.by_namespace[repo.full_namespace] = repo
+
+    def remove(self, repo):
+        """Remove a repo from the search path."""
+        if repo in self.repos:
+            self.repos.remove(repo)
+
+    def get_full_namespace(self, namespace):
+        """Returns the full namespace of a repository, given its relative one."""
+        return f"{self.base_namespace}.{namespace}"
+
+    def get_repo(self, namespace, default=NOT_PROVIDED):
+        """Get a repository by namespace.
+
+        Arguments:
+
+            namespace:
+
+                Look up this namespace in the RepoPath, and return it if found.
+
+        Optional Arguments:
+
+            default:
+
+                If default is provided, return it when the namespace
+                isn't found.  If not, raise an UnknownNamespaceError.
+        """
+        full_namespace = self.get_full_namespace(namespace)
+        if full_namespace not in self.by_namespace:
+            if default == NOT_PROVIDED:
+                raise UnknownNamespaceError(namespace)
+            return default
+        return self.by_namespace[full_namespace]
+
+    def first_repo(self):
+        """Get the first repo in precedence order."""
+        return self.repos[0] if self.repos else None
+
+    def all_object_names(self):
+        """Return all unique object names in all repositories."""
+        if self._all_object_names is None:
+            all_objs = set()
+            for repo in self.repos:
+                for name in repo.all_object_names():
+                    all_objs.add(name)
+            self._all_object_names = sorted(all_objs, key=lambda n: n.lower())
+        return self._all_object_names
+
+    def objects_with_tags(self, *tags):
+        r = set()
+        for repo in self.repos:
+            r |= set(repo.objects_with_tags(*tags))
+        return sorted(r)
+
+    def all_objects(self):
+        for name in self.all_object_names():
+            yield self.get(name)
+
+    def all_object_classes(self):
+        for name in self.all_object_names():
+            yield self.get_obj_class(name)
+
+    def find_module(self, fullname, path=None):
+        """Implements precedence for overlaid namespaces.
+
+        Loop checks each namespace in self.repos for objects, and
+        also handles loading empty containing namespaces.
+
+        """
+        # namespaces are added to repo, and object modules are leaves.
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        # If it's a module in some repo, or if it is the repo's
+        # namespace, let the repo handle it.
+        for repo in self.repos:
+            if namespace == repo.full_namespace:
+                if repo.real_name(module_name):
+                    return repo
+            elif fullname == repo.full_namespace:
+                return repo
+
+        # No repo provides the namespace, but it is a valid prefix of
+        # something in the RepoPath.
+        if self.by_namespace.is_prefix(fullname):
+            return self
+
+        return None
+
+    def load_module(self, fullname):
+        """Handles loading container namespaces when necessary.
+
+        See ``Repo`` for how actual object modules are loaded.
+        """
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        if not self.by_namespace.is_prefix(fullname):
+            raise ImportError("No such benchpark repo: %s" % fullname)
+
+        module = ObjectNamespace(fullname)
+        module.__loader__ = self
+        sys.modules[fullname] = module
+        return module
+
+    def last_mtime(self):
+        """Time a object file in this repo was last updated."""
+        return max(repo.last_mtime() for repo in self.repos)
+
+    def repo_for_obj(self, spec):
+        """Given a spec, get the repository for its object."""
+        # We don't @_autospec this function b/c it's called very frequently
+        # and we want to avoid parsing str's into Specs unnecessarily.
+        logger.debug(f"Getting repo for obj {spec}")
+        namespace = None
+        if isinstance(spec, benchpark.experiment_spec.Spec):
+            namespace = spec.namespace
+            name = spec.name
+        else:
+            # handle strings directly for speed instead of @_autospec'ing
+            namespace, _, name = spec.rpartition(".")
+
+        logger.debug(f" Name and namespace = {namespace} - {name}")
+        # If the spec already has a namespace, then return the
+        # corresponding repo if we know about it.
+        if namespace:
+            fullspace = self.get_full_namespace(namespace)
+            if fullspace not in self.by_namespace:
+                raise UnknownNamespaceError(spec.namespace)
+            return self.by_namespace[fullspace]
+
+        # If there's no namespace, search in the RepoPath.
+        for repo in self.repos:
+            if name in repo:
+                logger.debug("Found repo...")
+                return repo
+
+        # If the object isn't in any repo, return the one with
+        # highest precedence.  This is for commands like `ramble edit`
+        # that can operate on objects that don't exist yet.
+        return self.first_repo()
+
+    @autospec
+    def get(self, spec):
+        """Returns the object associated with the supplied spec."""
+        return self.repo_for_obj(spec).get(spec)
+
+    def get_obj_class(self, obj_name):
+        """Find a class for the spec's object and return the class object."""  # noqa: E501
+        return self.repo_for_obj(obj_name).get_obj_class(obj_name)
+
+    @autospec
+    def dump_provenance(self, spec, path):
+        """Dump provenance information for a spec to a particular path.
+
+        This dumps the object file and any associated patch files.
+        Raises UnknownObjectError if not found.
+        """
+        return self.repo_for_obj(spec).dump_provenance(spec, path)
+
+    def dirname_for_object_name(self, obj_name):
+        return self.repo_for_obj(obj_name).dirname_for_object_name(obj_name)
+
+    def filename_for_object_name(self, obj_name):
+        return self.repo_for_obj(obj_name).filename_for_object_name(obj_name)
+
+    def exists(self, obj_name):
+        """Whether object with the give name exists in the path's repos.
+
+        Note that virtual objects do not "exist".
+        """
+        return any(repo.exists(obj_name) for repo in self.repos)
+
+    # TODO: DWJ - Maybe we don't need this? Are we going to have virtual
+    #             objects
+    # def is_virtual(self, obj_name, use_index=True):
+    #     """True if the object with this name is virtual,
+    #        False otherwise.
+    #
+    #     Set `use_index` False when calling from a code block that could
+    #     be run during the computation of the provider index."""
+    #     have_name = obj_name is not None
+    #     if have_name and not isinstance(obj_name, str):
+    #         raise ValueError(
+    #             "is_virtual(): expected object name, got %s" %
+    #             type(obj_name))
+    #     if use_index:
+    #         return have_name and app_name in self.provider_index
+    #     else:
+    #         return have_name and (not self.exists(app_name) or
+    #                               self.get_app_class(app_name).virtual)
+
+    def __contains__(self, obj_name):
+        return self.exists(obj_name)
+
+
+class Repo(object):
+    """Class representing a object repository in the filesystem.
+
+    Each object repository must have a top-level configuration file
+    called `repo.yaml`.
+
+    Currently, `repo.yaml` this must define:
+
+    `namespace`:
+        A Python namespace where the repository's objects should live.
+
+    """
+
+    def __init__(self, root, object_type=default_type):
+        """Instantiate an object repository from a filesystem path.
+
+        Args:
+            root: the root directory of the repository
+        """
+        # Root directory, containing _repo.yaml and object dirs
+        # Allow roots to be ramble-relative by starting with '$ramble'
+        self.root = ramble.util.path.canonicalize_path(root)
+        self.object_file_name = type_definitions[object_type]["file_name"]
+        self.object_type = object_type
+        self.object_abbrev = type_definitions[object_type]["abbrev"]
+        self.base_namespace = f"{global_namespace}.{self.object_abbrev}"
+
+        # check and raise BadRepoError on fail.
+        def check(condition, msg):
+            if not condition:
+                raise BadRepoError(msg)
+
+        # Validate repository layout.
+        self.config_name = None
+        self.config_file = None
+        for config in type_definitions[object_type]["accepted_configs"]:
+            config_file = os.path.join(self.root, config)
+            if os.path.exists(config_file):
+                self.config_name = config
+                self.config_file = config_file
+        check(os.path.isfile(self.config_file), "No %s found in '%s'" % (self.config_name, root))
+
+        # Read configuration and validate namespace
+        config = self._read_config()
+        check(
+            "namespace" in config,
+            "%s must define a namespace." % os.path.join(root, self.config_name),
+        )
+
+        self.namespace = config["namespace"]
+        check(
+            re.match(r"[a-zA-Z][a-zA-Z0-9_.]+", self.namespace),
+            ("Invalid namespace '%s' in repo '%s'. " % (self.namespace, self.root))
+            + "Namespaces must be valid python identifiers separated by '.'",
+        )
+
+        objects_dir = (
+            config["subdirectory"]
+            if "subdirectory" in config
+            else type_definitions[object_type]["dir_name"]
+        )
+
+        self.objects_path = os.path.join(self.root, objects_dir)
+        check(
+            os.path.isdir(self.objects_path),
+            "No directory '%s' found in '%s'" % (objects_dir, root),
+        )
+
+        # Set up 'full_namespace' to include the super-namespace
+        self.full_namespace = f"{self.base_namespace}.{self.namespace}"
+
+        # Keep name components around for checking prefixes.
+        self._names = self.full_namespace.split(".")
+
+        # These are internal cache variables.
+        self._modules = {}
+        self._classes = {}
+        self._instances = {}
+
+        # Maps that goes from object name to corresponding file stat
+        self._fast_object_checker = None
+
+        # Indexes for this repository, computed lazily
+        self._repo_index = None
+
+        # make sure the namespace for objects in this repo exists.
+        self._create_namespace()
+
+    def _create_namespace(self):
+        """Create this repo's namespace module and insert it into sys.modules.
+
+        Ensures that modules loaded via the repo have a home, and that
+        we don't get runtime warnings from Python's module system.
+
+        """
+        parent = None
+        for i in range(1, len(self._names) + 1):
+            ns = ".".join(self._names[:i])
+
+            if ns not in sys.modules:
+                module = ObjectNamespace(ns)
+                module.__loader__ = self
+                sys.modules[ns] = module
+
+                # TODO: DWJ - Do we need this?
+                # Ensure the namespace is an attribute of its parent,
+                # if it has not been set by something else already.
+                #
+                # This ensures that we can do things like:
+                #    import ramble.app.builtin.mpich as mpich
+                if parent:
+                    modname = self._names[i - 1]
+                    setattr(parent, modname, module)
+            else:
+                # no need to set up a module
+                module = sys.modules[ns]
+
+            # but keep track of the parent in this loop
+            parent = module
+
+    def real_name(self, import_name):
+        """Allow users to import Ramble objects using Python identifiers.
+
+        A python identifier might map to many different Ramble object
+        names due to hyphen/underscore ambiguity.
+
+        Easy example:
+            num3proxy   -> 3proxy
+
+        Ambiguous:
+            foo_bar -> foo_bar, foo-bar
+
+        More ambiguous:
+            foo_bar_baz -> foo_bar_baz, foo-bar-baz, foo_bar-baz, foo-bar_baz
+        """
+        if import_name in self:
+            return import_name
+
+        options = nm.possible_ramble_module_names(import_name)
+        options.remove(import_name)
+        for name in options:
+            if name in self:
+                return name
+        return None
+
+    def is_prefix(self, fullname):
+        """True if fullname is a prefix of this Repo's namespace."""
+        parts = fullname.split(".")
+        return self._names[: len(parts)] == parts
+
+    def find_module(self, fullname, path=None):
+        """Python find_module import hook.
+
+        Returns this Repo if it can load the module; None if not.
+        """
+        if self.is_prefix(fullname):
+            return self
+
+        namespace, dot, module_name = fullname.rpartition(".")
+        if namespace == self.full_namespace:
+            if self.real_name(module_name):
+                return self
+
+        return None
+
+    def load_module(self, fullname):
+        """Python importer load hook.
+
+        Tries to load the module; raises an ImportError if it can't.
+        """
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        if self.is_prefix(fullname):
+            module = ObjectNamespace(fullname)
+
+        elif namespace == self.full_namespace:
+            real_name = self.real_name(module_name)
+            if not real_name:
+                raise ImportError("No module %s in %s" % (module_name, self))
+            module = self._get_obj_module(real_name)
+
+        else:
+            raise ImportError("No module %s in %s" % (fullname, self))
+
+        module.__loader__ = self
+        sys.modules[fullname] = module
+        if namespace != fullname:
+            parent = sys.modules[namespace]
+            if not hasattr(parent, module_name):
+                setattr(parent, module_name, module)
+
+        return module
+
+
+
+    @autospec
+    def get(self, spec):
+        """Returns the object associated with the supplied spec."""
+        # NOTE: we only check whether the object is None here, not whether
+        # it actually exists, because we have to load it anyway, and that ends
+        # up checking for existence. We avoid constructing
+        # FastObjectChecker, which will stat all objects.
+        logger.debug(f"Getting obj {spec} from repo")
+        if spec.name is None:
+            raise UnknownObjectError(None, self)
+
+        if spec.namespace and spec.namespace != self.namespace:
+            raise UnknownObjectError(spec.name, self.namespace)
+
+        object_class = self.get_obj_class(spec.name)
+        try:
+            return object_class(self.object_path(spec))
+        except ramble.error.RambleError:
+            # pass these through as their error messages will be fine.
+            raise
+        except Exception as e:
+            logger.debug(e)
+
+            # Make sure other errors in constructors hit the error
+            # handler by wrapping them
+            if ramble.config.get("config:debug"):
+                sys.excepthook(*sys.exc_info())
+            raise FailedConstructorError(spec.fullname, *sys.exc_info())
+
+    @autospec
+    def dump_provenance(self, spec, path):
+        """Dump provenance information for a spec to a particular path.
+
+        This dumps the object file.
+        Raises UnknownObjectError if not found.
+        """
+        if spec.namespace and spec.namespace != self.namespace:
+            raise UnknownObjectError(
+                f"Repository {self.namespace} does not "
+                f"contain {self.object_type.name} {spec.fullname}."
+            )
+
+        # Install the object's .py file itself.
+        fs.install(self.filename_for_object_name(spec.name), path)
+
+    def purge(self):
+        """Clear entire object instance cache."""
+        self._instances.clear()
+
+    @property
+    def index(self):
+        """Construct the index for this repo lazily."""
+        if self._repo_index is None:
+            self._repo_index = RepoIndex(self._obj_checker, self.namespace, self.object_type)
+            self._repo_index.add_indexer("tags", TagIndexer(self.object_type))
+        return self._repo_index
+
+    @property
+    def tag_index(self):
+        """Index of tags and which objects they're defined on."""
+        return self.index["tags"]
+
+    def dirname_for_object_name(self, obj_name):
+        """Get the directory name for a particular object.  This is the
+        directory that contains its object.py file."""
+        return os.path.join(self.objects_path, obj_name)
+
+    def filename_for_object_name(self, obj_name):
+        """Get the filename for the module we should load for a particular
+        object.  objects for a Repo live in
+        ``$root/<object_name>/<object_type>.py``
+
+        This will return a proper <object_type>.py path even if the
+        object doesn't exist yet, so callers will need to ensure
+        the object exists before importing.
+        """
+        obj_dir = self.dirname_for_object_name(obj_name)
+        return os.path.join(obj_dir, self.object_file_name)
+
+    @autospec
+    def object_path(self, spec):
+        return os.path.join(
+            self.objects_path,
+            self.dirname_for_object_name(spec.name),
+            self.filename_for_object_name(spec.name),
+        )
+
+    def all_object_names(self):
+        """Returns a sorted list of all object names in the Repo."""
+        names = sorted(self._obj_checker.keys())
+        return names
+
+    def objects_with_tags(self, *tags):
+        v = set(self.all_object_names())
+        index = self.tag_index
+
+        for t in tags:
+            t = t.lower()
+            v &= set(index[t])
+
+        return sorted(v)
+
+    def all_objects(self):
+        """Iterator over all objects in the repository.
+
+        Use this with care, because loading objects is slow.
+
+        """
+        for name in self.all_object_names():
+            yield self.get(name)
+
+    def all_object_classes(self):
+        """Iterator over all object *classes* in the repository.
+
+        Use this with care, because loading objects is slow.
+        """
+        for name in self.all_object_names():
+            yield self.get_obj_class(name)
+
+    def exists(self, obj_name):
+        """Whether a object with the supplied name exists."""
+        if obj_name is None:
+            return False
+
+        # if the FastObjectChecker is already constructed, use it
+        if self._fast_object_checker:
+            return obj_name in self._obj_checker
+
+        # if not, check for the object.py file
+        path = self.filename_for_object_name(obj_name)
+        return os.path.exists(path)
+
+    def last_mtime(self):
+        """Time a object file in this repo was last updated."""
+        return self._obj_checker.last_mtime()
+
+    def _get_obj_module(self, obj_name):
+        """Create a module for a particular object.
+
+        This caches the module within this Repo *instance*.  It does
+        *not* add it to ``sys.modules``.  So, you can construct
+        multiple Repos for testing and ensure that the module will be
+        loaded once per repo.
+
+        """
+        if obj_name not in self._modules:
+            file_path = self.filename_for_object_name(obj_name)
+
+            if not os.path.exists(file_path):
+                raise UnknownObjectError(obj_name, self)
+
+            if not os.path.isfile(file_path):
+                logger.die(f"Something's wrong. '{file_path}' is not a file!")
+
+            if not os.access(file_path, os.R_OK):
+                logger.die(f"Cannot read '{file_path}'!")
+
+            # e.g., ramble.app.builtin.mpich
+            fullname = "%s.%s" % (self.full_namespace, obj_name)
+
+            try:
+                module = ramble.util.imp.load_source(fullname, file_path)
+            except SyntaxError as e:
+                # SyntaxError strips the path from the filename so we need to
+                # manually construct the error message in order to give the
+                # user the correct .py where the syntax error is
+                # located
+                raise SyntaxError("invalid syntax in {0:}, line {1:}".format(file_path, e.lineno))
+
+            module.__object__ = self.full_namespace
+            module.__loader__ = self
+            self._modules[obj_name] = module
+
+        return self._modules[obj_name]
+
+    def get_obj_class(self, obj_name):
+        """Get the class for the object out of its module.
+
+        First loads (or fetches from cache) a module for the
+        object. Then extracts the object class from the module
+        according to Ramble's naming convention.
+        """
+        namespace, _, obj_name = obj_name.rpartition(".")
+        if namespace and (namespace != self.namespace):
+            raise InvalidNamespaceError(
+                "Invalid namespace for %s repo: %s" % (self.namespace, namespace)
+            )
+
+        class_name = nm.mod_to_class(obj_name)
+        logger.debug(f" Class name = {class_name}")
+        module = self._get_obj_module(obj_name)
+
+        cls = getattr(module, class_name)
+        if not inspect.isclass(cls):
+            logger.die(f"{obj_name}.{class_name} is not a class")
+
+        return cls
+
+    def __str__(self):
+        return "[Repo '%s' at '%s']" % (self.namespace, self.root)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __contains__(self, obj_name):
+        return self.exists(obj_name)
+
+
+class RepositoryNamespace(types.ModuleType):
+    """Allow lazy loading of modules."""
+
+    def __init__(self, namespace):
+        super(RepositoryNamespace, self).__init__(namespace)
+        self.__file__ = "(repository namespace)"
+        self.__path__ = []
+        self.__name__ = namespace
+        self.__package__ = namespace
+        self.__modules = {}
+
+    def __getattr__(self, name):
+        """Getattr lazily loads modules if they're not already loaded."""
+        submodule = self.__package__ + "." + name
+        try:
+            setattr(self, name, __import__(submodule))
+        except ImportError:
+            msg = "'{0}' object has no attribute {1}"
+            raise AttributeError(msg.format(type(self), name))
+        return getattr(self, name)
+
+
+class RepoLoader(importlib.machinery.SourceFileLoader):
+    """Loads a Python module associated with a object in specific repository"""
+
+    #: Code in ``_object_prepend`` is prepended to imported objects.
+    _object_prepend = "from __future__ import absolute_import;"
+
+    def __init__(self, fullname, repo, object_name):
+        self.repo = repo
+        self.object_name = object_name
+        self.object_py = repo.filename_for_object_name(object_name)
+        self.fullname = fullname
+        super(RepoLoader, self).__init__(
+            self.fullname, self.object_py, prepend=self._object_prepend
+        )
+
+
+class RepositoryNamespaceLoader(object):
+    def create_module(self, spec):
+        return RepositoryNamespace(spec.name)
+
+    def exec_module(self, module):
+        module.__loader__ = self
+
+
+class ReposFinder(object):
+    """MetaPathFinder class that loads a Python module corresponding to an object
+
+    Return a loader based on the inspection of the current global repository list.
+    """
+
+    def __init__(self, object_type=default_type):
+        self.object_type = object_type
+
+    def find_spec(self, fullname, python_path, target=None):
+        # "target" is not None only when calling importlib.reload()
+        if target is not None:
+            raise RuntimeError('cannot reload module "{0}"'.format(fullname))
+
+        # Preferred API from https://peps.python.org/pep-0451/
+        if not fullname.startswith("ramble."):
+            return None
+
+        loader = self.compute_loader(fullname)
+        if loader is None:
+            return None
+        return importlib.util.spec_from_loader(fullname, loader)
+
+    def compute_loader(self, fullname):
+        # namespaces are added to repo, and object modules are leaves.
+        namespace, dot, module_name = fullname.rpartition(".")
+
+        # If it's a module in some repo, or if it is the repo's
+        # namespace, let the repo handle it.
+        for repo in paths[self.object_type].repos:
+            # We are using the namespace of the repo and the repo contains the object
+            if namespace == repo.full_namespace:
+                # With 2 nested conditionals we can call "repo.real_name" only once
+                object_name = repo.real_name(module_name)
+                if object_name:
+                    return RepoLoader(fullname, repo, object_name)
+
+            # We are importing a full namespace like 'spack.pkg.builtin'
+            if fullname == repo.full_namespace:
+                return RepositoryNamespaceLoader()
+
+        # No repo provides the namespace, but it is a valid prefix of
+        # something in the RepoPath.
+        if paths[self.object_type].by_namespace.is_prefix(fullname):
+            return RepositoryNamespaceLoader()
+
+        return None
+
+
+# Add the finder to sys.meta_path
+REPOS_FINDER = ReposFinder()
+sys.meta_path.append(REPOS_FINDER)
+
+
+class RepoError(benchpark.error.BenchparkError):
+    """Superclass for repository-related errors."""
+
+
+class NoRepoConfiguredError(RepoError):
+    """Raised when there are no repositories configured."""
+
+
+class InvalidNamespaceError(RepoError):
+    """Raised when an invalid namespace is encountered."""
+
+
+class BadRepoError(RepoError):
+    """Raised when repo layout is invalid."""
+
+
+class UnknownEntityError(RepoError):
+    """Raised when we encounter a object ramble doesn't have."""
+
+
+class IndexError(RepoError):
+    """Raised when there's an error with an index."""
+
+
+class UnknownObjectError(UnknownEntityError):
+    """Raised when we encounter an object ramble doesn't have."""
+
+    def __init__(self, name, repo=None, object_type="Object"):
+        msg = None
+        long_msg = None
+
+        if name:
+            if repo:
+                msg = f"{object_type} '{name}' not found in repository '{repo.root}'"
+            else:
+                msg = f"{object_type} '{name}' not found."
+
+            # Special handling for specs that may have been intended as
+            # filenames: prompt the user to ask whether they intended to write
+            # './<name>'.
+            if name.endswith(".yaml"):
+                long_msg = "Did you mean to specify a filename with './{0}'?"
+                long_msg = long_msg.format(name)
+        else:
+            msg = f"Attempting to retrieve anonymous {object_type}."
+
+        super(UnknownObjectError, self).__init__(msg, long_msg)
+        self.name = name
+
+
+class UnknownNamespaceError(UnknownEntityError):
+    """Raised when we encounter an unknown namespace"""
+
+    def __init__(self, namespace):
+        super(UnknownNamespaceError, self).__init__("Unknown namespace: %s" % namespace)
+
+
+class FailedConstructorError(RepoError):
+    """Raised when an object's class constructor fails."""
+
+    def __init__(self, name, exc_type, exc_obj, exc_tb, object_type=None):
+        super(FailedConstructorError, self).__init__(
+            f"Class constructor failed for {object_type} '%s'." % name,
+            "\nCaused by:\n"
+            + ("%s: %s\n" % (exc_type.__name__, exc_obj))
+            + "".join(traceback.format_tb(exc_tb)),
+        )
+        self.name = name

--- a/lib/benchpark/test_repo/experiments/saxpy/experiment.py
+++ b/lib/benchpark/test_repo/experiments/saxpy/experiment.py
@@ -1,0 +1,12 @@
+# TODO
+from benchpark.experiment import Experiment
+from benchpark.directives import *
+
+
+class Saxpy(Experiment):
+    variant(
+        "programming_model",
+        default="openmp",
+        values=("openmp", "cuda", "rocm"),
+        description="on-node parallelism model",
+    )

--- a/lib/benchpark/test_repo/experiments/saxpy/experiment.py
+++ b/lib/benchpark/test_repo/experiments/saxpy/experiment.py
@@ -10,3 +10,60 @@ class Saxpy(Experiment):
         values=("openmp", "cuda", "rocm"),
         description="on-node parallelism model",
     )
+
+    def compute_applications_section(self):
+        variables = {}
+        matrix = {}
+
+        # GPU tests include some smaller sizes
+        n = ["512", "1024"]
+        matrix = ["size"]
+        if self.spec.satisfies("openmp"):
+            matrix += ["omp_num_threads"]
+            variables["n_nodes"] = ["1", "2"]
+            variables["n_ranks"] = "8"
+            variables["omp_num_threads"] = ["2", "4"]
+        else:
+            n = ["128", "256"] + n
+            variables["n_gpus"] = "1"
+
+        variables["n"] = n
+
+        return {
+            "saxpy": {  # ramble Application name
+                # TODO replace with a hash once we have one?
+                f"problem-{str(self.spec)}": {
+                    "experiments": {
+                        "saxpy_{n}_{n_nodes}_{omp_num_threads}": {
+                            "variables": variables,
+                            "matrices": matrix,
+                        }
+                    }
+                }
+            }
+        }
+
+    def compute_spack_section(self):
+        # TODO: express that we need certain variables from system
+        # Does not need to happen before merge, separate task
+        saxpy_spack_spec = "saxpy@1.0.0{modifier_spack_variant}"
+        if self.spec.satisfies("programming_model=openmp"):
+            saxpy_spack_spec += "+openmp"
+        elif self.spec.satisfies("programming_model=cuda"):
+            saxpy_spack_spec += "+cuda cuda_arch={cuda_arch}"
+        elif self.spec.satisfies("programming_model=rocm"):
+            saxpy_spack_spec += "+rocm amdgpu_target={rocm_arch}"
+
+        packages = ["default-mpi", self.spec.name, "{modifier_package_name}"]
+
+        return {
+            "spack": {
+                "packages": {
+                    "saxpy": {
+                        "spack_spec": saxpy_spack_spec,
+                        "compiler": "default_compiler",  # TODO: this should probably move?
+                    }
+                },
+                "environments": {"saxpy": {"packages": packages}},
+            }
+        }

--- a/lib/benchpark/test_repo/repo.yaml
+++ b/lib/benchpark/test_repo/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: builtin

--- a/lib/benchpark/variant.py
+++ b/lib/benchpark/variant.py
@@ -1,0 +1,118 @@
+import inspect
+
+
+class Variant:
+    """Represents a variant in a package, as declared in the
+    variant directive.
+    """
+
+    def __init__(
+        self,
+        name,
+        default,
+        description,
+        values=(True, False),
+        multi=False,
+        validator=None,
+        sticky=False,
+    ):
+        """Initialize a package variant.
+
+        Args:
+            name (str): name of the variant
+            default (str): default value for the variant in case
+                nothing has been specified
+            description (str): purpose of the variant
+            values (sequence): sequence of allowed values or a callable
+                accepting a single value as argument and returning True if the
+                value is good, False otherwise
+            multi (bool): whether multiple CSV are allowed
+            validator (callable): optional callable used to enforce
+                additional logic on the set of values being validated
+            sticky (bool): if true the variant is set to the default value at
+                concretization time
+        """
+        self.name = name
+        self.default = default
+        self.description = str(description)
+
+        self.values = None
+        if values == "*":
+            # wildcard is a special case to make it easy to say any value is ok
+            self.validator = lambda x: True
+
+        elif isinstance(values, type):
+            # supplying a type means any value *of that type*
+            def isa_type(v):
+                try:
+                    values(v)
+                    return True
+                except ValueError:
+                    return False
+
+            self.validator = isa_type
+
+        elif callable(values):
+            # If 'values' is a callable, assume it is a single value
+            # validator and reset the values to be explicit during debug
+            self.validator = values
+        else:
+            # Otherwise, assume values is the set of allowed explicit values
+            self.values = tuple(values)
+            self.validator = lambda x: x in self.values
+
+        self.multi = multi
+        self.sticky = sticky
+
+    def validate_values(self, variant_values, pkg_cls=None):
+        """Validate a variant spec against this package variant. Raises an
+        exception if any error is found.
+
+        Args:
+            vspec_values (tuple): values to be validated
+            pkg_cls (spack.package_base.PackageBase): the package class
+                that required the validation, if available
+
+        Raises: Exception
+        """
+        # If the value is exclusive there must be at most one
+        if not self.multi and len(variant_values) != 1:
+            raise Exception()
+
+        # Check and record the values that are not allowed
+        not_allowed_values = [
+            x for x in variant_values if x != "*" and self.validator(x) is False
+        ]
+        if not_allowed_values:
+            raise ValueError(f"{not_allowed_values} are not valid values for {pkg_cls}")
+
+    @property
+    def allowed_values(self):
+        """Returns a string representation of the allowed values for
+        printing purposes
+
+        Returns:
+            str: representation of the allowed values
+        """
+        # Join an explicit set of allowed values
+        if self.values is not None:
+            v = tuple(str(x) for x in self.values)
+            return ", ".join(v)
+        # In case we were given a single-value validator
+        # print the docstring
+        docstring = inspect.getdoc(self.single_value_validator)
+        v = docstring if docstring else ""
+        return v
+
+    def __eq__(self, other):
+        return (
+            self.name == other.name
+            and self.default == other.default
+            and self.values == other.values
+            and self.multi == other.multi
+            and self.single_value_validator == other.single_value_validator
+            and self.group_validator == other.group_validator
+        )
+
+    def __ne__(self, other):
+        return not self == other

--- a/lib/llnl/util/lang.py
+++ b/lib/llnl/util/lang.py
@@ -1,0 +1,1038 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import collections.abc
+import contextlib
+import functools
+import inspect
+import itertools
+import os
+import re
+import sys
+import traceback
+from datetime import datetime, timedelta
+from typing import Any, Callable, Iterable, List, Tuple
+
+# Ignore emacs backups when listing modules
+ignore_modules = [r"^\.#", "~$"]
+
+
+def index_by(objects, *funcs):
+    """Create a hierarchy of dictionaries by splitting the supplied
+    set of objects on unique values of the supplied functions.
+
+    Values are used as keys. For example, suppose you have four
+    objects with attributes that look like this::
+
+        a = Spec("boost %gcc target=skylake")
+        b = Spec("mrnet %intel target=zen2")
+        c = Spec("libelf %xlc target=skylake")
+        d = Spec("libdwarf %intel target=zen2")
+
+        list_of_specs = [a,b,c,d]
+        index1 = index_by(list_of_specs, lambda s: str(s.target),
+                          lambda s: s.compiler)
+        index2 = index_by(list_of_specs, lambda s: s.compiler)
+
+    ``index1`` now has two levels of dicts, with lists at the
+    leaves, like this::
+
+        { 'zen2'    : { 'gcc' : [a], 'xlc' : [c] },
+          'skylake' : { 'intel' : [b, d] }
+        }
+
+    And ``index2`` is a single level dictionary of lists that looks
+    like this::
+
+        { 'gcc'    : [a],
+          'intel'  : [b,d],
+          'xlc'    : [c]
+        }
+
+    If any elements in funcs is a string, it is treated as the name
+    of an attribute, and acts like getattr(object, name).  So
+    shorthand for the above two indexes would be::
+
+        index1 = index_by(list_of_specs, 'arch', 'compiler')
+        index2 = index_by(list_of_specs, 'compiler')
+
+    You can also index by tuples by passing tuples::
+
+        index1 = index_by(list_of_specs, ('target', 'compiler'))
+
+    Keys in the resulting dict will look like ('gcc', 'skylake').
+    """
+    if not funcs:
+        return objects
+
+    f = funcs[0]
+    if isinstance(f, str):
+        f = lambda x: getattr(x, funcs[0])
+    elif isinstance(f, tuple):
+        f = lambda x: tuple(getattr(x, p) for p in funcs[0])
+
+    result = {}
+    for o in objects:
+        key = f(o)
+        result.setdefault(key, []).append(o)
+
+    for key, objects in result.items():
+        result[key] = index_by(objects, *funcs[1:])
+
+    return result
+
+
+def caller_locals():
+    """This will return the locals of the *parent* of the caller.
+    This allows a function to insert variables into its caller's
+    scope.  Yes, this is some black magic, and yes it's useful
+    for implementing things like depends_on and provides.
+    """
+    # Passing zero here skips line context for speed.
+    stack = inspect.stack(0)
+    try:
+        return stack[2][0].f_locals
+    finally:
+        del stack
+
+
+def attr_setdefault(obj, name, value):
+    """Like dict.setdefault, but for objects."""
+    if not hasattr(obj, name):
+        setattr(obj, name, value)
+    return getattr(obj, name)
+
+
+def has_method(cls, name):
+    for base in inspect.getmro(cls):
+        if base is object:
+            continue
+        if name in base.__dict__:
+            return True
+    return False
+
+
+def union_dicts(*dicts):
+    """Use update() to combine all dicts into one.
+
+    This builds a new dictionary, into which we ``update()`` each element
+    of ``dicts`` in order.  Items from later dictionaries will override
+    items from earlier dictionaries.
+
+    Args:
+        dicts (list): list of dictionaries
+
+    Return: (dict): a merged dictionary containing combined keys and
+        values from ``dicts``.
+
+    """
+    result = {}
+    for d in dicts:
+        result.update(d)
+    return result
+
+
+# Used as a sentinel that disambiguates tuples passed in *args from coincidentally
+# matching tuples formed from kwargs item pairs.
+_kwargs_separator = (object(),)
+
+
+def stable_args(*args, **kwargs):
+    """A key factory that performs a stable sort of the parameters."""
+    key = args
+    if kwargs:
+        key += _kwargs_separator + tuple(sorted(kwargs.items()))
+    return key
+
+
+def memoized(func):
+    """Decorator that caches the results of a function, storing them in
+    an attribute of that function.
+    """
+    func.cache = {}
+
+    @functools.wraps(func)
+    def _memoized_function(*args, **kwargs):
+        key = stable_args(*args, **kwargs)
+
+        try:
+            return func.cache[key]
+        except KeyError:
+            ret = func(*args, **kwargs)
+            func.cache[key] = ret
+            return ret
+        except TypeError as e:
+            # TypeError is raised when indexing into a dict if the key is unhashable.
+            raise UnhashableArguments(
+                "args + kwargs '{}' was not hashable for function '{}'".format(key, func.__name__)
+            ) from e
+
+    return _memoized_function
+
+
+def list_modules(directory, **kwargs):
+    """Lists all of the modules, excluding ``__init__.py``, in a
+    particular directory.  Listed packages have no particular
+    order."""
+    list_directories = kwargs.setdefault("directories", True)
+
+    for name in os.listdir(directory):
+        if name == "__init__.py":
+            continue
+
+        path = os.path.join(directory, name)
+        if list_directories and os.path.isdir(path):
+            init_py = os.path.join(path, "__init__.py")
+            if os.path.isfile(init_py):
+                yield name
+
+        elif name.endswith(".py"):
+            if not any(re.search(pattern, name) for pattern in ignore_modules):
+                yield re.sub(".py$", "", name)
+
+
+def decorator_with_or_without_args(decorator):
+    """Allows a decorator to be used with or without arguments, e.g.::
+
+        # Calls the decorator function some args
+        @decorator(with, arguments, and=kwargs)
+
+    or::
+
+        # Calls the decorator function with zero arguments
+        @decorator
+
+    """
+
+    # See https://stackoverflow.com/questions/653368 for more on this
+    @functools.wraps(decorator)
+    def new_dec(*args, **kwargs):
+        if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+            # actual decorated function
+            return decorator(args[0])
+        else:
+            # decorator arguments
+            return lambda realf: decorator(realf, *args, **kwargs)
+
+    return new_dec
+
+
+def key_ordering(cls):
+    """Decorates a class with extra methods that implement rich comparison
+    operations and ``__hash__``.  The decorator assumes that the class
+    implements a function called ``_cmp_key()``.  The rich comparison
+    operations will compare objects using this key, and the ``__hash__``
+    function will return the hash of this key.
+
+    If a class already has ``__eq__``, ``__ne__``, ``__lt__``, ``__le__``,
+    ``__gt__``, or ``__ge__`` defined, this decorator will overwrite them.
+
+    Raises:
+        TypeError: If the class does not have a ``_cmp_key`` method
+    """
+
+    def setter(name, value):
+        value.__name__ = name
+        setattr(cls, name, value)
+
+    if not has_method(cls, "_cmp_key"):
+        raise TypeError("'%s' doesn't define _cmp_key()." % cls.__name__)
+
+    setter("__eq__", lambda s, o: (s is o) or (o is not None and s._cmp_key() == o._cmp_key()))
+    setter("__lt__", lambda s, o: o is not None and s._cmp_key() < o._cmp_key())
+    setter("__le__", lambda s, o: o is not None and s._cmp_key() <= o._cmp_key())
+
+    setter("__ne__", lambda s, o: (s is not o) and (o is None or s._cmp_key() != o._cmp_key()))
+    setter("__gt__", lambda s, o: o is None or s._cmp_key() > o._cmp_key())
+    setter("__ge__", lambda s, o: o is None or s._cmp_key() >= o._cmp_key())
+
+    setter("__hash__", lambda self: hash(self._cmp_key()))
+
+    return cls
+
+
+#: sentinel for testing that iterators are done in lazy_lexicographic_ordering
+done = object()
+
+
+def tuplify(seq):
+    """Helper for lazy_lexicographic_ordering()."""
+    return tuple((tuplify(x) if callable(x) else x) for x in seq())
+
+
+def lazy_eq(lseq, rseq):
+    """Equality comparison for two lazily generated sequences.
+
+    See ``lazy_lexicographic_ordering``.
+    """
+    liter = lseq()  # call generators
+    riter = rseq()
+
+    # zip_longest is implemented in native code, so use it for speed.
+    # use zip_longest instead of zip because it allows us to tell
+    # which iterator was longer.
+    for left, right in itertools.zip_longest(liter, riter, fillvalue=done):
+        if (left is done) or (right is done):
+            return False
+
+        # recursively enumerate any generators, otherwise compare
+        equal = lazy_eq(left, right) if callable(left) else left == right
+        if not equal:
+            return False
+
+    return True
+
+
+def lazy_lt(lseq, rseq):
+    """Less-than comparison for two lazily generated sequences.
+
+    See ``lazy_lexicographic_ordering``.
+    """
+    liter = lseq()
+    riter = rseq()
+
+    for left, right in itertools.zip_longest(liter, riter, fillvalue=done):
+        if (left is done) or (right is done):
+            return left is done  # left was shorter than right
+
+        sequence = callable(left)
+        equal = lazy_eq(left, right) if sequence else left == right
+        if equal:
+            continue
+
+        if sequence:
+            return lazy_lt(left, right)
+        if left is None:
+            return True
+        if right is None:
+            return False
+
+        return left < right
+
+    return False  # if equal, return False
+
+
+@decorator_with_or_without_args
+def lazy_lexicographic_ordering(cls, set_hash=True):
+    """Decorates a class with extra methods that implement rich comparison.
+
+    This is a lazy version of the tuple comparison used frequently to
+    implement comparison in Python. Given some objects with fields, you
+    might use tuple keys to implement comparison, e.g.::
+
+        class Widget:
+            def _cmp_key(self):
+                return (
+                    self.a,
+                    self.b,
+                    (self.c, self.d),
+                    self.e
+                )
+
+            def __eq__(self, other):
+                return self._cmp_key() == other._cmp_key()
+
+            def __lt__(self):
+                return self._cmp_key() < other._cmp_key()
+
+            # etc.
+
+    Python would compare ``Widgets`` lexicographically based on their
+    tuples. The issue there for simple comparators is that we have to
+    bulid the tuples *and* we have to generate all the values in them up
+    front. When implementing comparisons for large data structures, this
+    can be costly.
+
+    Lazy lexicographic comparison maps the tuple comparison shown above
+    to generator functions. Instead of comparing based on pre-constructed
+    tuple keys, users of this decorator can compare using elements from a
+    generator. So, you'd write::
+
+        @lazy_lexicographic_ordering
+        class Widget:
+            def _cmp_iter(self):
+                yield a
+                yield b
+                def cd_fun():
+                    yield c
+                    yield d
+                yield cd_fun
+                yield e
+
+            # operators are added by decorator
+
+    There are no tuples preconstructed, and the generator does not have
+    to complete. Instead of tuples, we simply make functions that lazily
+    yield what would've been in the tuple. The
+    ``@lazy_lexicographic_ordering`` decorator handles the details of
+    implementing comparison operators, and the ``Widget`` implementor
+    only has to worry about writing ``_cmp_iter``, and making sure the
+    elements in it are also comparable.
+
+    Some things to note:
+
+      * If a class already has ``__eq__``, ``__ne__``, ``__lt__``,
+        ``__le__``, ``__gt__``, ``__ge__``, or ``__hash__`` defined, this
+        decorator will overwrite them.
+
+      * If ``set_hash`` is ``False``, this will not overwrite
+        ``__hash__``.
+
+      * This class uses Python 2 None-comparison semantics. If you yield
+        None and it is compared to a non-None type, None will always be
+        less than the other object.
+
+    Raises:
+        TypeError: If the class does not have a ``_cmp_iter`` method
+
+    """
+    if not has_method(cls, "_cmp_iter"):
+        raise TypeError("'%s' doesn't define _cmp_iter()." % cls.__name__)
+
+    # comparison operators are implemented in terms of lazy_eq and lazy_lt
+    def eq(self, other):
+        if self is other:
+            return True
+        return (other is not None) and lazy_eq(self._cmp_iter, other._cmp_iter)
+
+    def lt(self, other):
+        if self is other:
+            return False
+        return (other is not None) and lazy_lt(self._cmp_iter, other._cmp_iter)
+
+    def ne(self, other):
+        if self is other:
+            return False
+        return (other is None) or not lazy_eq(self._cmp_iter, other._cmp_iter)
+
+    def gt(self, other):
+        if self is other:
+            return False
+        return (other is None) or lazy_lt(other._cmp_iter, self._cmp_iter)
+
+    def le(self, other):
+        if self is other:
+            return True
+        return (other is not None) and not lazy_lt(other._cmp_iter, self._cmp_iter)
+
+    def ge(self, other):
+        if self is other:
+            return True
+        return (other is None) or not lazy_lt(self._cmp_iter, other._cmp_iter)
+
+    def h(self):
+        return hash(tuplify(self._cmp_iter))
+
+    def add_func_to_class(name, func):
+        """Add a function to a class with a particular name."""
+        func.__name__ = name
+        setattr(cls, name, func)
+
+    add_func_to_class("__eq__", eq)
+    add_func_to_class("__ne__", ne)
+    add_func_to_class("__lt__", lt)
+    add_func_to_class("__le__", le)
+    add_func_to_class("__gt__", gt)
+    add_func_to_class("__ge__", ge)
+    if set_hash:
+        add_func_to_class("__hash__", h)
+
+    return cls
+
+
+@lazy_lexicographic_ordering
+class HashableMap(collections.abc.MutableMapping):
+    """This is a hashable, comparable dictionary.  Hash is performed on
+    a tuple of the values in the dictionary."""
+
+    __slots__ = ("dict",)
+
+    def __init__(self):
+        self.dict = {}
+
+    def __getitem__(self, key):
+        return self.dict[key]
+
+    def __setitem__(self, key, value):
+        self.dict[key] = value
+
+    def __iter__(self):
+        return iter(self.dict)
+
+    def __len__(self):
+        return len(self.dict)
+
+    def __delitem__(self, key):
+        del self.dict[key]
+
+    def _cmp_iter(self):
+        for _, v in sorted(self.items()):
+            yield v
+
+    def copy(self):
+        """Type-agnostic clone method.  Preserves subclass type."""
+        # Construct a new dict of my type
+        self_type = type(self)
+        clone = self_type()
+
+        # Copy everything from this dict into it.
+        for key in self:
+            clone[key] = self[key].copy()
+        return clone
+
+
+def match_predicate(*args):
+    """Utility function for making string matching predicates.
+
+    Each arg can be a:
+    * regex
+    * list or tuple of regexes
+    * predicate that takes a string.
+
+    This returns a predicate that is true if:
+    * any arg regex matches
+    * any regex in a list or tuple of regexes matches.
+    * any predicate in args matches.
+    """
+
+    def match(string):
+        for arg in args:
+            if isinstance(arg, str):
+                if re.search(arg, string):
+                    return True
+            elif isinstance(arg, list) or isinstance(arg, tuple):
+                if any(re.search(i, string) for i in arg):
+                    return True
+            elif callable(arg):
+                if arg(string):
+                    return True
+            else:
+                raise ValueError(
+                    "args to match_predicate must be regex, " "list of regexes, or callable."
+                )
+        return False
+
+    return match
+
+
+def dedupe(sequence, key=None):
+    """Yields a stable de-duplication of an hashable sequence by key
+
+    Args:
+        sequence: hashable sequence to be de-duplicated
+        key: callable applied on values before uniqueness test; identity
+            by default.
+
+    Returns:
+        stable de-duplication of the sequence
+
+    Examples:
+
+        Dedupe a list of integers:
+
+            [x for x in dedupe([1, 2, 1, 3, 2])] == [1, 2, 3]
+
+            [x for x in llnl.util.lang.dedupe([1,-2,1,3,2], key=abs)] == [1, -2, 3]
+    """
+    seen = set()
+    for x in sequence:
+        x_key = x if key is None else key(x)
+        if x_key not in seen:
+            yield x
+            seen.add(x_key)
+
+
+def pretty_date(time, now=None):
+    """Convert a datetime or timestamp to a pretty, relative date.
+
+    Args:
+        time (datetime.datetime or int): date to print prettily
+        now (datetime.datetime): datetime for 'now', i.e. the date the pretty date
+            is relative to (default is datetime.now())
+
+    Returns:
+        (str): pretty string like 'an hour ago', 'Yesterday',
+            '3 months ago', 'just now', etc.
+
+    Adapted from https://stackoverflow.com/questions/1551382.
+
+    """
+    if now is None:
+        now = datetime.now()
+
+    if type(time) is int:
+        diff = now - datetime.fromtimestamp(time)
+    elif isinstance(time, datetime):
+        diff = now - time
+    else:
+        raise ValueError("pretty_date requires a timestamp or datetime")
+
+    second_diff = diff.seconds
+    day_diff = diff.days
+
+    if day_diff < 0:
+        return ""
+
+    if day_diff == 0:
+        if second_diff < 10:
+            return "just now"
+        if second_diff < 60:
+            return str(second_diff) + " seconds ago"
+        if second_diff < 120:
+            return "a minute ago"
+        if second_diff < 3600:
+            return str(second_diff // 60) + " minutes ago"
+        if second_diff < 7200:
+            return "an hour ago"
+        if second_diff < 86400:
+            return str(second_diff // 3600) + " hours ago"
+    if day_diff == 1:
+        return "yesterday"
+    if day_diff < 7:
+        return str(day_diff) + " days ago"
+    if day_diff < 28:
+        weeks = day_diff // 7
+        if weeks == 1:
+            return "a week ago"
+        else:
+            return str(day_diff // 7) + " weeks ago"
+    if day_diff < 365:
+        months = day_diff // 30
+        if months == 1:
+            return "a month ago"
+        elif months == 12:
+            months -= 1
+        return str(months) + " months ago"
+
+    diff = day_diff // 365
+    if diff == 1:
+        return "a year ago"
+    else:
+        return str(diff) + " years ago"
+
+
+def pretty_string_to_date(date_str, now=None):
+    """Parses a string representing a date and returns a datetime object.
+
+    Args:
+        date_str (str): string representing a date. This string might be
+            in different format (like ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``,
+            ``YYYY-MM-DD HH:MM``, ``YYYY-MM-DD HH:MM:SS``)
+            or be a *pretty date* (like ``yesterday`` or ``two months ago``)
+
+    Returns:
+        (datetime.datetime): datetime object corresponding to ``date_str``
+    """
+
+    pattern = {}
+
+    now = now or datetime.now()
+
+    # datetime formats
+    pattern[re.compile(r"^\d{4}$")] = lambda x: datetime.strptime(x, "%Y")
+    pattern[re.compile(r"^\d{4}-\d{2}$")] = lambda x: datetime.strptime(x, "%Y-%m")
+    pattern[re.compile(r"^\d{4}-\d{2}-\d{2}$")] = lambda x: datetime.strptime(x, "%Y-%m-%d")
+    pattern[re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$")] = lambda x: datetime.strptime(
+        x, "%Y-%m-%d %H:%M"
+    )
+    pattern[re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")] = lambda x: datetime.strptime(
+        x, "%Y-%m-%d %H:%M:%S"
+    )
+
+    pretty_regex = re.compile(r"(a|\d+)\s*(year|month|week|day|hour|minute|second)s?\s*ago")
+
+    def _n_xxx_ago(x):
+        how_many, time_period = pretty_regex.search(x).groups()
+
+        how_many = 1 if how_many == "a" else int(how_many)
+
+        # timedelta natively supports time periods up to 'weeks'.
+        # To apply month or year we convert to 30 and 365 days
+        if time_period == "month":
+            how_many *= 30
+            time_period = "day"
+        elif time_period == "year":
+            how_many *= 365
+            time_period = "day"
+
+        kwargs = {(time_period + "s"): how_many}
+        return now - timedelta(**kwargs)
+
+    pattern[pretty_regex] = _n_xxx_ago
+
+    # yesterday
+    callback = lambda x: now - timedelta(days=1)
+    pattern[re.compile("^yesterday$")] = callback
+
+    for regexp, parser in pattern.items():
+        if bool(regexp.match(date_str)):
+            return parser(date_str)
+
+    msg = 'date "{0}" does not match any valid format'.format(date_str)
+    raise ValueError(msg)
+
+
+def pretty_seconds_formatter(seconds):
+    if seconds >= 1:
+        multiplier, unit = 1, "s"
+    elif seconds >= 1e-3:
+        multiplier, unit = 1e3, "ms"
+    elif seconds >= 1e-6:
+        multiplier, unit = 1e6, "us"
+    else:
+        multiplier, unit = 1e9, "ns"
+    return lambda s: "%.3f%s" % (multiplier * s, unit)
+
+
+def pretty_seconds(seconds):
+    """Seconds to string with appropriate units
+
+    Arguments:
+        seconds (float): Number of seconds
+
+    Returns:
+        str: Time string with units
+    """
+    return pretty_seconds_formatter(seconds)(seconds)
+
+
+class ObjectWrapper:
+    """Base class that wraps an object. Derived classes can add new behavior
+    while staying undercover.
+
+    This class is modeled after the stackoverflow answer:
+    * http://stackoverflow.com/a/1445289/771663
+    """
+
+    def __init__(self, wrapped_object):
+        wrapped_cls = type(wrapped_object)
+        wrapped_name = wrapped_cls.__name__
+
+        # If the wrapped object is already an ObjectWrapper, or a derived class
+        # of it, adding type(self) in front of type(wrapped_object)
+        # results in an inconsistent MRO.
+        #
+        # TODO: the implementation below doesn't account for the case where we
+        # TODO: have different base classes of ObjectWrapper, say A and B, and
+        # TODO: we want to wrap an instance of A with B.
+        if type(self) not in wrapped_cls.__mro__:
+            self.__class__ = type(wrapped_name, (type(self), wrapped_cls), {})
+        else:
+            self.__class__ = type(wrapped_name, (wrapped_cls,), {})
+
+        self.__dict__ = wrapped_object.__dict__
+
+
+class Singleton:
+    """Simple wrapper for lazily initialized singleton objects."""
+
+    def __init__(self, factory):
+        """Create a new singleton to be inited with the factory function.
+
+        Args:
+            factory (function): function taking no arguments that
+                creates the singleton instance.
+        """
+        self.factory = factory
+        self._instance = None
+
+    @property
+    def instance(self):
+        if self._instance is None:
+            self._instance = self.factory()
+        return self._instance
+
+    def __getattr__(self, name):
+        # When unpickling Singleton objects, the 'instance' attribute may be
+        # requested but not yet set. The final 'getattr' line here requires
+        # 'instance'/'_instance' to be defined or it will enter an infinite
+        # loop, so protect against that here.
+        if name in ["_instance", "instance"]:
+            raise AttributeError(f"cannot create {name}")
+        return getattr(self.instance, name)
+
+    def __getitem__(self, name):
+        return self.instance[name]
+
+    def __contains__(self, element):
+        return element in self.instance
+
+    def __call__(self, *args, **kwargs):
+        return self.instance(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self.instance)
+
+    def __str__(self):
+        return str(self.instance)
+
+    def __repr__(self):
+        return repr(self.instance)
+
+
+def get_entry_points(*, group: str):
+    """Wrapper for ``importlib.metadata.entry_points``
+
+    Args:
+        group: entry points to select
+
+    Returns:
+        EntryPoints for ``group`` or empty list if unsupported
+    """
+
+    try:
+        import importlib.metadata  # type: ignore  # novermin
+    except ImportError:
+        return []
+
+    try:
+        return importlib.metadata.entry_points(group=group)
+    except TypeError:
+        # Prior to Python 3.10, entry_points accepted no parameters and always
+        # returned a dictionary of entry points, keyed by group.  See
+        # https://docs.python.org/3/library/importlib.metadata.html#entry-points
+        return importlib.metadata.entry_points().get(group, [])
+
+
+def load_module_from_file(module_name, module_path):
+    """Loads a python module from the path of the corresponding file.
+
+    If the module is already in ``sys.modules`` it will be returned as
+    is and not reloaded.
+
+    Args:
+        module_name (str): namespace where the python module will be loaded,
+            e.g. ``foo.bar``
+        module_path (str): path of the python file containing the module
+
+    Returns:
+        A valid module object
+
+    Raises:
+        ImportError: when the module can't be loaded
+        FileNotFoundError: when module_path doesn't exist
+    """
+    import importlib.util
+
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    # This recipe is adapted from https://stackoverflow.com/a/67692/771663
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    # The module object needs to exist in sys.modules before the
+    # loader executes the module code.
+    #
+    # See https://docs.python.org/3/reference/import.html#loading
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        try:
+            del sys.modules[spec.name]
+        except KeyError:
+            pass
+        raise
+    return module
+
+
+def uniq(sequence):
+    """Remove strings of duplicate elements from a list.
+
+    This works like the command-line ``uniq`` tool.  It filters strings
+    of duplicate elements in a list. Adjacent matching elements are
+    merged into the first occurrence.
+
+    For example::
+
+        uniq([1, 1, 1, 1, 2, 2, 2, 3, 3]) == [1, 2, 3]
+        uniq([1, 1, 1, 1, 2, 2, 2, 1, 1]) == [1, 2, 1]
+
+    """
+    if not sequence:
+        return []
+
+    uniq_list = [sequence[0]]
+    last = sequence[0]
+    for element in sequence[1:]:
+        if element != last:
+            uniq_list.append(element)
+            last = element
+    return uniq_list
+
+
+def elide_list(line_list, max_num=10):
+    """Takes a long list and limits it to a smaller number of elements,
+    replacing intervening elements with '...'.  For example::
+
+        elide_list([1,2,3,4,5,6], 4)
+
+    gives::
+
+        [1, 2, 3, '...', 6]
+    """
+    if len(line_list) > max_num:
+        return line_list[: max_num - 1] + ["..."] + line_list[-1:]
+    else:
+        return line_list
+
+
+@contextlib.contextmanager
+def nullcontext(*args, **kwargs):
+    """Empty context manager.
+    TODO: replace with contextlib.nullcontext() if we ever require python 3.7.
+    """
+    yield
+
+
+class UnhashableArguments(TypeError):
+    """Raise when an @memoized function receives unhashable arg or kwarg values."""
+
+
+def enum(**kwargs):
+    """Return an enum-like class.
+
+    Args:
+        **kwargs: explicit dictionary of enums
+    """
+    return type("Enum", (object,), kwargs)
+
+
+def stable_partition(
+    input_iterable: Iterable, predicate_fn: Callable[[Any], bool]
+) -> Tuple[List[Any], List[Any]]:
+    """Partition the input iterable according to a custom predicate.
+
+    Args:
+        input_iterable: input iterable to be partitioned.
+        predicate_fn: predicate function accepting an iterable item
+            as argument.
+
+    Return:
+        Tuple of the list of elements evaluating to True, and
+        list of elements evaluating to False.
+    """
+    true_items, false_items = [], []
+    for item in input_iterable:
+        if predicate_fn(item):
+            true_items.append(item)
+            continue
+        false_items.append(item)
+    return true_items, false_items
+
+
+def ensure_last(lst, *elements):
+    """Performs a stable partition of lst, ensuring that ``elements``
+    occur at the end of ``lst`` in specified order. Mutates ``lst``.
+    Raises ``ValueError`` if any ``elements`` are not already in ``lst``."""
+    for elt in elements:
+        lst.append(lst.pop(lst.index(elt)))
+
+
+class TypedMutableSequence(collections.abc.MutableSequence):
+    """Base class that behaves like a list, just with a different type.
+
+    Client code can inherit from this base class:
+
+        class Foo(TypedMutableSequence):
+            pass
+
+    and later perform checks based on types:
+
+        if isinstance(l, Foo):
+            # do something
+    """
+
+    def __init__(self, iterable):
+        self.data = list(iterable)
+
+    def __getitem__(self, item):
+        return self.data[item]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+
+    def __delitem__(self, key):
+        del self.data[key]
+
+    def __len__(self):
+        return len(self.data)
+
+    def insert(self, index, item):
+        self.data.insert(index, item)
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def __str__(self):
+        return str(self.data)
+
+
+class GroupedExceptionHandler:
+    """A generic mechanism to coalesce multiple exceptions and preserve tracebacks."""
+
+    def __init__(self):
+        self.exceptions: List[Tuple[str, Exception, List[str]]] = []
+
+    def __bool__(self):
+        """Whether any exceptions were handled."""
+        return bool(self.exceptions)
+
+    def forward(self, context: str, base: type = BaseException) -> "GroupedExceptionForwarder":
+        """Return a contextmanager which extracts tracebacks and prefixes a message."""
+        return GroupedExceptionForwarder(context, self, base)
+
+    def _receive_forwarded(self, context: str, exc: Exception, tb: List[str]):
+        self.exceptions.append((context, exc, tb))
+
+    def grouped_message(self, with_tracebacks: bool = True) -> str:
+        """Print out an error message coalescing all the forwarded errors."""
+        each_exception_message = [
+            "{0} raised {1}: {2}{3}".format(
+                context,
+                exc.__class__.__name__,
+                exc,
+                "\n{0}".format("".join(tb)) if with_tracebacks else "",
+            )
+            for context, exc, tb in self.exceptions
+        ]
+        return "due to the following failures:\n{0}".format("\n".join(each_exception_message))
+
+
+class GroupedExceptionForwarder:
+    """A contextmanager to capture exceptions and forward them to a
+    GroupedExceptionHandler."""
+
+    def __init__(self, context: str, handler: GroupedExceptionHandler, base: type):
+        self._context = context
+        self._handler = handler
+        self._base = base
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_value is not None:
+            if not issubclass(exc_type, self._base):
+                return False
+            self._handler._receive_forwarded(self._context, exc_value, traceback.format_tb(tb))
+
+        # Suppress any exception from being re-raised:
+        # https://docs.python.org/3/reference/datamodel.html#object.__exit__.
+        return True
+
+
+class classproperty:
+    """Non-data descriptor to evaluate a class-level property. The function that performs
+    the evaluation is injected at creation time and take an instance (could be None) and
+    an owner (i.e. the class that originated the instance)
+    """
+
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __get__(self, instance, owner):
+        return self.callback(owner)

--- a/lib/llnl/util/lang.py
+++ b/lib/llnl/util/lang.py
@@ -753,7 +753,6 @@ class Singleton:
 
     @property
     def instance(self):
-        print("HEREHEREHERE")
         if self._instance is None:
             self._instance = self.factory()
         return self._instance
@@ -763,10 +762,6 @@ class Singleton:
         # requested but not yet set. The final 'getattr' line here requires
         # 'instance'/'_instance' to be defined or it will enter an infinite
         # loop, so protect against that here.
-        print("HERE", name)
-        import traceback
-
-        traceback.print_stack()
         if name in ["_instance", "instance"]:
             raise AttributeError(f"cannot create {name}")
         return getattr(self.instance, name)

--- a/lib/llnl/util/lang.py
+++ b/lib/llnl/util/lang.py
@@ -166,7 +166,9 @@ def memoized(func):
         except TypeError as e:
             # TypeError is raised when indexing into a dict if the key is unhashable.
             raise UnhashableArguments(
-                "args + kwargs '{}' was not hashable for function '{}'".format(key, func.__name__)
+                "args + kwargs '{}' was not hashable for function '{}'".format(
+                    key, func.__name__
+                )
             ) from e
 
     return _memoized_function
@@ -240,11 +242,17 @@ def key_ordering(cls):
     if not has_method(cls, "_cmp_key"):
         raise TypeError("'%s' doesn't define _cmp_key()." % cls.__name__)
 
-    setter("__eq__", lambda s, o: (s is o) or (o is not None and s._cmp_key() == o._cmp_key()))
+    setter(
+        "__eq__",
+        lambda s, o: (s is o) or (o is not None and s._cmp_key() == o._cmp_key()),
+    )
     setter("__lt__", lambda s, o: o is not None and s._cmp_key() < o._cmp_key())
     setter("__le__", lambda s, o: o is not None and s._cmp_key() <= o._cmp_key())
 
-    setter("__ne__", lambda s, o: (s is not o) and (o is None or s._cmp_key() != o._cmp_key()))
+    setter(
+        "__ne__",
+        lambda s, o: (s is not o) and (o is None or s._cmp_key() != o._cmp_key()),
+    )
     setter("__gt__", lambda s, o: o is None or s._cmp_key() > o._cmp_key())
     setter("__ge__", lambda s, o: o is None or s._cmp_key() >= o._cmp_key())
 
@@ -510,7 +518,8 @@ def match_predicate(*args):
                     return True
             else:
                 raise ValueError(
-                    "args to match_predicate must be regex, " "list of regexes, or callable."
+                    "args to match_predicate must be regex, "
+                    "list of regexes, or callable."
                 )
         return False
 
@@ -633,15 +642,19 @@ def pretty_string_to_date(date_str, now=None):
     # datetime formats
     pattern[re.compile(r"^\d{4}$")] = lambda x: datetime.strptime(x, "%Y")
     pattern[re.compile(r"^\d{4}-\d{2}$")] = lambda x: datetime.strptime(x, "%Y-%m")
-    pattern[re.compile(r"^\d{4}-\d{2}-\d{2}$")] = lambda x: datetime.strptime(x, "%Y-%m-%d")
-    pattern[re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$")] = lambda x: datetime.strptime(
-        x, "%Y-%m-%d %H:%M"
+    pattern[re.compile(r"^\d{4}-\d{2}-\d{2}$")] = lambda x: datetime.strptime(
+        x, "%Y-%m-%d"
     )
-    pattern[re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")] = lambda x: datetime.strptime(
-        x, "%Y-%m-%d %H:%M:%S"
-    )
+    pattern[
+        re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$")
+    ] = lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M")
+    pattern[
+        re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
+    ] = lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S")
 
-    pretty_regex = re.compile(r"(a|\d+)\s*(year|month|week|day|hour|minute|second)s?\s*ago")
+    pretty_regex = re.compile(
+        r"(a|\d+)\s*(year|month|week|day|hour|minute|second)s?\s*ago"
+    )
 
     def _n_xxx_ago(x):
         how_many, time_period = pretty_regex.search(x).groups()
@@ -740,6 +753,7 @@ class Singleton:
 
     @property
     def instance(self):
+        print("HEREHEREHERE")
         if self._instance is None:
             self._instance = self.factory()
         return self._instance
@@ -749,6 +763,10 @@ class Singleton:
         # requested but not yet set. The final 'getattr' line here requires
         # 'instance'/'_instance' to be defined or it will enter an infinite
         # loop, so protect against that here.
+        print("HERE", name)
+        import traceback
+
+        traceback.print_stack()
         if name in ["_instance", "instance"]:
             raise AttributeError(f"cannot create {name}")
         return getattr(self.instance, name)
@@ -981,7 +999,9 @@ class GroupedExceptionHandler:
         """Whether any exceptions were handled."""
         return bool(self.exceptions)
 
-    def forward(self, context: str, base: type = BaseException) -> "GroupedExceptionForwarder":
+    def forward(
+        self, context: str, base: type = BaseException
+    ) -> "GroupedExceptionForwarder":
         """Return a contextmanager which extracts tracebacks and prefixes a message."""
         return GroupedExceptionForwarder(context, self, base)
 
@@ -999,7 +1019,9 @@ class GroupedExceptionHandler:
             )
             for context, exc, tb in self.exceptions
         ]
-        return "due to the following failures:\n{0}".format("\n".join(each_exception_message))
+        return "due to the following failures:\n{0}".format(
+            "\n".join(each_exception_message)
+        )
 
 
 class GroupedExceptionForwarder:
@@ -1018,7 +1040,9 @@ class GroupedExceptionForwarder:
         if exc_value is not None:
             if not issubclass(exc_type, self._base):
                 return False
-            self._handler._receive_forwarded(self._context, exc_value, traceback.format_tb(tb))
+            self._handler._receive_forwarded(
+                self._context, exc_value, traceback.format_tb(tb)
+            )
 
         # Suppress any exception from being re-raised:
         # https://docs.python.org/3/reference/datamodel.html#object.__exit__.

--- a/lib/test/benchpark/directives.py
+++ b/lib/test/benchpark/directives.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Introduces the `Experiment` class to encapsulate an experiment. An `Experiment` lives in a `Repo`, modeled after the repos in Spack/Ramble, and is written in an `experiment.py` file. An `Experiment` is instantiated and fetched from a repo based on a `ConcreteExperimentSpec`. A user supplies an `ExperimentSpec`, which is concretized to generate a `ConcreteExperimentSpec` with all options instantiated.

An `Experiment` can have a `variant`, which is defined using a `directive` as in Spack/Ramble.

The current Experiment repository is in `test_repo` and Benchpark is hardcoded to use that directory. This is just for WIP purposes. The only current Experiment is saxpy, and it is not in working condition yet at this point.

Calling code calls the `Experiment.write_ramble_dict()` method which calls per-section methods to construct the dictionary and writes it to yaml. Either the whole computation method or only the per-section methods can be overridden on a per-experiment-class basis.