### PR TITLE
rename section to match new ramble interface

### DIFF
--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -88,7 +88,7 @@ class Experiment(ExperimentSystemBase):
                 "config": self.compute_config_section(),
                 "modifiers": self.compute_modifiers_section(),
                 "applications": self.compute_applications_section(),
-                "spack": self.compute_spack_section(),
+                "software": self.compute_spack_section(),
             }
         }
 


### PR DESCRIPTION
Ramble interface changed `spack` to `software` in one spot

Question: do we update our internals to match, or only update our outputs.

This PR only does the outputs, but we could update the internals as well