### PR TITLE
Improvements to `benchpark audit`

### DIFF
--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -11,7 +11,7 @@ import sys
 import benchpark.paths
 import benchpark.repo
 
-# import benchpark.system as system
+import benchpark.system as system
 from benchpark.runtime import RuntimeResources
 
 bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
@@ -80,17 +80,12 @@ def audit_system(sys_cls):
     externals = basedir / "externals"
     if externals.exists():
         for f in _find_yaml_files(externals):
-            pass
-            # TODO: this fails for reasons I don't understand, even though
-            # this duplicates logic from system.py
-            # cfg.read_config_file(f, system.packages_schema)
+            cfg.read_config_file(f, system.packages_schema.schema)
 
     compilers = basedir / "compilers"
     if compilers.exists():
         for f in _find_yaml_files(compilers):
-            pass
-            # cfg.read_config_file(f, system.compilers_schema)
-            # TODO: same problem as prior loop
+            cfg.read_config_file(f, system.compilers_schema.schema)
     return errors
 
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -31,6 +31,10 @@ def setup_parser(subparser):
 def audit_experiment(exp_cls):
     required_methods = ["compute_applications_section", "compute_spack_section"]
 
+    if exp_cls.__name__ == "Caliper":
+        # Caliper is an abstract class, and is never directly instantiated
+        return []
+
     errors = list()
 
     for method in required_methods:

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -82,7 +82,6 @@ class RuntimeResources:
         self.spack_location = self.dest / "spack"
 
     def bootstrap(self):
-        print("Hold tight, Benchpark is bootstrapping itself.")
         if not self.ramble_location.exists():
             self._install_ramble()
         ramble_lib_path = self.ramble_location / "lib" / "ramble"


### PR DESCRIPTION
* Right now `benchpark audit` will fail on caliper because it doesn't define some methods: skip it (it's abstract and doesn't need to)
* This now audits the config files distributed with systems verifying 
  * That it is valid yaml
  * and also follows the Spack section schema (e.g. that properties are not mispelled)
    * This doesn't guarantee that all generated configs are valid (in particular `sierra` is an example of this, because it dynamically generates some configs), but it gets pretty close

I also reduced the verbosity of messages for bootstrapping: other edits that were packaged with that change should print messages when things are in fact going slow.