### PR TITLE
temporarily pin github CI to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: read
     outputs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -55,7 +55,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   verify-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   saxpy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Benchpark
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -91,7 +91,7 @@ jobs:
             --update-index ci-buildcache \
             $(spack find --format '/{hash}')
   dryrunexperiments:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Benchpark
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 


### PR DESCRIPTION
## Description

Temporarily pin GitHub CI to ubuntu-22.04 (usually ubuntu-latest) while we debug test failures with ubuntu-latest. This is the last known working ubuntu version.

## Type of Change

- { } Adding a system, benchmark, or experiment
- { } Modifying an existing system, benchmark, or experiment
- { } Documentation update
- {x} Build/CI update
- { } Benchpark core functionality

## Checklist:

If adding/modifying a system:
- { } Create a new directory for the system and a new `system.py` file
- { } Add a new dry run unit test in `.github/workflows`
- { } System appears in System Specifications table in docs catalogue section

If adding/modifying a benchpark:
- { } Add a new `application.py` and (maybe) `package.py` under a new directory
      for this benchmark
- { } Configure an experiment
- { } Benchmark appears in Benchmarks and Experiments table in docs catalogue
      section

If adding/modifying a experiment:
- { } Extend `experiment.py` under existing directory for specific benchmark
- { } Define a single node and multi-node experiments

If adding/modifying core functionality:
- { } Update docs
- { } Update `.github/workflows` and `.gitlab/ci` unit tests (if needed)
