### PR TITLE
Fix license verification CI check

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Verify license headers
         run: |

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -40,7 +40,6 @@ schemas = {
 }
 
 
-# Test comment to trigger CI
 def load_schema(schema_id, schema_path):
     schema_spec = importlib.util.spec_from_file_location(schema_id, schema_path)
     schema = importlib.util.module_from_spec(schema_spec)

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -40,6 +40,7 @@ schemas = {
 }
 
 
+# Test comment to trigger CI
 def load_schema(schema_id, schema_path):
     schema_spec = importlib.util.spec_from_file_location(schema_id, schema_path)
     schema = importlib.util.module_from_spec(schema_spec)


### PR DESCRIPTION
I'm not clear what changed, but

* Without this change - removing the pip cache for the license verification check - there can be a failure
* I don't think we actually need to use any cache for license verification, because this check has no dependencies

Example of failure without this change: https://github.com/LLNL/benchpark/pull/515

This affects all PRs, e.g. if you look at commit 07295aa (the first commit in this PR, which just tried to reproduce the issue), that has a CI failure.

See also: `https://github.com/actions/setup-python/issues/436`