### PR TITLE
allow newer compilers with older cuda versions

### DIFF
--- a/systems/llnl-sierra/externals/cuda/00-version-10-1-243-packages.yaml
+++ b/systems/llnl-sierra/externals/cuda/00-version-10-1-243-packages.yaml
@@ -16,7 +16,7 @@ packages:
     buildable: false
   cuda:
     externals:
-    - spec: cuda@10.1.243
+    - spec: cuda@10.1.243+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
     buildable: false
   cub:

--- a/systems/llnl-sierra/externals/cuda/01-version-11-8-0-packages.yaml
+++ b/systems/llnl-sierra/externals/cuda/01-version-11-8-0-packages.yaml
@@ -16,7 +16,7 @@ packages:
     buildable: false
   cuda:
     externals:
-    - spec: cuda@11.8.0
+    - spec: cuda@11.8.0+allow-unsupported-compilers
       prefix: /usr/tce/packages/cuda/cuda-11.8.0
     buildable: false
   cub:


### PR DESCRIPTION
CUDA versions offered for `system init llnl-sierra` are old enough that Spack is generally unwilling to use the newer compiler versions that are in the config. This allows using whatever compiler version we specify with the selected CUDA version.
