### PR TITLE
New command: `benchpark audit`

### DIFF
--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -22,7 +22,7 @@ def audit_experiment(exp_cls):
     errors = list()
 
     for method in required_methods:
-        if method  not in exp_cls.__dict__:
+        if method not in exp_cls.__dict__:
             errors.append(f"{exp_cls.__name__} does not implement {method}")
 
     return errors

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -10,7 +10,7 @@ import sys
 
 import benchpark.paths
 import benchpark.repo
-import benchpark.system as system
+# import benchpark.system as system
 from benchpark.runtime import RuntimeResources
 
 bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+def setup_parser(subparser):
+    pass
+
+
+def command(args):
+    pass

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -3,9 +3,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import benchpark.repo
+
+sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
+exp_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
+
 def setup_parser(subparser):
     pass
 
 
+def audit_experiment(exp_cls):
+    required_methods = ["compute_applications_section"]
+
+    for method in required_methods:
+        if method  not in exp_cls.__dict__:
+            raise ValueError(f"{exp_class.__name__} does not implement {method}")
+
+
 def command(args):
-    pass
+    for exp_name in exp_repo.all_object_names():
+        exp_cls = exp_repo.get_obj_class(exp_name)
+        audit_experiment(exp_cls)

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -5,12 +5,19 @@
 
 import os
 import pathlib
+import re
 import sys
 
+import benchpark.paths
 import benchpark.repo
 import benchpark.system as system
+from benchpark.runtime import RuntimeResources
 
-import ramble.config as cfg
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper.bootstrap()  # noqa
+
+import ramble.config as cfg  # noqa
+
 
 sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 exp_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
@@ -40,18 +47,43 @@ def _find_yaml_files(d):
     return yaml_files
 
 
+# TODO: when .template_dir is fixed, this won't be needed
+def _path_for_system_class(sys_cls):
+    name = sys_cls.__name__
+    component = ""
+    components = []
+    for letter in name:
+        if re.match("[A-Z]", letter):
+            if component:
+                components.append(component)
+            component = letter
+        else:
+            component += letter
+    if component:
+        components.append(component)
+    system_dirname = "-".join(x.lower() for x in components)
+    basedir = pathlib.Path(sys_repo.filename_for_object_name(sys_cls.__name__)).parent.parent
+    assert basedir.exists()
+    return basedir / system_dirname
+
+
 def audit_system(sys_cls):
     errors = list()
-    basedir = pathlib.Path(sys_repo.filename_for_object_name(sys_cls.__name__)).parent
+    basedir = _path_for_system_class(sys_cls)
     externals = basedir / "externals"
     if externals.exists():
         for f in _find_yaml_files(externals):
-            cfg.read_config_file(f, system.packages_schema)
+            pass
+            # TODO: this fails for reasons I don't understand, even though
+            # this duplicates logic from system.py
+            # cfg.read_config_file(f, system.packages_schema)
 
     compilers = basedir / "compilers"
     if compilers.exists():
         for f in _find_yaml_files(compilers):
-            cfg.read_config_file(f, system.compilers_schema)
+            pass
+            # cfg.read_config_file(f, system.compilers_schema)
+            # TODO: same problem as prior loop
     return errors
 
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -17,7 +17,7 @@ def setup_parser(subparser):
 
 
 def audit_experiment(exp_cls):
-    required_methods = ["compute_applications_section"]
+    required_methods = ["compute_applications_section", "compute_spack_section"]
 
     errors = list()
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -62,7 +62,9 @@ def _path_for_system_class(sys_cls):
     if component:
         components.append(component)
     system_dirname = "-".join(x.lower() for x in components)
-    basedir = pathlib.Path(sys_repo.filename_for_object_name(sys_cls.__name__)).parent.parent
+    basedir = pathlib.Path(
+        sys_repo.filename_for_object_name(sys_cls.__name__)
+    ).parent.parent
     assert basedir.exists()
     return basedir / system_dirname
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 import benchpark.repo
+
 
 sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 exp_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
+
 
 def setup_parser(subparser):
     pass
@@ -15,12 +19,24 @@ def setup_parser(subparser):
 def audit_experiment(exp_cls):
     required_methods = ["compute_applications_section"]
 
+    errors = list()
+
     for method in required_methods:
         if method  not in exp_cls.__dict__:
