### PR TITLE
legacy: update saxpy openmp mpi compiler on tioga

### DIFF
--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -84,10 +84,7 @@ legacy_test_run:
   <<: *legacy_test_clusters
   <<: *report_status
   rules:
-    - if: |
-        $CI_PIPELINE_SOURCE == "merge_request_event" ||
-        $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      changes:
+    - changes:
         - .gitlab-ci.yml
         - .gitlab/ci/*
         - experiments/**
@@ -124,10 +121,7 @@ test_run:
   <<: *test_clusters
   <<: *report_status
   rules:
-    - if: |
-        $CI_PIPELINE_SOURCE == "merge_request_event" ||
-        $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      changes:
+    - changes:
         - .gitlab-ci.yml
         - .gitlab/ci/*
         - experiments/**

--- a/legacy/systems/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/software.yaml
+++ b/legacy/systems/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/software.yaml
@@ -8,7 +8,7 @@ software:
     default-compiler:
       pkg_spec: cce@16.0.0-rocm5.5.1
     default-mpi:
-      pkg_spec: cray-mpich@8.1.26%cce@16.0.0 +gtl
+      pkg_spec: cray-mpich@8.1.26%cce@16.0.0 ~gtl
     compiler-rocm:
       pkg_spec: cce@16.0.0-rocm5.5.1
     compiler-amdclang:


### PR DESCRIPTION
@slabasan what is this intended to fix?  I think this makes the default saxpy fail.