### PR TITLE
Disable all compiler search

### DIFF
--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -156,7 +156,9 @@ system:
         os.makedirs(aux, exist_ok=True)
         aux_compilers = aux / "compilers.yaml"
 
-        self._merge_config_files(compilers_schema.schema, selections, aux_compilers, override=True)
+        self._merge_config_files(
+            compilers_schema.schema, selections, aux_compilers, override=True
+        )
 
     def system_specific_variables(self):
         return {}

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -117,10 +117,15 @@ system:
     def system_uid(self):
         return _hash_id([str(self.spec)])
 
-    def _merge_config_files(self, schema, selections, dst_path):
+    def _merge_config_files(self, schema, selections, dst_path, override=False):
         data = cfg.read_config_file(selections[0], schema)
         for selection in selections[1:]:
             cfg.merge_yaml(data, cfg.read_config_file(selection, schema))
+
+        if override:
+            for top_level_key, _ in data.items():
+                break
+            top_level_key.override = True
 
         with open(dst_path, "w") as outstream:
             syaml.dump_config(data, outstream)
@@ -151,7 +156,7 @@ system:
         os.makedirs(aux, exist_ok=True)
         aux_compilers = aux / "compilers.yaml"
 
-        self._merge_config_files(compilers_schema.schema, selections, aux_compilers)
+        self._merge_config_files(compilers_schema.schema, selections, aux_compilers, override=True)
 
     def system_specific_variables(self):
         return {}

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -279,7 +279,7 @@ packages:
         cuda_ver = self.spec.variants["cuda"][0]
         cfg = compiler_cfgs[(compiler, cuda_ver)]
         full_cfg = f"""\
-compilers:
+compilers::
 {cfg}
 """
         gen_file = self.next_adhoc_cfg()

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -279,7 +279,7 @@ packages:
         cuda_ver = self.spec.variants["cuda"][0]
         cfg = compiler_cfgs[(compiler, cuda_ver)]
         full_cfg = f"""\
-compilers::
+compilers:
 {cfg}
 """
         gen_file = self.next_adhoc_cfg()


### PR DESCRIPTION
Closes https://github.com/LLNL/benchpark/issues/504

This makes it the only compilers known to Spack (when run by Ramble to build benchmarks/dependencies) are those defined as part of `benchpark system init`. Without this PR, Ramble will run `spack compiler find` to search for compilers, which can lead to unexpected build choices.

### Approach 1 (what this PR currently does)

With this change the compiler config generated by `benchpark system init` will ignore all outside configuration (e.g. any other compilers that have been configured).

### Approach 2

I also experimented with disabling compiler search that automatically occurs within ramble by excluding the phase that does this, like:

```
ramble --workspace-dir ... workspace setup --phases define_package_paths evaluate_requirements get_inputs license_includes make_experiments software_configure software_create_env software_install warn_deprecated_variables write_inventory write_status
```

(i.e. this includes every phase except `software_install_requested_compilers`)

### Comparison

Both of these approaches work, but both depend on Ramble behavior that is not guaranteed for future commits of Ramble (i.e. this could break if the pinned Ramble version were updated).

[2] will fail if any call to `workspace setup` doesn't omit this phase (i.e. if you run one experiment with this phase, then every other experiment will see those compilers, because the config is dumped into the spack prefix config scope); therefore I prefer [1].