### PR TITLE
cmd/experiment: --basedir use experiment_spec hash

### DIFF
--- a/lib/benchpark/cmd/experiment.py
+++ b/lib/benchpark/cmd/experiment.py
@@ -17,8 +17,8 @@ def experiment_init(args):
 
     if args.basedir:
         base = args.basedir
-        sysdir = experiment.experiment_id()
-        destdir = os.path.join(base, sysdir)
+        expdir = str(hash(experiment_spec))
+        destdir = os.path.join(base, expdir)
     elif args.dest:
         destdir = args.dest
     else:


### PR DESCRIPTION
Previously we used a nonexistent attribute.