### PR TITLE
Added external papi package for lassen/sierra

### DIFF
--- a/systems/llnl-sierra/externals/base/00-packages.yaml
+++ b/systems/llnl-sierra/externals/base/00-packages.yaml
@@ -37,5 +37,10 @@ packages:
     - spec: python@3.8.2
       prefix: /usr/tce/packages/python/python-3.8.2
       buildable: false
+  papi:
+    externals:
+    - spec: papi@5.2.0.0
+      prefix: /usr
+    buildable: false
   mpi:
     buildable: false


### PR DESCRIPTION
## Description
ISSUE: This PR fixed an issue that occurs when building on lassen with the llnl-sierra config.  PAPI fails to install properly.

FIX: To alleviate this issue, i have added an external package for PAPI for the llnl-sierra system description. 


## Type of Change

- [ ] Adding a system, benchmark, or experiment
- [x] Modifying an existing system, benchmark, or experiment
- [ ]  Documentation update
- [ ]  Build/CI update
- [ ]  Benchpark core functionality