### PR TITLE
allow conditional variant definition

### DIFF
--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -53,6 +53,53 @@ class DirectiveMeta(ramble.language.shared_language.SharedMeta):
 benchpark_directive = DirectiveMeta.directive
 
 
+def _make_when_spec(
+    value: Optional[Union["benchpark.spec.Spec", str, bool]]
+) -> Optional["benchpark.spec.Spec"]:
+    """Create a ``Spec`` that indicates when a directive should be applied.
+
+    Directives with ``when`` specs, e.g.:
+
+        patch('foo.patch', when='@4.5.1:')
+        depends_on('mpi', when='+mpi')
+        depends_on('readline', when=sys.platform() != 'darwin')
+
+    are applied conditionally depending on the value of the ``when``
+    keyword argument.  Specifically:
+
+      1. If the ``when`` argument is ``True``, the directive is always applied
+      2. If it is ``False``, the directive is never applied
+      3. If it is a ``Spec`` string, it is applied when the package's
+         concrete spec satisfies the ``when`` spec.
+
+    The first two conditions are useful for the third example case above.
+    It allows package authors to include directives that are conditional
+    at package definition time, in additional to ones that are evaluated
+    as part of concretization.
+
+    Arguments:
+        value: a conditional Spec, constant ``bool``, or None if not supplied
+           value indicating when a directive should be applied.
+
+    """
+    if isinstance(value, benchpark.spec.Spec):
+        return value
+
+    # Unsatisfiable conditions are discarded by the caller, and never
+    # added to the package class
+    if value is False:
+        return None
+
+    # If there is no constraint, the directive should always apply;
+    # represent this by returning the unconstrained `Spec()`, which is
+    # always satisfied.
+    if value is None or value is True:
+        return benchpark.spec.Spec()
+
+    # This is conditional on the spec
+    return benchpark.spec.Spec(value)
+
+
 @benchpark_directive("variants")
 def variant(
     name: str,
@@ -82,6 +129,8 @@ def variant(
     Raises:
         DirectiveError: If arguments passed to the directive are invalid
     """
+    if sticky:
+        raise NotImplementedError("Sticky variants are not yet implemented in Ramble")
 
     def format_error(msg, pkg):
         msg += " @*r{{[{0}, variant '{1}']}}"
@@ -140,12 +189,15 @@ def variant(
     description = str(description).strip()
 
     def _execute_variant(pkg):
+        when_spec = _make_when_spec(when)
+
         if not re.match(benchpark.spec.IDENTIFIER, name):
             directive = "variant"
             msg = "Invalid variant name in {0}: '{1}'"
             raise DirectiveError(directive, msg.format(pkg.name, name))
 
-        pkg.variants[name] = benchpark.variant.Variant(
+        variants_by_name = pkg.variants.setdefault(when_spec, {})
+        variants_by_name[name] = benchpark.variant.Variant(
             name, default, description, values, multi, validator, sticky
         )
 

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Tuple
+from typing import Dict
 import yaml  # TODO: some way to ensure yaml available
 
 from benchpark.directives import ExperimentSystemBase

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -44,8 +44,8 @@ class Experiment(ExperimentSystemBase):
 
     # This allows analysis tools to correctly interpret the class attributes.
     variants: Dict[
-        str,
-        Tuple["benchpark.variant.Variant", "benchpark.spec.ConcreteExperimentSpec"],
+        "benchpark.spec.Spec",
+        Dict[str, benchpark.variant.Variant],
     ]
 
     def __init__(self, spec):

--- a/lib/benchpark/variant.py
+++ b/lib/benchpark/variant.py
@@ -86,6 +86,14 @@ class Variant:
         if not_allowed_values:
             raise ValueError(f"{not_allowed_values} are not valid values for {pkg_cls}")
 
+    def validate_values_bool(self, *args, **kwargs):
+        """Wrapper around ``validate_values`` that returns boolean instead of raising."""
+        try:
+            self.validate_values(*args, **kwargs)
+            return True
+        except Exception:
+            return False
+
     @property
     def allowed_values(self):
         """Returns a string representation of the allowed values for


### PR DESCRIPTION
This allows things like:

```
    variant(                                                                                                                                                                                                                   
        "programming_model",                                                                                                                                                                                                   
        default="openmp",                                                                                                                                                                                                      
        values=("openmp", "cuda", "rocm"),                                                                                                                                                                                     
        description="on-node parallelism model",                                                                                                                                                                               
    )                                                                                                                                                                                                                          
                                                                                                                                                                                                                               
    variant(                                                                                                                                                                                                                   
        "openmp_numthreads",                                                                                                                                                                                                   
        default="12",                                                                                                                                                                                                          
        values=int,                                                                                                                                                                                                            
        when="programming_model=openmp",                                                                                                                                                                                       
        description="testing",                                                                                                                                                                                                 
    )                                                                                                                                                                                                                          
    variant(                                                                                                                                                                                                                   
        "rocm_version",                                                                                                                                                                                                        
        default="5.5.1",                                                                                                                                                                                                       
        values=("5.5.1", "6.0.2"),                                                                                                                                                                                             
        when="programming_model=rocm",                                                                                                                                                                                         
        description="testing",                                                                                                                                                                                                 
    )
```

The concretizer updates in this PR allow concretizing `foo rocm_version=6.0.2`, and the concretizer is smart enough to know that it needs the non-default setting `programming_model=rocm`.