-            raise ValueError(f"{exp_class.__name__} does not implement {method}")
+            errors.append(f"{exp_cls.__name__} does not implement {method}")
+
+    return errors
 
 
 def command(args):
+    all_errors = list()
+
     for exp_name in exp_repo.all_object_names():
         exp_cls = exp_repo.get_obj_class(exp_name)
-        audit_experiment(exp_cls)
+        all_errors.extend(audit_experiment(exp_cls))
+
+    for error in all_errors:
+        print(error)
+
+    if all_errors:
+        sys.exit(1)

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -10,6 +10,7 @@ import sys
 
 import benchpark.paths
 import benchpark.repo
+
 # import benchpark.system as system
 from benchpark.runtime import RuntimeResources
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import pathlib
 import sys
 
 import benchpark.repo
+import benchpark.system as system
 
+import ramble.config as cfg
 
 sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 exp_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
@@ -28,12 +32,39 @@ def audit_experiment(exp_cls):
     return errors
 
 
+def _find_yaml_files(d):
+    yaml_files = list()
+    for root, dirs, files in os.walk(d):
+        root = pathlib.Path(root)
+        yaml_files.extend((root / f) for f in files if f.endswith(".yaml"))
+    return yaml_files
+
+
+def audit_system(sys_cls):
+    errors = list()
+    basedir = pathlib.Path(sys_repo.filename_for_object_name(sys_cls.__name__)).parent
+    externals = basedir / "externals"
+    if externals.exists():
+        for f in _find_yaml_files(externals):
+            cfg.read_config_file(f, system.packages_schema)
+
+    compilers = basedir / "compilers"
+    if compilers.exists():
+        for f in _find_yaml_files(compilers):
+            cfg.read_config_file(f, system.compilers_schema)
+    return errors
+
+
 def command(args):
     all_errors = list()
 
     for exp_name in exp_repo.all_object_names():
         exp_cls = exp_repo.get_obj_class(exp_name)
         all_errors.extend(audit_experiment(exp_cls))
+
+    for sys_name in sys_repo.all_object_names():
+        sys_cls = sys_repo.get_obj_class(sys_name)
+        all_errors.extend(audit_system(sys_cls))
 
     for error in all_errors:
         print(error)

--- a/lib/main.py
+++ b/lib/main.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import yaml
 
+import benchpark.cmd.audit
 import benchpark.cmd.system
 import benchpark.cmd.experiment
 import benchpark.cmd.setup
@@ -212,10 +213,15 @@ def init_commands(subparsers, actions_dict):
     )
     benchpark.cmd.unit_test.setup_parser(unit_test_parser)
 
+    audit_parser = subparsers.add_parser(
+        "audit", help="Look for problems in System/Experiment repos"
+    )
+
     actions_dict["system"] = benchpark.cmd.system.command
     actions_dict["experiment"] = benchpark.cmd.experiment.command
     actions_dict["setup"] = benchpark.cmd.setup.command
     actions_dict["unit-test"] = benchpark.cmd.unit_test.command
+    actions_dict["audit"] = benchpark.cmd.audit.command
 
 
 def run_command(command_str, env=None):

--- a/lib/main.py
+++ b/lib/main.py
@@ -216,6 +216,7 @@ def init_commands(subparsers, actions_dict):
     audit_parser = subparsers.add_parser(
         "audit", help="Look for problems in System/Experiment repos"
     )
+    benchpark.cmd.audit.setup_parser(audit_parser)
 
     actions_dict["system"] = benchpark.cmd.system.command
     actions_dict["experiment"] = benchpark.cmd.experiment.command


### PR DESCRIPTION
`benchpark audit` (no options or arguments at the moment) checks all Experiment subclass definitions for basic errors (which would otherwise need to be caught by instantiating the experiment).

Right now it only performs one simple check: the Experiment subclass must include a definition of each method that is abstract in the base class.

The audit imports each Experiment, so it can also catch some basic errors that would otherwise not occur until doing `benchpark experiment init`.

Other possible checks for experiments:

* If the `Experiment` starts referring to a `System`, the audit could make sure that the `System` is defined
* It could warn about a variant defining a value like `cuda` that is not called `programming_model`

It could likewise perform checks on Systems (but does not at the moment):

* Are all the config files in the experiment valid spack configs (or rather, are they either valid `packages.yaml` or `compilers.yaml`