### PR TITLE
docs: fix ramble links

### DIFF
--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -242,7 +242,7 @@ The following yaml files are examples of what is generated for the modified_x86 
 manager (Spack) should use to build the benchmarks on this system.
 ``software.yaml`` becomes the spack section in the `Ramble configuration
 file
-<https://googlecloudplatform.github.io/ramble/configuration_files.html#spack-config>`_.
+<https://ramble.readthedocs.io/en/latest/configuration_files.html#external-spack-environment-support>`_.
 
 .. code-block:: yaml
 

--- a/docs/add-an-experiment.rst
+++ b/docs/add-an-experiment.rst
@@ -56,10 +56,10 @@ For example, to run the AMG2023 strong scaling experiment for problem 1, using C
 
 Initializing an experiment generates the following yaml files:
 
-- ``ramble.yaml`` defines the `Ramble specs <https://googlecloudplatform.github.io/ramble/workspace_config.html#workspace-config>`_ for building, running, analyzing and archiving experiments.
+- ``ramble.yaml`` defines the `Ramble specs <https://ramble.readthedocs.io/en/latest/workspace_config.html#>`_ for building, running, analyzing and archiving experiments.
 - ``execution_template.tpl`` serves as a template for the final experiment script that will be concretized and executed.
 
-A detailed description of Ramble configuration files is available at `Ramble workspace_config <https://googlecloudplatform.github.io/ramble/workspace_config.html>`_.
+A detailed description of Ramble configuration files is available at `Ramble workspace_config <https://ramble.readthedocs.io/en/latest/workspace_config.html#>`_.
 
 For more advanced usage, such as customizing hardware allocation or performance profiling see :doc:`modifiers`.
 

--- a/docs/analyze-experiment.rst
+++ b/docs/analyze-experiment.rst
@@ -12,5 +12,5 @@ Once the experiments completed running, the command::
   ramble --disable-progress-bar --workspace-dir . workspace analyze 
 
 can be used to analyze figures of merit and evaluate 
-`success/failure <https://googlecloudplatform.github.io/ramble/success_criteria.html>`_ 
+`success/failure <https://ramble.readthedocs.io/en/latest/success_criteria.html#success-criteria>`
 of the experiments. Ramble generates a file with summary of the results in ``$workspace``.

--- a/docs/benchpark-setup.rst
+++ b/docs/benchpark-setup.rst
@@ -45,7 +45,7 @@ with the following directory structure::
 
 The ``setup.sh`` script calls the Spack and Ramble setup scripts.  It optionally accepts
 parameters to ``ramble workspace setup`` as `documented in Ramble
-<https://googlecloudplatform.github.io/ramble/workspace.html#setting-up-a-workspace>`_,
+<https://ramble.readthedocs.io/en/latest/getting_started.html#setting-up-a-workspace>`_,
 including ``--dry-run`` and ``--phases make_experiments``.
 
 Now you are ready to compile your experiments as described in :doc:`build-experiment`.

--- a/docs/modifiers.rst
+++ b/docs/modifiers.rst
@@ -7,7 +7,7 @@
 Benchpark Modifiers
 =====================
 In Benchpark, a ``modifier`` follows the `Ramble Modifier
-<https://googlecloudplatform.github.io/ramble/tutorials/10_using_modifiers.html#modifiers>`_
+<https://ramble.readthedocs.io/en/latest/tutorials/10_using_modifiers.html>`_
 and is an abstract object that can be applied to a large set of reproducible
 specifications. Modifiers are intended to encapsulate reusable patterns that
 perform a specific configuration of an experiment. This may include injecting


### PR DESCRIPTION
Links to ramble docs have moved, this updates the links in our benchpark docs.