### PR TITLE
Docs: Make System Configs Table Searchable

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -81,6 +81,10 @@ a:visited {
 .wy-side-nav-search img {
     background-color: #7fa866
 }
+.dataTables_wrapper .dataTables_filter {
+  float: unset;
+  text-align: right;
+}
 
 html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
     color: #7fa866

--- a/docs/_static/main.js
+++ b/docs/_static/main.js
@@ -1,3 +1,3 @@
 $(document).ready( function () {
-    $('csv-table.datatable').DataTable();
+    $('table.datatable').DataTable({paging: false});
 } );

--- a/docs/_static/main.js
+++ b/docs/_static/main.js
@@ -1,0 +1,3 @@
+$(document).ready( function () {
+    $('csv-table.datatable').DataTable();
+} );

--- a/docs/benchmark-list.rst
+++ b/docs/benchmark-list.rst
@@ -8,6 +8,7 @@ Benchmarks and Experiments
 ==========================
 
 .. csv-table:: Current Benchpark tags by Benchmark and tag groups.
+   :class: datatable
    :file: benchmark-list.csv
    :header-rows: 1
    :align: left

--- a/docs/benchmark-list.rst
+++ b/docs/benchmark-list.rst
@@ -8,7 +8,6 @@ Benchmarks and Experiments
 ==========================
 
 .. csv-table:: Current Benchpark tags by Benchmark and tag groups.
-   :class: datatable 
    :file: benchmark-list.csv
    :header-rows: 1
    :align: left

--- a/docs/benchmark-list.rst
+++ b/docs/benchmark-list.rst
@@ -8,7 +8,7 @@ Benchmarks and Experiments
 ==========================
 
 .. csv-table:: Current Benchpark tags by Benchmark and tag groups.
-   :class: datatable
+   :class: datatable 
    :file: benchmark-list.csv
    :header-rows: 1
    :align: left

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,17 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".spack-env"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_static_path = ["_static"]
-html_js_files = ['https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js', 'main.js',]
-html_css_files = [("https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css", {"priority": 800}), ("css/custom.css", {"priority": 999}) ]
+html_js_files = [
+    "https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js",
+    "main.js",
+]
+html_css_files = [
+    (
+        "https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css",
+        {"priority": 800},
+    ),
+    ("css/custom.css", {"priority": 999}),
+]
 html_logo = "_static/images/benchpark-dark.svg"
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {"logo_only": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,17 +39,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".spack-env"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
-html_css_files = ["css/custom.css"]
+html_js_files = ['https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js', 'main.js',]
+html_css_files = [("https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css", {"priority": 800}), ("css/custom.css", {"priority": 999}) ]
 html_logo = "_static/images/benchpark-dark.svg"
+html_theme = "sphinx_rtd_theme"
 html_theme_options = {"logo_only": True}
-
-html_css_files = [
-    'https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css',
-]
-
-html_js_files = [
-    'https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js',
-    'main.js',
-]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,3 +44,12 @@ html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 html_logo = "_static/images/benchpark-dark.svg"
 html_theme_options = {"logo_only": True}
+
+html_css_files = [
+    'https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css',
+]
+
+html_js_files = [
+    'https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js',
+    'main.js',
+]

--- a/docs/generate-sys-defs-list.py
+++ b/docs/generate-sys-defs-list.py
@@ -45,30 +45,18 @@ def main():
         list_of_strings.append(", ".join(item for item in i if item))
     df.loc[:, "system_definition.top500-system-instances"] = list_of_strings
 
-    # Set index to be system names
-    df.set_index("system_definition.name", inplace=True)
-    df.index.name = ""  # remove system_definition.name from cell
-    df_tpose = df.T
-
     # Remove system_definition from all field names
     # (e.g., system_definition.system-tested.description)
-    df_tpose["fielddesc"] = df_tpose.index
-    df_tpose[["first", ""]] = df_tpose["fielddesc"].str.split(".", n=1, expand=True)
-
-    # Add ** to either side of field names for bold rendering in RST
-    df_tpose[""] = "**" + df_tpose[""] + "**"
-
-    # Drop temporary columns
-    df_tpose.drop(["first", "fielddesc"], axis=1, inplace=True)
+    df.columns = df.columns.str.removeprefix('system_definition.')
 
     # Replace NaN with empty string
-    df_tpose.fillna("", inplace=True)
+    df.fillna("", inplace=True)
 
     # Set index to be field names
-    df_tpose.set_index([""], inplace=True)
+    df.set_index("name", inplace=True)
 
     # Write out current system definitions to CSV format
-    df_tpose.to_csv("current-system-definitions.csv")
+    df.to_csv("current-system-definitions.csv")
 
 
 if __name__ == "__main__":

--- a/docs/generate-sys-defs-list.py
+++ b/docs/generate-sys-defs-list.py
@@ -47,7 +47,7 @@ def main():
 
     # Remove system_definition from all field names
     # (e.g., system_definition.system-tested.description)
-    df.columns = df.columns.str.removeprefix('system_definition.')
+    df.columns = df.columns.str.removeprefix("system_definition.")
 
     # Replace NaN with empty string
     df.fillna("", inplace=True)

--- a/docs/system-list.rst
+++ b/docs/system-list.rst
@@ -16,3 +16,4 @@ use as the ``system`` parameter in ``Benchpark setup``. See
    :class: datatable
    :file: current-system-definitions.csv
    :header-rows: 1
+   :align: left

--- a/docs/system-list.rst
+++ b/docs/system-list.rst
@@ -16,4 +16,3 @@ use as the ``system`` parameter in ``Benchpark setup``. See
    :class: datatable
    :file: current-system-definitions.csv
    :header-rows: 1
-   :align: left

--- a/docs/system-list.rst
+++ b/docs/system-list.rst
@@ -13,6 +13,7 @@ use as the ``system`` parameter in ``Benchpark setup``. See
 :doc:`4-benchpark-setup` for more details.
 
 .. csv-table:: Current System Specifications in Benchpark.
+   :class: datatable
    :file: current-system-definitions.csv
    :header-rows: 1
    :align: left


### PR DESCRIPTION
Addresses issue #241 

The system config table now has a search bar and sortable columns, I undid the table transpose that was originally there so that sorting by column makes sense, but if preferred I can revert to the transposed table and remove sorting functionality. Table still has horizontal scroll as well (just can't see it in the screenshots).

New searchable table:
<img width="1166" alt="new_table" src="https://github.com/user-attachments/assets/bf19604e-8343-4907-94dc-149bc1ac90b2">
<img width="1169" alt="table_with_search" src="https://github.com/user-attachments/assets/57d379ea-e763-4374-ba77-d2809681b9d4">
