### PR TITLE
Fix Tioga system class

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -187,11 +187,11 @@ jobs:
       - name: Dry run dynamic saxpy/rocm with dynamic Tioga
         run: |
           ./bin/benchpark system init --dest=tioga-system2 tioga rocm=551 compiler=cce ~gtl
-          ./bin/benchpark experiment init --dest=saxpy-rocm saxpy programming_model=rocm
-          ./bin/benchpark setup ./saxpy-rocm ./tioga-system2 workspace/
+          ./bin/benchpark experiment init --dest=saxpy-rocm2 saxpy programming_model=rocm
+          ./bin/benchpark setup ./saxpy-rocm2 ./tioga-system2 workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-rocm/Tioga-d34a754/workspace \
+            --workspace-dir workspace/saxpy-rocm2/Tioga-d34a754/workspace \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -184,18 +184,17 @@ jobs:
             --disable-logger \
             workspace setup --dry-run
 
-# TODO: mixing dynamic saxpy with dynamic Tioga fails
-#      - name: Dry run dynamic saxpy/rocm with dynamic Tioga
-#        run: |
-#          ./bin/benchpark system init --dest=tioga-system2 tioga rocm=551 compiler=cce ~gtl
-#          ./bin/benchpark experiment init --dest=saxpy-rocm saxpy programming_model=rocm
-#          ./bin/benchpark setup ./saxpy-rocm ./tioga-system2 workspace/
-#          . workspace/setup.sh
-#          ramble \
-#            --workspace-dir workspace/saxpy-rocm/Tioga-d34a754/workspace \
-#            --disable-progress-bar \
-#            --disable-logger \
-#            workspace setup --dry-run
+      - name: Dry run dynamic saxpy/rocm with dynamic Tioga
+        run: |
+          ./bin/benchpark system init --dest=tioga-system2 tioga rocm=551 compiler=cce ~gtl
+          ./bin/benchpark experiment init --dest=saxpy-rocm saxpy programming_model=rocm
+          ./bin/benchpark setup ./saxpy-rocm ./tioga-system2 workspace/
+          . workspace/setup.sh
+          ramble \
+            --workspace-dir workspace/saxpy-rocm/Tioga-d34a754/workspace \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace setup --dry-run
 
       - name: Dry run laghos/mpi-only on LLNL-Magma-Penguin-icelake-OmniPath with allocation modifier
         run: |

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -148,6 +148,9 @@ system:
 
         self._merge_config_files(compilers_schema.schema, selections, aux_compilers)
 
+    def system_specific_variables(self):
+        return {}
+
     def variables_yaml(self):
         for attr in self.required:
             if not getattr(self, attr, None):
@@ -158,9 +161,17 @@ system:
         for opt in ["sys_gpus_per_node", "sys_mem_per_node", "queue"]:
             if getattr(self, opt, None):
                 optionals.append(f"{opt}: {getattr(self, opt)}")
+
+        system_specific = list()
+        for k, v in self.system_specific_variables().items():
+            system_specific.append(f"{k}: {v}")
+
+        extra_variables = optionals + system_specific
         indent = " " * 2
-        if optionals:
-            optionals_as_cfg = f"\n{indent}".join(optionals)
+        extras_as_cfg = ""
+        if extra_variables:
+            extras_as_cfg = f"\n{indent}".join(extra_variables)
+
         return f"""\
 # SPDX-License-Identifier: Apache-2.0
 
@@ -168,7 +179,7 @@ variables:
   timeout: "{self.timeout}"
   scheduler: "{self.scheduler}"
   sys_cores_per_node: "{self.sys_cores_per_node}"
-  {optionals_as_cfg}
+  {extras_as_cfg}
   max_request: "1000"  # n_ranks/n_nodes cannot exceed this
   n_ranks: '1000001'  # placeholder value
   n_nodes: '1000001'  # placeholder value

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -157,7 +157,6 @@ system:
                 raise ValueError(f"Missing required info: {attr}")
 
         optionals = list()
-        optionals_as_cfg = ""
         for opt in ["sys_gpus_per_node", "sys_mem_per_node", "queue"]:
             if getattr(self, opt, None):
                 optionals.append(f"{opt}: {getattr(self, opt)}")

--- a/var/exp_repo/experiments/saxpy/experiment.py
+++ b/var/exp_repo/experiments/saxpy/experiment.py
@@ -41,13 +41,18 @@ class Saxpy(Experiment):
         }
         the_experiment.update(matrix_cfg)
 
+        if self.spec.satisfies("programming_model=openmp"):
+            experiment_id = "saxpy_{n}_{n_nodes}_{omp_num_threads}"
+        elif self.spec.satisfies("programming_model=cuda") or self.spec.satisfies("programming_model=rocm"):
+            experiment_id = "saxpy_{n}"
+
         return {
             "saxpy": {  # ramble Application name
                 "workloads": {
                     # TODO replace with a hash once we have one?
                     "problem": {
                         "experiments": {
-                            "saxpy_{n}_{n_nodes}_{omp_num_threads}": the_experiment,
+                            experiment_id: the_experiment,
                         }
                     }
                 }

--- a/var/exp_repo/experiments/saxpy/experiment.py
+++ b/var/exp_repo/experiments/saxpy/experiment.py
@@ -43,7 +43,9 @@ class Saxpy(Experiment):
 
         if self.spec.satisfies("programming_model=openmp"):
             experiment_id = "saxpy_{n}_{n_nodes}_{omp_num_threads}"
-        elif self.spec.satisfies("programming_model=cuda") or self.spec.satisfies("programming_model=rocm"):
+        elif self.spec.satisfies("programming_model=cuda") or self.spec.satisfies(
+            "programming_model=rocm"
+        ):
             experiment_id = "saxpy_{n}"
 
         return {

--- a/var/sys_repo/systems/tioga/system.py
+++ b/var/sys_repo/systems/tioga/system.py
@@ -89,6 +89,9 @@ class Tioga(System):
 
         return selections
 
+    def system_specific_variables(self):
+        return {"rocm_arch": "gfx90a"}
+
     def sw_description(self):
         """This is somewhat vestigial: for the Tioga config that is committed
         to the repo, multiple instances of mpi/compilers are stored and


### PR DESCRIPTION
The `tioga` system (used by `benchpark system init`)  was not setting `rocm_arch`

With the changes here, the dynamic-Tioga/dynamic-saxpy test from https://github.com/LLNL/benchpark/pull/368 is working