### PR TITLE
fix license/copyright information

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -7,6 +7,9 @@ or http://www.apache.org/licenses/LICENSE-2.0).
 Copyrights and patents in the Benchpark project are retained by contributors.
 No copyright assignment is required to contribute to Benchpark.
 
+Benchpark is derived from Ramble and Spack.
+Ramble: https://github.com/GoogleCloudPlatform/ramble
+Spack: https://github.com/spack/spack
 
 SPDX usage
 ------------

--- a/lib/benchpark/cmd/experiment.py
+++ b/lib/benchpark/cmd/experiment.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2013-2023 Spack Project Developers.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2013-2023 Spack Project Developers.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/lib/benchpark/cmd/system.py
+++ b/lib/benchpark/cmd/system.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2013-2023 Spack Project Developers.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -1,6 +1,10 @@
 # Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2022-2024 The Ramble Authors
+#
+# Copyright 2013-2024 Spack Project Developers
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import collections.abc

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -1,10 +1,9 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
 # Copyright 2022-2024 The Ramble Authors
 #
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
+# SPDX-License-Identifier: Apache-2.0
 
 import sys
 import contextlib

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
 from contextlib import contextmanager
 import os
 import pathlib

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -1,3 +1,10 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2013-2024 Spack project developers
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import enum
 import pathlib
 import re

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib

--- a/lib/benchpark/variant.py
+++ b/lib/benchpark/variant.py
@@ -1,3 +1,9 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2013-2024 Spack project developers
+#
+# SPDX-License-Identifier: Apache-2.0
 import inspect
 
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2013-2024 Spack project developers
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse


### PR DESCRIPTION
I have not modified the files under `configs` and `experiments`, since we are in the process of phasing those files out of Benchpark. For technical correctness, they are covered by the overall license of the repo.

I have not put license information on pure config files (e.g. `.github/workflows/*`), in keeping with the style seen in other repos including Ramble and Spack. If those files are copyrightable, they are covered by the overall LICENSE and COPYRIGHT files for the repo.

Code files for which the code comes entirely from benchpark, regardless of whether the concepts come entirely from benchpark, are marked as copyright of the LLNS and other benchpark project developers. The new IP attribution from the `COPYRIGHT` file applies, denoting that the entire project is derived from Ramble and Spack. Files that contain code from either Ramble or Spack and are modified by Benchpark are marked copyright of both the original authors and the benchpark project developers, in accordance with the Apache License requirement to note when code has been modified. We do not have any files containing unmodified code from other projects.

We should make sure in code review to ensure we are vigilant about keeping this up-to-date for both new files and for additions of copied code from the older projects into files that do not already contain copyright information from that project.