### PR TITLE
`benchpark setup`: easier referencing of dynamically generated systems

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -177,9 +177,10 @@ jobs:
         run: |
           ./bin/benchpark system init --dest=tioga-system tioga rocm=551 compiler=cce ~gtl
           ./bin/benchpark setup kripke/rocm ./tioga-system workspace/
+          system_id=$(./bin/benchpark system id ./tioga-system)
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/kripke/rocm/Tioga-975af3c/workspace \
+            --workspace-dir "workspace/kripke/rocm/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -198,11 +199,12 @@ jobs:
       - name: Dry run dynamic saxpy/rocm with dynamic Tioga
         run: |
           ./bin/benchpark system init --dest=tioga-system2 tioga rocm=551 compiler=cce ~gtl
+          system_id=$(./bin/benchpark system id ./tioga-system2)
           ./bin/benchpark experiment init --dest=saxpy-rocm2 saxpy+rocm
           ./bin/benchpark setup ./saxpy-rocm2 ./tioga-system2 workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-rocm2/Tioga-975af3c/workspace \
+            --workspace-dir "workspace/saxpy-rocm2/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -210,11 +212,12 @@ jobs:
       - name: Dry run dynamic saxpy/cuda with dynamic Sierra
         run: |
           ./bin/benchpark system init --dest=sierra-system sierra cuda=10-1-243 compiler=xl
+          system_id=$(./bin/benchpark system id ./sierra-system)
           ./bin/benchpark experiment init --dest=saxpy-cuda saxpy+cuda
           ./bin/benchpark setup ./saxpy-cuda ./sierra-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-cuda/Sierra-bdc4915/workspace \
+            --workspace-dir "workspace/saxpy-cuda/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -334,11 +337,12 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic CTS ruby
         run: |
           ./bin/benchpark system init --dest=ruby-system cts cluster=ruby
+          system_id=$(./bin/benchpark system id ./ruby-system)
           ./bin/benchpark experiment init --dest=saxpy-openmp saxpy+openmp
           ./bin/benchpark setup ./saxpy-openmp ./ruby-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-openmp/Cts-6d48f81/workspace \
+            --workspace-dir "workspace/saxpy-openmp/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -346,11 +350,12 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic CTS dane
         run: |
           ./bin/benchpark system init --dest=dane-system cts cluster=dane
+          system_id=$(./bin/benchpark system id ./dane-system)
           ./bin/benchpark experiment init --dest=saxpy-openmp2 saxpy+openmp
           ./bin/benchpark setup ./saxpy-openmp2 ./dane-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-openmp2/Cts-2c51a80/workspace \
+            --workspace-dir "workspace/saxpy-openmp2/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -358,11 +363,12 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic CTS magma
         run: |
           ./bin/benchpark system init --dest=magma-system cts cluster=magma
+          system_id=$(./bin/benchpark system id ./magma-system)
           ./bin/benchpark experiment init --dest=saxpy-openmp3 saxpy+openmp
           ./bin/benchpark setup ./saxpy-openmp3 ./magma-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-openmp3/Cts-54a5761/workspace \
+            --workspace-dir "workspace/saxpy-openmp3/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -370,22 +376,24 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic generic x86
         run: |
           ./bin/benchpark system init --dest=x86-system genericx86
+          system_id=$(./bin/benchpark system id ./x86-system)
           ./bin/benchpark experiment init --dest=saxpy-omp-generic saxpy+openmp
           ./bin/benchpark setup ./saxpy-omp-generic ./x86-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/saxpy-omp-generic/Genericx86-040898b/workspace \
+            --workspace-dir "workspace/saxpy-omp-generic/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
 
       - name: Dry run dynamic ior/mpi with dynamic CTS ruby
         run: |
+          system_id=$(./bin/benchpark system id ./ruby-system)
           ./bin/benchpark experiment init --dest=ior-mpi ior
           ./bin/benchpark setup ./ior-mpi ./ruby-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir workspace/ior-mpi/Cts-6d48f81/workspace \
