### PR TITLE
elcapitan system: associate module with compiler

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -345,7 +345,8 @@ compilers:
       cxxflags: -g -O2
     operating_system: rhel8
     target: x86_64
-    modules: []
+    modules:
+    - cce/{y}
     environment:
       set:
         RFE_811452_DISABLE: '1'


### PR DESCRIPTION
Fixes https://github.com/LLNL/benchpark/issues/487

Associate a module with the `%cce` compiler on `llnl-elcapitan`: without this, concretizations that occur as part of `ramble workspace setup` may fail (they can succeed if this module is loaded manually, but with the addition in this PR, you can `ramble workspace setup` using `llnl-elcapitan compiler=cce` in a `module purge`d environment).

Note: The module is not needed for finding compilers (that was disabled in https://github.com/LLNL/benchpark/pull/572)