### PR TITLE
includes: name mangle ramble and include from spack normally

### DIFF
--- a/lib/benchpark/cmd/init.py
+++ b/lib/benchpark/cmd/init.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import shutil
+import sys
+
+import benchpark.experiment
+import benchpark.spec
+
+
+def init(args):
+    # Handle conjoined arguments that argparse doesn't separate
+    specs_str = " ".join(args.specs)
+    experiment_args, system_args = specs_str.split("--")
+
+    # Parse and concretize system
+    system_spec = benchpark.spec.SystemSpec(system_args).concretize()
+    system = system_spec.system
+
+    # Parse and concretize experiments
+    exp_spec_parser = benchpark.spec.SpecParser(
+        benchpark.spec.ExperimentSpec, experiment_args
+    )
+    experiment_specs = [es.concretize() for es in exp_spec_parser.all_specs()]
+    experiments = [es.experiment for es in experiment_specs]
+
+    # Create system directory and print out yaml
+    sysdir = os.path.join(args.basedir, system.system_uid())
+
+    try:
+        os.mkdir(sysdir)
+        system.generate_description(sysdir)
+    except FileExistsError:
+        print(f"Abort: system dir already exists ({sysdir})")
+        sys.exit(1)
+    except Exception:
+        # If there was a failure, remove any partially-generated resources
+        shutil.rmtree(sysdir)
+        raise
+
+    # For each experiment, create experiment directory and print out yaml
+    for experiment_spec, experiment in zip(experiment_specs, experiments):
+        expdir = os.path.join(args.basedir, str(hash(experiment_spec)))
+
+        try:
+            os.mkdir(expdir)
+            experiment.write_ramble_dict(f"{expdir}/ramble.yaml")
+        except FileExistsError:
+            print(f"Abort: workload dir already exists ({expdir})")
+            sys.exit(1)
+        except Exception:
+            # If there was a failure, remove any partially-generated resources
+            shutil.rmtree(expdir)
+            raise
+
+
+def setup_parser(parser):
+    parser.add_argument(
+        "--basedir",
+        required=True,
+        help="Generate a system dir under this, and place all files there",
+    )
+
+    parser.add_argument(
+        "specs",
+        nargs=argparse.REMAINDER,
+        metavar="experiment_spec(s) -- system_spec",
+        help="Experiment spec(s) and system spec",
+    )
+
+
+def command(args):
+    init(args)

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -20,10 +20,28 @@ from benchpark.debug import debug_print
 from benchpark.runtime import RuntimeResources
 import benchpark.system
 
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
 
-import llnl.util.link_tree  # noqa
+# Note: it would be nice to vendor spack.llnl.util.link_tree, but that
+# involves pulling in most of llnl/util/ and spack/util/
+def symlink_tree(src, dst, include_fn=None):
+    """Like ``cp -R`` but instead of files, create symlinks"""
+    src = os.path.abspath(src)
+    dst = os.path.abspath(dst)
+    # By default, we include all filenames
+    include_fn = include_fn or (lambda f: True)
+    for x in [src, dst]:
+        if not os.path.isdir(x):
+            raise ValueError(f"Not a directory: {x}")
+    for src_subdir, directories, files in os.walk(src):
+        relative_src_dir = pathlib.Path(os.path.relpath(src_subdir, src))
+        dst_dir = pathlib.Path(dst) / relative_src_dir
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        for x in files:
+            if not include_fn(x):
+                continue
+            dst_symlink = dst_dir / x
+            src_file = os.path.join(src_subdir, x)
+            os.symlink(src_file, dst_symlink)
 
 
 def setup_parser(root_parser):
@@ -168,25 +186,23 @@ def command(args):
     ramble_logs_dir.mkdir(parents=True)
     ramble_spack_experiment_configs_dir.mkdir(parents=True)
 
-    def ignore_fn(fname):
+    def include_fn(fname):
         # Only include .yaml files
         # Always exclude files that start with "."
         if fname.startswith("."):