+            --workspace-dir "workspace/ior-mpi/$system_id/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -363,12 +363,11 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic CTS magma
         run: |
           ./bin/benchpark system init --dest=magma-system cts cluster=magma
-          system_id=$(./bin/benchpark system id ./magma-system)
           ./bin/benchpark experiment init --dest=saxpy-openmp3 saxpy+openmp
           ./bin/benchpark setup ./saxpy-openmp3 ./magma-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir "workspace/saxpy-openmp3/$system_id/workspace" \
+            --workspace-dir "workspace/saxpy-openmp3/magma-system/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
@@ -376,12 +375,11 @@ jobs:
       - name: Dry run dynamic saxpy/openmp with dynamic generic x86
         run: |
           ./bin/benchpark system init --dest=x86-system genericx86
-          system_id=$(./bin/benchpark system id ./x86-system)
           ./bin/benchpark experiment init --dest=saxpy-omp-generic saxpy+openmp
           ./bin/benchpark setup ./saxpy-omp-generic ./x86-system workspace/
           . workspace/setup.sh
           ramble \
-            --workspace-dir "workspace/saxpy-omp-generic/$system_id/workspace" \
+            --workspace-dir "workspace/saxpy-omp-generic/x86-system/workspace" \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -170,7 +170,9 @@ def command(args):
 
     workspace_dir.mkdir(parents=True)
     if simple_system_name:
-        os.symlink(workspace_dir, experiments_root / str(experiment_id) / simple_system_name)
+        os.symlink(
+            workspace_dir, experiments_root / str(experiment_id) / simple_system_name
+        )
 
     ramble_workspace_dir = workspace_dir / "workspace"
     ramble_configs_dir = ramble_workspace_dir / "configs"

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -10,8 +10,6 @@ import pathlib
 import shutil
 import sys
 
