### PR TITLE
Add genesis experiment

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -597,7 +597,6 @@ jobs:
             --disable-logger \
             workspace setup --dry-run
 
-
       - name: Dry run dynamic genesis/openmp with dynamic CTS ruby
         run: |
           system_id=$(./bin/benchpark system id ./ruby-system)

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -346,26 +346,6 @@ jobs:
             --disable-logger \
             workspace setup --dry-run
 
-      - name: Dry run genesis/openmp with allocation modifier on Fugaku
-        run: |
-          ./bin/benchpark setup genesis/openmp RCCS-Fugaku-Fujitsu-A64FX-TofuD workspace/
-          . workspace/setup.sh
-          ramble \
-            --workspace-dir workspace/genesis/openmp/RCCS-Fugaku-Fujitsu-A64FX-TofuD/workspace \
-            --disable-progress-bar \
-            --disable-logger \
-            workspace setup --dry-run
-
-      - name: Dry run genesis/openmp with allocation modifier on nosite-x86_64
-        run: |
-          ./bin/benchpark setup genesis/openmp nosite-x86_64 workspace/
-          . workspace/setup.sh
-          ramble \
-            --workspace-dir workspace/genesis/openmp/nosite-x86_64/workspace \
-            --disable-progress-bar \
-            --disable-logger \
-            workspace setup --dry-run
-
       - name: Dry run salmon/openmp with allocation modifier on Fugaku
         run: |
           ./bin/benchpark setup salmon/openmp RCCS-Fugaku-Fujitsu-A64FX-TofuD workspace/
@@ -626,6 +606,18 @@ jobs:
           . workspace/setup.sh
           ramble \
             --workspace-dir workspace/genesis-openmp/$system_id/workspace \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace setup --dry-run
+
+      - name: Dry run dynamic genesis/openmp with dynamic fugaku
+        run: |
+          system_id=$(./bin/benchpark system id ./fugaku-system)
+          ./bin/benchpark experiment init --dest=genesis-openmp-fugaku genesis+openmp
+          ./bin/benchpark setup ./genesis-openmp-fugaku ./fugaku-system workspace/
+          . workspace/setup.sh
+          ramble \
+            --workspace-dir workspace/genesis-openmp-fugaku/$system_id/workspace \
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -616,3 +616,16 @@ jobs:
             --disable-progress-bar \
             --disable-logger \
             workspace setup --dry-run
+
+
+      - name: Dry run dynamic genesis/openmp with dynamic CTS ruby
+        run: |
+          system_id=$(./bin/benchpark system id ./ruby-system)
+          ./bin/benchpark experiment init --dest genesis-openmp genesis +openmp
+          ./bin/benchpark setup genesis-openmp ./ruby-system workspace/
+          . workspace/setup.sh
+          ramble \
+            --workspace-dir workspace/genesis-openmp/$system_id/workspace \
+            --disable-progress-bar \
+            --disable-logger \
+            workspace setup --dry-run

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -40,10 +40,10 @@ class Genesis(Experiment, OpenMPExperiment):
         self.add_experiment_variable("maxiter_inner", "50")
 
         if self.spec.satisfies("+openmp"):
-            self.add_experiment_variable("n_nodes", ["1"], True)
-            self.add_experiment_variable("processes_per_node", ["8"])
+            self.add_experiment_variable("n_nodes", ["2"], True)
+            self.add_experiment_variable("processes_per_node", ["4"])
             self.add_experiment_variable("n_ranks", "{processes_per_node} * {n_nodes}")
-            self.add_experiment_variable("omp_num_threads", ["48"])
+            self.add_experiment_variable("omp_num_threads", ["12"])
             self.add_experiment_variable("arch", "OpenMP")
 
     def compute_spack_section(self):
@@ -53,10 +53,15 @@ class Genesis(Experiment, OpenMPExperiment):
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
+        system_specs["lapack"] = "lapack"
 
         # if package_spec left empty spack will use external
         self.add_spack_spec(system_specs["mpi"])
+        self.add_spack_spec(system_specs["lapack"])
 
         self.add_spack_spec(
             self.name, [f"genesis@{app_version} +mpi", system_specs["compiler"]]
+        )
+        self.add_spack_spec(
+            system_specs["lapack"], [system_specs["lapack"], system_specs["compiler"]]
         )

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -41,7 +41,7 @@ class Genesis(Experiment, OpenMPExperiment):
 
         if self.spec.satisfies("+openmp"):
             self.add_experiment_variable("n_nodes", ["1"], True)
