### PR TITLE
llnl-sierra system config: pkg_spec needs to be a compiler name spack recognizes

### DIFF
--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -301,6 +301,8 @@ compilers:
         compiler_id = self.spec.variants["compiler"][0]
         if compiler_id == "clang-ibm":
             compiler_id = "clang"
+        elif compiler_id == "xl-gcc":
+            compiler_id = "xl"
 
         return f"""\
 software:

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -298,11 +298,15 @@ compilers:
         will fail if these variables are not defined though, so for now
         they are still generated (but with more-generic values).
         """
+        compiler_id = self.spec.variants["compiler"][0]
+        if compiler_id == "clang-ibm":
+            compiler_id = "clang"
+
         return f"""\
 software:
   packages:
     default-compiler:
-      pkg_spec: "{self.spec.variants["compiler"][0]}"
+      pkg_spec: "{compiler_id}"
     default-mpi:
       pkg_spec: spectrum-mpi
     compiler-xl:


### PR DESCRIPTION
This fixes a problem with `system init llnl-sierra compiler=clang-ibm` - this would have always failed without this patch (at the `ramble workspace setup` step).