### PR TITLE
fix concretization error

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -120,7 +120,7 @@ class LlnlElcapitan(System):
 packages:
   all:
     require:
-    - one_of: ["%cce", "@:"]
+    - one_of: ["%cce", "%gcc"]
 """
         elif compiler == "gcc":
             return """\


### PR DESCRIPTION
## Description

For `system init llnl-elcapitan compiler=cce`, there is an issue with the generated config.

## Type of Change

- [ ] Adding a system, benchmark, or experiment
- [x] Modifying an existing system, benchmark, or experiment
- [ ] Documentation update
- [ ] Build/CI update
- [ ] Benchpark core functionality
