### PR TITLE
Test `benchpark system init`

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -156,7 +156,7 @@ jobs:
           ./bin/benchpark setup kripke/rocm ./tioga-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/kripke/rocm/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/workspace \
+            --workspace-dir workspace/kripke/rocm/Tioga/workspace \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -152,7 +152,8 @@ jobs:
 
       - name: Dry run kripke/rocm on Tioga with allocation modifier
         run: |
-          ./bin/benchpark setup kripke/rocm LLNL-Tioga-HPECray-zen3-MI250X-Slingshot workspace/
+          ./bin/benchpark system init --dest=tioga-system tioga rocm=551 compiler=cce ~gtl
+          ./bin/benchpark setup kripke/rocm ./tioga-system workspace/
           . workspace/setup.sh
           ramble \
             --workspace-dir workspace/kripke/rocm/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/workspace \

--- a/docs/4-benchpark-setup.rst
+++ b/docs/4-benchpark-setup.rst
@@ -15,7 +15,7 @@ Also choose a directory for your experiment::
 where:
 
 - ``<Benchmark/ProgrammingModel>``: amg2023/openmp | amg2023/cuda | saxpy/openmp (available choices in ``benchpark/experiments``)
-- ``<System>``: nosite-x86_64 | LLNL-Sierra-IBM-power9-V100-Infiniband | RCCS-Fugaku-Fujitsu-A64FX-TofuD | nosite-AWS_PCluster_Hpc7a-zen4-EFA (available choices in :doc:`available-system-specs`)
+- ``<System>``: use ``benchpark system init``, or a predefined system in :doc:`available-system-specs`)
 
 This command will assemble a Ramble workspace per experiment
 with a configuration for the specified benchmark and system

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -7,9 +7,36 @@
 Adding a System Specification
 =============================
 
-``benchpark/configs`` contains a directory for each system specified in Benchpark.
-If your system is unlike the available configurations,
-you can add a new directory with a name which identifies the system.
+System specifications include details like
+
+- How many CPUs are there per node on the system
+- What pre-installed MPI/GPU libraries are available
+
+There are currently some static, pre-generated system descriptions available
+for use. These are intended to be useful for most experiment runs, but
+generally define multiple versions of resources which imposes additional
+complexity on the experiment definitions. The ``benchpark system init`` can
+generate more precise system definitions (e.g. ensuring there is only one
+instance of the CUDA libraries defined)
+
+Generate a customized system description with ``benchpark system init``
+-----------------------------------------------------------------------
+
+System classes are defined in ``var/sys_repo``. You can run
+``benchpark system init`` to generate a system configuration directory that
+can then be passed to ``benchpark setup``::
+
+    benchpark system init --dest=tioga-system tioga rocm=551 compiler=cce ~gtl
+
+where "tioga rocm=551 compiler=cce ~gtl" describes a config for Tioga that
+uses ROCm 5.5.1 components, a CCE compiler, and MPI without GTL support.
+
+Static System Configurations
+----------------------------
+
+``benchpark/configs`` contains a number of static, manually-generated system
+definitions. As an alternative to implementing a new ``System`` class, you
+can add a new directory with a name which identifies the system.
 
 The naming convention for the systems is as following::
 

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -12,19 +12,17 @@ System specifications include details like
 - How many CPUs are there per node on the system
 - What pre-installed MPI/GPU libraries are available
 
-There are currently some static, pre-generated system descriptions available
-for use. These are intended to be useful for most experiment runs, but
-generally define multiple versions of resources which imposes additional
-complexity on the experiment definitions. ``benchpark system init`` can
-generate more precise system definitions (e.g. ensuring there is only one
-instance of the CUDA libraries defined)
+A system description is a set of YAML files collected into a directory.
+You can generate these files directly, but Benchpark also provides an API
+where you can represent systems as objects and customize their description
+with command line arguments.
 
-Generate a customized system description with ``benchpark system init``
------------------------------------------------------------------------
+Using System API to Generate a System Description
+-------------------------------------------------
 
-System classes are defined in ``var/sys_repo``. You can run
-``benchpark system init`` to generate a system configuration directory that
-can then be passed to ``benchpark setup``::
+System classes are defined in ``var/sys_repo``; once the class has been
+defined, you can invoke ``benchpark system init`` to generate a system
+configuration directory that can then be passed to ``benchpark setup``::
 
     benchpark system init --dest=tioga-system tioga rocm=551 compiler=cce ~gtl
 

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -15,7 +15,7 @@ System specifications include details like
 There are currently some static, pre-generated system descriptions available
 for use. These are intended to be useful for most experiment runs, but
 generally define multiple versions of resources which imposes additional
-complexity on the experiment definitions. The ``benchpark system init`` can
+complexity on the experiment definitions. ``benchpark system init`` can
 generate more precise system definitions (e.g. ensuring there is only one
 instance of the CUDA libraries defined)
 
@@ -30,6 +30,17 @@ can then be passed to ``benchpark setup``::
 
 where "tioga rocm=551 compiler=cce ~gtl" describes a config for Tioga that
 uses ROCm 5.5.1 components, a CCE compiler, and MPI without GTL support.
+
+If you want to add support for a new system you can add a class definition
+for that system in a separate directory in ``var/sys_repo/systems/``. For
+example the Tioga system is defined in::
+
+  $benchpark
+  ├── var
+     ├── sys_repo
+        ├── systems
+           ├── tioga
+              ├── system.py
 
 Static System Configurations
 ----------------------------


### PR DESCRIPTION
Update an existing workflow using `benchpark setup; ramble workspace setup --dry-run` to use a system configuration generated with `benchpark system init`.

This should ensure that all necessary variables are defined in the system config as needed for the experiment (although does not ensure that the values are sensible - for that I think we'll have to run the benchmarks).

This also adds some initial documentation for `benchpark system init`.