### PR TITLE
RAJAPerf experiment class

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -586,3 +586,15 @@ jobs:
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
+
+      - name: Dry run dynamic raja-perf/mpi with dynamic CTS ruby
+        run: |
+          ./bin/benchpark experiment init --dest=raja-perf raja-perf
+          ./bin/benchpark setup ./raja-perf ./ruby-system workspace/
+          system_id=$(./bin/benchpark system id ./ruby-system)
+          . workspace/setup.sh
+          ramble \
+            --workspace-dir "workspace/raja-perf/$system_id/workspace" \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace setup --dry-run

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -12,6 +12,7 @@ from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.expr.builtin.caliper import Caliper
 
+
 class RajaPerf(
     Experiment,
     StrongScaling,
@@ -41,7 +42,7 @@ class RajaPerf(
                 n_resources = pv
 
         elif self.spec.satisfies("+strong"):
-            scaled_variables= self.generate_strong_scaling_params(
+            scaled_variables = self.generate_strong_scaling_params(
                 {tuple(n_resources.keys()): list(n_resources.values())},
                 int(self.spec.variants["scaling-factor"][0]),
                 int(self.spec.variants["scaling-iterations"][0]),
@@ -63,7 +64,7 @@ class RajaPerf(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        
+
         if self.spec.satisfies("+cuda"):
             system_specs["cuda_version"] = "{default_cuda_version}"
             system_specs["cuda_arch"] = "{cuda_arch}"
@@ -72,4 +73,6 @@ class RajaPerf(
 
         self.add_spack_spec(system_specs["mpi"])
 
-        self.add_spack_spec(self.name, [f"raja-perf@{app_version}", system_specs["compiler"]])
+        self.add_spack_spec(
+            self.name, [f"raja-perf@{app_version}", system_specs["compiler"]]
+        )

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from benchpark.directives import variant
+from benchpark.experiment import Experiment
+from benchpark.scaling import StrongScaling
+from benchpark.scaling import WeakScaling
+from benchpark.openmp import OpenMPExperiment
+from benchpark.cuda import CudaExperiment
+from benchpark.rocm import ROCmExperiment
+from benchpark.expr.builtin.caliper import Caliper
+
+class RajaPerf(
+    Experiment,
+    StrongScaling,
+    CudaExperiment,
+    ROCmExperiment,
+    OpenMPExperiment,
+):
+    variant(
+        "workload",
+        default="suite",
+        description="base Rajaperf suiteor other problem",
+    )
+
+    variant(
+        "version",
+        default="develop",
+        description="app version",
+    )
+
+    def compute_applications_section(self):
+
+        n_resources = {"n_ranks": 1}
+        
+        if self.spec.satisfies("+single_node"):
+            for pk, pv in n_resources.items():
+                self.add_experiment_variable(pk, pv, True)
+        elif self.spec.satisfies("+strong"):
+            scaled_variables = self.generate_strong_scaling_params(
+                {tuple(n_resources.keys()): list(n_resources.values())},
+                int(self.spec.variants["scaling-factor"][0]),
+                int(self.spec.variants["scaling-iterations"][0]),
+            )
+            for k, v in scaled_variables.items():
+                self.add_experiment_variable(k, v, True)
+            # 256 mb
+            self.add_experiment_variable("b", "268435456 / {n_nodes}", True)
+
+        self.add_experiment_variable("t", t, True)
+        self.add_experiment_variable(
+            "n_ranks", "{sys_cores_per_node} * {n_nodes}", True
+        )
+
+    def compute_spack_section(self):
+        # get package version
+        app_version = self.spec.variants["version"][0]
+
+        # get system config options
+        # TODO: Get compiler/mpi/package handles directly from system.py
+        system_specs = {}
+        system_specs["compiler"] = "default-compiler"
+        system_specs["mpi"] = "default-mpi"
+
+        # set package spack specs
+        self.add_spack_spec(system_specs["mpi"])
+
+        self.add_spack_spec(self.name, [f"raja-perf@{app_version}", system_specs["compiler"]])

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -18,11 +18,12 @@ class RajaPerf(
     CudaExperiment,
     ROCmExperiment,
     OpenMPExperiment,
+    Caliper,
 ):
     variant(
         "workload",
         default="suite",
-        description="base Rajaperf suiteor other problem",
+        description="base Rajaperf suite or other problem",
     )
 
     variant(
@@ -34,37 +35,41 @@ class RajaPerf(
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}
-        
+
         if self.spec.satisfies("+single_node"):
             for pk, pv in n_resources.items():
-                self.add_experiment_variable(pk, pv, True)
+                n_resources = pv
+
         elif self.spec.satisfies("+strong"):
-            scaled_variables = self.generate_strong_scaling_params(
+            scaled_variables= self.generate_strong_scaling_params(
                 {tuple(n_resources.keys()): list(n_resources.values())},
                 int(self.spec.variants["scaling-factor"][0]),
                 int(self.spec.variants["scaling-iterations"][0]),
             )
-            for k, v in scaled_variables.items():
-                self.add_experiment_variable(k, v, True)
-            # 256 mb
-            self.add_experiment_variable("b", "268435456 / {n_nodes}", True)
+            n_resources = scaled_variables["n_ranks"]
 
-        self.add_experiment_variable("t", t, True)
-        self.add_experiment_variable(
-            "n_ranks", "{sys_cores_per_node} * {n_nodes}", True
-        )
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+            self.add_experiment_variable("n_gpus", n_resources, True)
+        elif self.spec.satisfies("+openmp"):
+            self.add_experiment_variable("n_ranks", n_resources, True)
+            self.add_experiment_variable("n_threads_per_proc", 1, True)
+        else:
+            self.add_experiment_variable("n_ranks", n_resources, True)
 
     def compute_spack_section(self):
         # get package version
         app_version = self.spec.variants["version"][0]
 
-        # get system config options
-        # TODO: Get compiler/mpi/package handles directly from system.py
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
+        
+        if self.spec.satisfies("+cuda"):
+            system_specs["cuda_version"] = "{default_cuda_version}"
+            system_specs["cuda_arch"] = "{cuda_arch}"
+        if self.spec.satisfies("+rocm"):
+            system_specs["rocm_arch"] = "{rocm_arch}"
 
-        # set package spack specs
         self.add_spack_spec(system_specs["mpi"])
 
         self.add_spack_spec(self.name, [f"raja-perf@{app_version}", system_specs["compiler"]])

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -6,7 +6,6 @@
 from benchpark.directives import variant
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
-from benchpark.scaling import WeakScaling
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment


### PR DESCRIPTION
Description
Adding updated experiment class for RAJAPerf.  includes, openmp, rocm, cuda implementations, and caliper variant. Added dryrun as well
 
    {x} Adding a system, benchmark, or experiment
    { } Modifying an existing system, benchmark, or experiment
    { } Documentation update
    { } Build/CI update
    { } Benchpark core functionality

Checklist:

If adding/modifying a system:

    { } Create a new directory for the system and a new system.py file
    { } Add a new dry run unit test in .github/workflows
    { } System appears in System Specifications table in docs catalogue section

If adding/modifying a benchmark:

    { } Add a new application.py and (maybe) package.py under a new directory
    for this benchmark
    {x} Configure an experiment
    { } Benchmark appears in Benchmarks and Experiments table in docs catalogue
    section

If adding/modifying a experiment:

    {x} Extend experiment.py under existing directory for specific benchmark
    {x} Define a single node and multi-node experiments

If adding/modifying core functionality:

    { } Update docs
    {x} Update .github/workflows and .gitlab/ci unit tests (if needed)