-            self.add_experiment_variable("processes_per_node", ["1"])
+            self.add_experiment_variable("processes_per_node", ["8"])
             self.add_experiment_variable("n_ranks", "{processes_per_node} * {n_nodes}")
             self.add_experiment_variable("omp_num_threads", ["48"])
             self.add_experiment_variable("arch", "OpenMP")

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -19,7 +19,7 @@ class Genesis(Experiment, OpenMPExperiment):
 
     variant(
         "version",
-        default="master",
+        default="main",
         description="app version",
     )
 

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from benchpark.directives import variant
+from benchpark.experiment import Experiment
+from benchpark.openmp import OpenMPExperiment
+
+
+class Genesis(Experiment, OpenMPExperiment):
+
+    variant(
+        "workload",
+        default="genesis",
+        description="genesis",
+    )
+
+    variant(
+        "version",
+        default="master",
+        description="app version",
+    )
+
+    def compute_applications_section(self):
+
+        self.add_experiment_variable("experiment_setup", "")
+        self.add_experiment_variable("lx", "32")
+        self.add_experiment_variable("ly", "6")
+        self.add_experiment_variable("lz", "4")
+        self.add_experiment_variable("lt", "3")
+        self.add_experiment_variable("px", "1")
+        self.add_experiment_variable("py", "1")
+        self.add_experiment_variable("pz", "1")
+        self.add_experiment_variable("pt", "1")
+        self.add_experiment_variable("tol_outer", "-1")
+        self.add_experiment_variable("tol_inner", "-1")
+        self.add_experiment_variable("maxiter_plus1_outer", "6")
+        self.add_experiment_variable("maxiter_inner", "50")
+
+        if self.spec.satisfies("+openmp"):
+            self.add_experiment_variable("n_nodes", ["1"], True)
+            self.add_experiment_variable("processes_per_node", ["1"])
+            self.add_experiment_variable("n_ranks", "{processes_per_node} * {n_nodes}")
+            self.add_experiment_variable("omp_num_threads", ["48"])
+            self.add_experiment_variable("arch", "OpenMP")
+
+    def compute_spack_section(self):
+        # get package version
+        app_version = self.spec.variants["version"][0]
+
+        system_specs = {}
+        system_specs["compiler"] = "default-compiler"
+        system_specs["mpi"] = "default-mpi"
+
+        # if package_spec left empty spack will use external
+        self.add_spack_spec(system_specs["mpi"])
+
+        self.add_spack_spec(
+            self.name, [f"genesis@{app_version} +mpi", system_specs["compiler"]]
+        )

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -12,7 +12,8 @@ class Genesis(Experiment, OpenMPExperiment):
 
     variant(
         "workload",
-        default="genesis",
+        default="DHFR",
+        values=("DHFR", "ApoA1", "UUN", "cryoEM"),
         description="genesis",
     )
 

--- a/repo/genesis/package.py
+++ b/repo/genesis/package.py
@@ -17,7 +17,10 @@ class Genesis(AutotoolsPackage):
     homepage = "https://www.r-ccs.riken.jp/labs/cbrt/"
     git = "https://github.com/genesis-release-r-ccs/genesis"
 
-    version("master", branch="master", submodules=False)
+    version("main", branch="main", submodules=False)
+    version(
+        "2.1.4", submodules=False, tag="v2.1.4", commit="48fa5654ae1ecdf606fb6cd0bdcc2952f5caaa65"
+    )
     version(
         "2.1.3", submodules=False, tag="v2.1.3", commit="835ef1538f9350cfa7e9489f340837d0908afbd2"
     )


### PR DESCRIPTION
## Description

To test on Fugaku:
```
cd benchpark
. setup-env.sh
benchpark system init --dest fugaku-system fugaku 
benchpark experiment init --dest genesis-openmp genesis +openmp
benchpark setup genesis-openmp ./fugaku-system workspace/
```

Then follow the output steps.

Please validate the runtime parameters in the ramble.yaml (workspace/genesis-openmp/ramble.yaml)
Please validate the output when the job completes

Experiment.py for genesis.  

Dependencies: None

Fixes issue(s): Part of #460.

## Type of Change

- {X} Adding a system, benchmark, or experiment
- { } Modifying an existing system, benchmark, or experiment
- { } Documentation update
- { } Build/CI update
- { } Benchpark core functionality

## Checklist:

If adding/modifying a system:
- { } Create a new directory for the system and a new `system.py` file
- { } Add a new dry run unit test in `.github/workflows`
- { } System appears in System Specifications table in docs catalogue section

If adding/modifying a benchpark:
- { } Add a new `application.py` and (maybe) `package.py` under a new directory
      for this benchmark
- { } Configure an experiment
- { } Benchmark appears in Benchmarks and Experiments table in docs catalogue
      section

If adding/modifying a experiment:
- { x } Extend `experiment.py` under existing directory for specific benchmark
- { } Define a single node and multi-node experiments

If adding/modifying core functionality:
- { } Update docs
- { } Update `.github/workflows` and `.gitlab/ci` unit tests (if needed)