-import yaml
-
 import benchpark.paths
 from benchpark.accounting import (
     benchpark_experiments,

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -20,6 +20,7 @@ from benchpark.accounting import (
 )
 from benchpark.debug import debug_print
 from benchpark.runtime import RuntimeResources
+import benchpark.system
 
 
 # Note: it would be nice to vendor spack.llnl.util.link_tree, but that
@@ -100,11 +101,7 @@ def benchpark_check_system(arg_str):
     if cfg_path.is_dir():
         system_id_path = cfg_path / "system_id.yaml"
         if system_id_path.exists():
-            with open(system_id_path, "r") as f:
-                data = yaml.safe_load(f)
-            name = data["system"]["name"]
-            spec_hash = data["system"]["config-hash"]
-            system_id = f"{name}-{spec_hash[:7]}"
+            system_id = benchpark.system.unique_dir_for_description(cfg_path)
             return system_id, cfg_path
 
     # If it's not a directory, it might be a shorthand that refers

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -102,7 +102,7 @@ def benchpark_check_system(arg_str):
         system_id_path = cfg_path / "system_id.yaml"
         if system_id_path.exists():
             system_id = benchpark.system.unique_dir_for_description(cfg_path)
-            return system_id, cfg_path
+            return system_id, cfg_path.name, cfg_path
 
     # If it's not a directory, it might be a shorthand that refers
     # to a pre-constructed config
@@ -118,7 +118,7 @@ def benchpark_check_system(arg_str):
     configs_src_dir = (
         benchpark.paths.benchpark_root / "legacy" / "systems" / str(arg_str)
     )
-    return arg_str, configs_src_dir
+    return arg_str, None, configs_src_dir
 
 
 def benchpark_check_modifier(arg_str):
@@ -151,7 +151,7 @@ def command(args):
     debug_print(f"source_dir = {source_dir}")
     experiment_id, experiment_src_dir = benchpark_check_experiment(args.experiment)
     debug_print(f"specified experiment (benchmark/ProgrammingModel) = {experiment_id}")
-    system_id, configs_src_dir = benchpark_check_system(args.system)
+    system_id, simple_system_name, configs_src_dir = benchpark_check_system(args.system)
     debug_print(f"specified system = {system_id}")
     debug_print(f"specified modifier = {modifier}")
     benchpark_check_modifier(modifier)
@@ -169,6 +169,8 @@ def command(args):
             sys.exit(1)
 
     workspace_dir.mkdir(parents=True)
+    if simple_system_name:
+        os.symlink(workspace_dir, experiments_root / str(experiment_id) / simple_system_name)
 
     ramble_workspace_dir = workspace_dir / "workspace"
     ramble_configs_dir = ramble_workspace_dir / "configs"

--- a/lib/benchpark/cmd/system.py
+++ b/lib/benchpark/cmd/system.py
@@ -45,6 +45,10 @@ def system_list(args):
     raise NotImplementedError("'benchpark system list' is not available")
 
 
+def system_id(args):
+    print(benchpark.system.unique_dir_for_description(args.system_dir))
+
+
 def setup_parser(root_parser):
     system_subparser = root_parser.add_subparsers(dest="system_subcommand")
 
@@ -58,11 +62,15 @@ def setup_parser(root_parser):
 
     system_subparser.add_parser("list")
 
+    id_parser = system_subparser.add_parser("id")
+    id_parser.add_argument("system_dir")
+
 
 def command(args):
     actions = {
         "init": system_init,
         "list": system_list,
+        "id": system_id,
     }
     if args.system_subcommand in actions:
         actions[args.system_subcommand](args)

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -8,6 +8,7 @@ import importlib.util
 import os
 import pathlib
 import sys
+import yaml
 
 import benchpark.paths
 from benchpark.directives import ExperimentSystemBase
@@ -188,3 +189,12 @@ variables:
   batch_submit: "placeholder"
   mpi_command: "placeholder"
 """
+
+
+def unique_dir_for_description(system_dir):
+    system_id_path = os.path.join(system_dir, "system_id.yaml")
+    with open(system_id_path, "r") as f:
+        data = yaml.safe_load(f)
+    name = data["system"]["name"]
+    spec_hash = data["system"]["config-hash"]
+    return f"{name}-{spec_hash[:7]}"


### PR DESCRIPTION
`benchpark setup`, when using a dynamically generated system (from `benchpark system init`), will generate a ramble workspace in part using the name/hash of the system

This can make it awkward to reference, as is demonstrated in our dry run CI checks:

```
./bin/benchpark system init --dest=tioga-system tioga rocm=551 compiler=cce ~gtl
...
./bin/benchpark setup ./saxpy-rocm ./tioga-system workspace/
...
ramble --workspace-dir workspace/saxpy-rocm/Tioga-975af3c/workspace 
^
|
(this has to refer to "Tioga-975af3c")
```

This adds some convenience functionality:

1. New command `benchpark system id <a dir generated by system-init>`: which will print the directory component related to the system (e.g. "Tioga-975af3c" in the above example)
2. `benchpark setup` now generates a symlink that follows the same pattern as for an experiment, using the basename of the system config dir. In terms of the above example, that would be `workspace/saxpy-rocm/tioga-system -> workspace/saxpy-rocm/Tioga-975af3c`

Notes:

* Keeping the hash-based link would help users that want to dynamically generate multiple workspace from a set of (experiment/system) tuples (the symlink would have to be removed for that to work well though)
* Until then (if ever) the symlink based on the simple name means a user can anticipate the name of the Ramble workspace generated by `benchpark setup`
* Either way, keeping the hash-name means that any existing scripts referring to system config dirs will continue to work
  * ... if that is important
  * if not, then this could just switch over to the simple name (i.e. the symlink becomes the actual path, and the hash is omitted)