### PR TITLE
Aws system: integrate 6a/7a configs

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -384,6 +384,17 @@ jobs:
             --disable-logger \
             workspace setup --dry-run
 
+      - name: Dry run dynamic saxpy/openmp with dynamic aws
+        run: |
+          ./bin/benchpark system init --dest=aws1 aws-pcluster instance_type=hpc6a.48xlarge
+          ./bin/benchpark setup ./saxpy-omp-generic ./aws1 workspace/
+          . workspace/setup.sh
+          ramble \
+            --workspace-dir "workspace/saxpy-omp-generic/aws1/workspace" \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace setup --dry-run
+
       - name: Dry run dynamic remhos/mpi with dynamic llnl-cluster ruby
         run: |
           ./bin/benchpark experiment init --dest=remhos-ruby remhos

--- a/systems/aws-pcluster/compilers/gcc/00-gcc-7-compilers.yaml
+++ b/systems/aws-pcluster/compilers/gcc/00-gcc-7-compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    spec: gcc@7.3.1
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: alinux2
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/systems/aws-pcluster/externals/base/00-packages.yaml
+++ b/systems/aws-pcluster/externals/base/00-packages.yaml
@@ -1,0 +1,28 @@
+packages:
+  tar:
+    externals:
+    - spec: tar@1.26
+      prefix: /usr
+    buildable: false
+  gmake:
+    externals:
+    - spec: gmake@3.8.2
+      prefix: /usr
+  blas:
+    externals:
+    - spec: blas@3.4.2
+      prefix: /usr
+    buildable: false
+  lapack:
+    externals:
+    - spec: lapack@3.4.2
+      prefix: /usr
+    buildable: false
+  mpi:
+    buildable: false
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.5%gcc@7.3.1
+      prefix: /opt/amazon/openmpi
+      extra_attributes:
+        ldflags: "-L/opt/amazon/openmpi/lib -lmpi"

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pathlib
+
 from benchpark.system import System
 from benchpark.directives import variant
 
@@ -28,7 +30,7 @@ id_to_resources = {
 }
 
 
-class Aws(System):
+class AwsPcluster(System):
     variant(
         "instance_type",
         values=("c6g.xlarge", "c4.xlarge", "hpc7a.48xlarge", "hpc6a.48xlarge"),
@@ -44,8 +46,16 @@ class Aws(System):
         for k, v in attrs.items():
             setattr(self, k, v)
 
+    def system_specific_variables(self):
+        return {
+            "extra_cmd_opts": """|
+    --mpi=pmix
+    --export=ALL,FI_EFA_USE_DEVICE_RDMA=1,FI_PROVIDER="efa",OMPI_MCA_mtl_base_verbose=100'
+"""
+        }
+
     def external_pkg_configs(self):
-        externals = LlnlElcapitan.resource_location / "externals"
+        externals = AwsPcluster.resource_location / "externals"
 
         selections = [
             externals / "base" / "00-packages.yaml",
@@ -54,13 +64,21 @@ class Aws(System):
         return selections
 
     def compiler_configs(self):
-        compilers = LlnlElcapitan.resource_location / "compilers"
+        compilers = AwsPcluster.resource_location / "compilers"
 
         selections = [
             compilers / "gcc" / "00-gcc-7-compilers.yaml",
         ]
 
         return selections
+
+    def generate_description(self, output_dir):
+        super().generate_description(output_dir)
+
+        sw_description = pathlib.Path(output_dir) / "software.yaml"
+
+        with open(sw_description, "w") as f:
+            f.write(self.sw_description())
 
     def sw_description(self):
         return """\

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -48,10 +48,7 @@ class AwsPcluster(System):
 
     def system_specific_variables(self):
         return {
-            "extra_cmd_opts": """|
-    --mpi=pmix
-    --export=ALL,FI_EFA_USE_DEVICE_RDMA=1,FI_PROVIDER="efa",OMPI_MCA_mtl_base_verbose=100'
-"""
+            "extra_cmd_opts": '--mpi=pmix --export=ALL,FI_EFA_USE_DEVICE_RDMA=1,FI_PROVIDER="efa",OMPI_MCA_mtl_base_verbose=100',
         }
 
     def external_pkg_configs(self):

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -17,21 +17,63 @@ id_to_resources = {
         "sys_cores_per_node": 4,
         "sys_mem_per_node": 8,
     },
+    "hpc7a.48xlarge": {
+        "sys_cores_per_node": 96,
+        "sys_mem_per_node": 768,
+    },
+    "hpc6a.48xlarge": {
+        "sys_cores_per_node": 96,
+        "sys_mem_per_node": 384,
+    },
 }
 
 
 class Aws(System):
     variant(
         "instance_type",
-        values=("c6g.xlarge", "c4.xlarge"),
+        values=("c6g.xlarge", "c4.xlarge", "hpc7a.48xlarge", "hpc6a.48xlarge"),
         default="c4.xlarge",
         description="AWS instance type",
     )
 
     def initialize(self):
         super().initialize()
-        self.scheduler = "mpi"
+        self.scheduler = "slurm"
         # TODO: for some reason I have to index to get value, even if multi=False
         attrs = id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+    def external_pkg_configs(self):
+        externals = LlnlElcapitan.resource_location / "externals"
+
+        selections = [
+            externals / "base" / "00-packages.yaml",
+        ]
+
+        return selections
+
+    def compiler_configs(self):
+        compilers = LlnlElcapitan.resource_location / "compilers"
+
+        selections = [
+            compilers / "gcc" / "00-gcc-7-compilers.yaml",
+        ]
+
+        return selections
+
+    def sw_description(self):
+        return """\
+software:
+  packages:
+    default-compiler:
+      pkg_spec: gcc@7.3.1
+    default-mpi:
+      pkg_spec: openmpi@4.1.5%gcc@7.3.1
+    compiler-gcc:
+      pkg_spec: gcc@7.3.1
+    lapack:
+      pkg_spec: lapack@3.4.2
+    mpi-gcc:
+      pkg_spec: openmpi@4.1.5%gcc@7.3.1
+"""


### PR DESCRIPTION
https://github.com/LLNL/benchpark/tree/develop/legacy/systems/nosite-AWS_PCluster_Hpc6a-zen3-EFA 

and

https://github.com/LLNL/benchpark/tree/develop/legacy/systems/nosite-AWS_PCluster_Hpc7a-zen4-EFA

are quite similar except for `variables.yaml` (different system specs)

The external packages config for each of these had a schema error:

```
  blas:
    externals:
    - spec: blas@3.4.2
      prefix: /usr
      buildable: false
```

should be

```
  blas:
    buildable: false
    externals:
    - spec: blas@3.4.2
      prefix: /usr
```

(this occurs multiple times, fixed in the template files used by the `aws-pcluster` system, but the original static files are not fixed)