-            return True
-        if fname.endswith(".yaml"):
             return False
-        return True
+        if fname.endswith(".yaml"):
+            return True
+        return False
 
-    configs_tree = llnl.util.link_tree.LinkTree(configs_src_dir)
-    experiment_tree = llnl.util.link_tree.LinkTree(experiment_src_dir)
-    modifier_tree = llnl.util.link_tree.LinkTree(modifier_config_dir)
-    for tree in (configs_tree, experiment_tree, modifier_tree):
-        tree.merge(ramble_configs_dir, ignore=ignore_fn)
-
-    systems_tree = llnl.util.link_tree.LinkTree(
-        source_dir / "legacy" / "systems" / "common"
+    symlink_tree(configs_src_dir, ramble_configs_dir, include_fn)
+    symlink_tree(experiment_src_dir, ramble_configs_dir, include_fn)
+    symlink_tree(modifier_config_dir, ramble_configs_dir, include_fn)
+    symlink_tree(
+        source_dir / "legacy" / "systems" / "common",
+        ramble_spack_experiment_configs_dir,
+        include_fn,
     )
-    systems_tree.merge(ramble_spack_experiment_configs_dir, ignore=ignore_fn)
 
     template_name = "execute_experiment.tpl"
     experiment_template_options = [

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -20,28 +20,10 @@ from benchpark.debug import debug_print
 from benchpark.runtime import RuntimeResources
 import benchpark.system
 
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper.bootstrap()  # noqa
 
-# Note: it would be nice to vendor spack.llnl.util.link_tree, but that
-# involves pulling in most of llnl/util/ and spack/util/
-def symlink_tree(src, dst, include_fn=None):
-    """Like ``cp -R`` but instead of files, create symlinks"""
-    src = os.path.abspath(src)
-    dst = os.path.abspath(dst)
-    # By default, we include all filenames
-    include_fn = include_fn or (lambda f: True)
-    for x in [src, dst]:
-        if not os.path.isdir(x):
-            raise ValueError(f"Not a directory: {x}")
-    for src_subdir, directories, files in os.walk(src):
-        relative_src_dir = pathlib.Path(os.path.relpath(src_subdir, src))
-        dst_dir = pathlib.Path(dst) / relative_src_dir
-        dst_dir.mkdir(parents=True, exist_ok=True)
-        for x in files:
-            if not include_fn(x):
-                continue
-            dst_symlink = dst_dir / x
-            src_file = os.path.join(src_subdir, x)
-            os.symlink(src_file, dst_symlink)
+import llnl.util.link_tree  # noqa
 
 
 def setup_parser(root_parser):
@@ -186,23 +168,25 @@ def command(args):
     ramble_logs_dir.mkdir(parents=True)
     ramble_spack_experiment_configs_dir.mkdir(parents=True)
 
-    def include_fn(fname):
+    def ignore_fn(fname):
         # Only include .yaml files
         # Always exclude files that start with "."
         if fname.startswith("."):
-            return False
-        if fname.endswith(".yaml"):
             return True
-        return False
+        if fname.endswith(".yaml"):
+            return False
+        return True
 
-    symlink_tree(configs_src_dir, ramble_configs_dir, include_fn)
-    symlink_tree(experiment_src_dir, ramble_configs_dir, include_fn)
-    symlink_tree(modifier_config_dir, ramble_configs_dir, include_fn)
-    symlink_tree(
-        source_dir / "legacy" / "systems" / "common",
-        ramble_spack_experiment_configs_dir,
-        include_fn,
+    configs_tree = llnl.util.link_tree.LinkTree(configs_src_dir)
+    experiment_tree = llnl.util.link_tree.LinkTree(experiments_src_dir)
+    modifier_tree = llnl.util.link_tree.LinkTree(modifier_config_dir)
+    for tree in (configs_tree, experiment_tree, modifier_tree):
+        tree.merge(ramble_configs_dir, ignore=ignore_fn)
+
+    systems_tree = llnl.util.link_tree.LinkTree(
+        source_dir / "legacy" / "systems" / "common"
     )
+    systems_tree.merge(ramble_spack_experiment_configs_dir, ignore=ignore_fn)
 
     template_name = "execute_experiment.tpl"
     experiment_template_options = [

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -178,7 +178,7 @@ def command(args):
         return True
 
     configs_tree = llnl.util.link_tree.LinkTree(configs_src_dir)
-    experiment_tree = llnl.util.link_tree.LinkTree(experiments_src_dir)
+    experiment_tree = llnl.util.link_tree.LinkTree(experiment_src_dir)
     modifier_tree = llnl.util.link_tree.LinkTree(modifier_config_dir)
     for tree in (configs_tree, experiment_tree, modifier_tree):
         tree.merge(ramble_configs_dir, ignore=ignore_fn)

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import os
 import pathlib
 import shlex
+import stat
 import subprocess
 import sys
 
@@ -82,9 +83,28 @@ class RuntimeResources:
         self.spack_location = self.dest / "spack"
 
     def bootstrap(self):
+        # Bootstrap Spack first because we will use Spack resources while bootstrapping ramble
+        if not self.spack_location.exists():
+            self._install_spack()
+
+        spack_lib_path = self.spack_location / "lib" / "spack"
+        externals = str(spack_lib_path / "external")
+        if externals not in sys.path:
+            sys.path.insert(1, externals)
+        internals = str(spack_lib_path)
+        if internals not in sys.path:
+            sys.path.insert(1, internals)
+
         if not self.ramble_location.exists():
             self._install_ramble()
+
         ramble_lib_path = self.ramble_location / "lib" / "ramble"
+
+        # If ramble is present but not yet name mangled, do that
+        ramble_spack_path = ramble_lib_path / "ramble_spack"
+        if not ramble_spack_path.exists():
+            self._mangle_ramble()
+
         externals = str(ramble_lib_path / "external")
         if externals not in sys.path:
             sys.path.insert(1, externals)
@@ -92,11 +112,23 @@ class RuntimeResources:
         if internals not in sys.path:
             sys.path.insert(1, internals)
 
-        # Spack does not go in sys.path, but we will manually access modules from it
-        # The reason for this oddity is that spack modules will compete with the internal
-        # spack modules from ramble
-        if not self.spack_location.exists():
-            self._install_spack()
+    def _mangle_ramble(self):
+        """Name mangle ramble spack.* symbols to allow separate spack imports."""
+        import llnl.util.filesystem as fs
+
+        files = [
+            f
+            for f in fs.find(self.ramble_location, "*")
+            if os.stat(f).st_mode & stat.S_IWUSR and not os.path.isdir(f)
+        ]
+        file_filter = fs.FileFilter(*files)
+        # Don't replace if it's already replaced or if it's a field in an existing module
+        file_filter.filter(r"(?<!_|\.)spack\.", "ramble_spack.")
+        file_filter.filter(r"(?<!_)llnl\.", "ramble_llnl.")
+
+        ramble_lib_path = self.ramble_location / "lib" / "ramble"
+        os.rename(ramble_lib_path / "spack", ramble_lib_path / "ramble_spack")
+        os.rename(ramble_lib_path / "llnl", ramble_lib_path / "ramble_llnl")
 
     def _install_ramble(self):
         print(f"Cloning Ramble to {self.ramble_location}")

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -25,36 +25,10 @@ bootstrapper.bootstrap()  # noqa
 import ramble.config as cfg  # noqa
 import ramble.language.language_helpers  # noqa
 import ramble.language.shared_language  # noqa
+
 import spack.util.spack_yaml as syaml  # noqa
-
-# We cannot import this the normal way because it from modern Spack
-# and mixing modern Spack modules with ramble modules that depend on
-# ancient Spack will cause errors. This module is safe to load as an
-# individual because it is not used by Ramble
-# The following code block implements the line
-# import spack.schema.packages as packages_schema
-schemas = {
-    "spack.schema.packages": f"{bootstrapper.spack_location}/lib/spack/spack/schema/packages.py",
-    "spack.schema.compilers": f"{bootstrapper.spack_location}/lib/spack/spack/schema/compilers.py",
-}
-
-
-def load_schema(schema_id, schema_path):
-    schema_spec = importlib.util.spec_from_file_location(schema_id, schema_path)
-    schema = importlib.util.module_from_spec(schema_spec)
-    sys.modules[schema_id] = schema
-    schema_spec.loader.exec_module(schema)
-    return schema
-
-
-packages_schema = load_schema(
-    "spack.schema.packages",
-    f"{bootstrapper.spack_location}/lib/spack/spack/schema/packages.py",
-)
-compilers_schema = load_schema(
-    "spack.schema.compilers",
-    f"{bootstrapper.spack_location}/lib/spack/spack/schema/compilers.py",
-)
+import spack.schema.packages as packages_schema  # noqa
+import spack.schema.compilers as compilers_schema  # noqa
 
 
 _repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-import importlib.util
 import os
 import pathlib
-import sys
 import yaml
 
 import benchpark.paths

--- a/lib/main.py
+++ b/lib/main.py
@@ -17,6 +17,7 @@ import yaml
 import benchpark.cmd.audit
 import benchpark.cmd.system
 import benchpark.cmd.experiment
+import benchpark.cmd.init
 import benchpark.cmd.setup
 import benchpark.cmd.unit_test
 import benchpark.paths
@@ -198,6 +199,11 @@ def init_commands(subparsers, actions_dict):
     system_parser = subparsers.add_parser("system", help="Initialize a system config")
     benchpark.cmd.system.setup_parser(system_parser)
 
+    init_parser = subparsers.add_parser(
+        "init", help="Initialize a set of experiments with a compatible system"
+    )
+    benchpark.cmd.init.setup_parser(init_parser)
+
     experiment_parser = subparsers.add_parser(
         "experiment", help="Interact with experiments"
     )
@@ -218,6 +224,7 @@ def init_commands(subparsers, actions_dict):
     )
     benchpark.cmd.audit.setup_parser(audit_parser)
 
+    actions_dict["init"] = benchpark.cmd.init.command
     actions_dict["system"] = benchpark.cmd.system.command
     actions_dict["experiment"] = benchpark.cmd.experiment.command
     actions_dict["setup"] = benchpark.cmd.setup.command


### PR DESCRIPTION
## Description

This PR allows us to import from Spack in the normal way instead of our crazy workaround.

The key is that we name mangle all of the ramble imports from `spack.*` to `ramble_spack.*` and `llnl.*` to `ramble_llnl.*`.

Dependencies: FIXME:Add a list of any dependencies.

Fixes issue(s): FIXME:Add list of relevant issues.

## Type of Change

- { } Adding a system, benchmark, or experiment
- { } Modifying an existing system, benchmark, or experiment
- { } Documentation update
- { } Build/CI update
- { } Benchpark core functionality

## Checklist:

If adding/modifying a system:
- { } Create a new directory for the system and a new `system.py` file
- { } Add a new dry run unit test in `.github/workflows`
- { } System appears in System Specifications table in docs catalogue section

If adding/modifying a benchpark:
- { } Add a new `application.py` and (maybe) `package.py` under a new directory
      for this benchmark
- { } Configure an experiment
- { } Benchmark appears in Benchmarks and Experiments table in docs catalogue
      section

If adding/modifying a experiment:
- { } Extend `experiment.py` under existing directory for specific benchmark
- { } Define a single node and multi-node experiments

If adding/modifying core functionality:
- { } Update docs
- { } Update `.github/workflows` and `.gitlab/ci` unit tests (if needed)