### PR TITLE
Benchpark info command, new experiment and system directives

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -41,6 +41,12 @@ Search for available system and experiment specifications in Benchpark.
    * - benchpark tags -t tag workspace
      - Lists all experiments in Benchpark with a given tag
      -
+   * - benchpark info system <system>
+     - Lists all information about a given system
+     -
+   * - benchpark info experiment <experiment>
+     - Lists all information about a given experiment
+     -
 
 Now that you know the existing benchmarks and systems, you can determine your necessary workflow in :doc:`benchpark-workflow`.
 

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -42,10 +42,6 @@ class Amg2023(
 
     url = "https://github.com/LLNL/AMG2023"
 
-    spack_name = "amg2023"
-
-    ramble_name = "amg2023"
-
     # requires("system+papi", when(caliper=topdown*))
 
     # TODO: Support list of 3-tuples

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -40,7 +40,6 @@ class Amg2023(
 
     maintainers("pearce8")
 
-
     # requires("system+papi", when(caliper=topdown*))
 
     # TODO: Support list of 3-tuples

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -37,6 +37,14 @@ class Amg2023(
         default="develop",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/LLNL/AMG2023"
+
+    spack_name = "amg2023"
+
+    ramble_name = "amg2023"
 
     # requires("system+papi", when(caliper=topdown*))
 

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -38,6 +38,8 @@ class Amg2023(
         description="app version",
     )
 
+    maintainers("pearce8")
+
     url = "https://github.com/LLNL/AMG2023"
 
     # requires("system+papi", when(caliper=topdown*))

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -40,7 +40,6 @@ class Amg2023(
 
     maintainers("pearce8")
 
-    url = "https://github.com/LLNL/AMG2023"
 
     # requires("system+papi", when(caliper=topdown*))
 

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -37,8 +37,6 @@ class Amg2023(
         default="develop",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/LLNL/AMG2023"
 

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
@@ -30,6 +30,14 @@ class Babelstream(
         values=("4.0", "develop", "caliper"),
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/UoB-HPC/BabelStream"
+
+    spack_name = "babelstream"
+
+    ramble_name = "babelstream"
 
     def compute_applications_section(self):
 

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -32,7 +32,6 @@ class Babelstream(
     )
 
     maintainers("daboehme")
-    url = "https://github.com/UoB-HPC/BabelStream"
 
     def compute_applications_section(self):
 

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
@@ -30,8 +30,6 @@ class Babelstream(
         values=("4.0", "develop", "caliper"),
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/UoB-HPC/BabelStream"
 

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -35,10 +35,6 @@ class Babelstream(
 
     url = "https://github.com/UoB-HPC/BabelStream"
 
-    spack_name = "babelstream"
-
-    ramble_name = "babelstream"
-
     def compute_applications_section(self):
 
         self.add_experiment_variable("processes_per_node", "1", True)

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -31,6 +31,7 @@ class Babelstream(
         description="app version",
     )
 
+    maintainers("daboehme")
     url = "https://github.com/UoB-HPC/BabelStream"
 
     def compute_applications_section(self):

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 
@@ -22,8 +22,6 @@ class Genesis(Experiment, OpenMPExperiment):
         default="main",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://www.r-ccs.riken.jp/labs/cbrt/"
 

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -23,6 +23,7 @@ class Genesis(Experiment, OpenMPExperiment):
         description="app version",
     )
 
+    maintainers("jdomke", "SBA0486")
     url = "https://www.r-ccs.riken.jp/labs/cbrt/"
 
     def compute_applications_section(self):

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 
@@ -22,6 +22,14 @@ class Genesis(Experiment, OpenMPExperiment):
         default="main",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://www.r-ccs.riken.jp/labs/cbrt/"
+
+    spack_name = "genesis"
+
+    ramble_name = "genesis"
 
     def compute_applications_section(self):
 

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -27,10 +27,6 @@ class Genesis(Experiment, OpenMPExperiment):
 
     url = "https://www.r-ccs.riken.jp/labs/cbrt/"
 
-    spack_name = "genesis"
-
-    ramble_name = "genesis"
-
     def compute_applications_section(self):
 
         self.add_experiment_variable("experiment_setup", "")

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -24,7 +24,6 @@ class Genesis(Experiment, OpenMPExperiment):
     )
 
     maintainers("jdomke", "SBA0486")
-    url = "https://www.r-ccs.riken.jp/labs/cbrt/"
 
     def compute_applications_section(self):
 

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -29,6 +29,7 @@ class Gromacs(
         description="app version",
     )
 
+    maintainers("pszi1ard")
     url = "https://www.gromacs.org"
 
     # off: turn off GPU-aware MPI

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -33,10 +33,6 @@ class Gromacs(
 
     url = "https://www.gromacs.org"
 
-    spack_name = "gromacs"
-
-    ramble_name = "gromacs"
-
     # off: turn off GPU-aware MPI
     # on: turn on, but allow groamcs to disable it if GPU-aware MPI is not supported
     # force: turn on and force gromacs to use GPU-aware MPI. May result in error if unsupported

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -28,8 +28,6 @@ class Gromacs(
         values=("2024", "2023.3"),
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://www.gromacs.org"
 

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -30,7 +30,6 @@ class Gromacs(
     )
 
     maintainers("pszi1ard")
-    url = "https://www.gromacs.org"
 
     # off: turn off GPU-aware MPI
     # on: turn on, but allow groamcs to disable it if GPU-aware MPI is not supported

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -28,6 +28,14 @@ class Gromacs(
         values=("2024", "2023.3"),
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://www.gromacs.org"
+
+    spack_name = "gromacs"
+
+    ramble_name = "gromacs"
 
     # off: turn off GPU-aware MPI
     # on: turn on, but allow groamcs to disable it if GPU-aware MPI is not supported

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
@@ -31,6 +31,14 @@ class Hpl(
         default="2.3-caliper",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://www.netlib.org/benchmark/hpl/"
+
+    spack_name = "hpl"
+
+    ramble_name = "hpl"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -33,7 +33,6 @@ class Hpl(
     )
 
     maintainers("daboehme")
-    url = "https://www.netlib.org/benchmark/hpl/"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -32,6 +32,7 @@ class Hpl(
         description="app version",
     )
 
+    maintainers("daboehme")
     url = "https://www.netlib.org/benchmark/hpl/"
 
     def compute_applications_section(self):

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -36,10 +36,6 @@ class Hpl(
 
     url = "https://www.netlib.org/benchmark/hpl/"
 
-    spack_name = "hpl"
-
-    ramble_name = "hpl"
-
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause
         scaling_modes = {

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
@@ -31,8 +31,6 @@ class Hpl(
         default="2.3-caliper",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://www.netlib.org/benchmark/hpl/"
 

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -31,10 +31,6 @@ class Ior(
 
     url = "https://github.com/hpc/ior"
 
-    spack_name = "ior"
-
-    ramble_name = "ior"
-
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause
         scaling_modes = {

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
@@ -26,8 +26,6 @@ class Ior(
         default="3.3.0",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/hpc/ior"
 

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
@@ -26,6 +26,14 @@ class Ior(
         default="3.3.0",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/hpc/ior"
+
+    spack_name = "ior"
+
+    ramble_name = "ior"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -27,6 +27,7 @@ class Ior(
         description="app version",
     )
 
+    maintainers("hariharan-devarajan")
     url = "https://github.com/hpc/ior"
 
     def compute_applications_section(self):

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -28,7 +28,6 @@ class Ior(
     )
 
     maintainers("hariharan-devarajan")
-    url = "https://github.com/hpc/ior"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -36,8 +36,6 @@ class Kripke(
         default="develop",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://computing.llnl.gov/projects/co-design/kripke"
 

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -41,10 +41,6 @@ class Kripke(
 
     url = "https://computing.llnl.gov/projects/co-design/kripke"
 
-    spack_name = "kripke"
-
-    ramble_name = "kripke"
-
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause
         scaling_modes = {

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -37,6 +37,7 @@ class Kripke(
         description="app version",
     )
 
+    maintainers("pearce8")
     url = "https://computing.llnl.gov/projects/co-design/kripke"
 
     def compute_applications_section(self):

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -36,6 +36,14 @@ class Kripke(
         default="develop",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://computing.llnl.gov/projects/co-design/kripke"
+
+    spack_name = "kripke"
+
+    ramble_name = "kripke"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -38,7 +38,6 @@ class Kripke(
     )
 
     maintainers("pearce8")
-    url = "https://computing.llnl.gov/projects/co-design/kripke"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -35,10 +35,6 @@ class Laghos(
 
     url = "https://github.com/wdhawkins/laghos"
 
-    spack_name = "laghos"
-
-    ramble_name = "laghos"
-
     def compute_applications_section(self):
 
         # Number of initial nodes

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.caliper import Caliper
@@ -30,8 +30,6 @@ class Laghos(
         default="develop",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/wdhawkins/laghos"
 

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.caliper import Caliper
@@ -30,6 +30,14 @@ class Laghos(
         default="develop",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/wdhawkins/laghos"
+
+    spack_name = "laghos"
+
+    ramble_name = "laghos"
 
     def compute_applications_section(self):
 

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -32,7 +32,6 @@ class Laghos(
     )
 
     maintainers("wdhawkins")
-    url = "https://github.com/wdhawkins/laghos"
 
     def compute_applications_section(self):
 

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -31,6 +31,7 @@ class Laghos(
         description="app version",
     )
 
+    maintainers("wdhawkins")
     url = "https://github.com/wdhawkins/laghos"
 
     def compute_applications_section(self):

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -36,8 +36,6 @@ class Lammps(
         when=("+cuda" or "+rocm"),
         description="Enable GPU-aware MPI",
     )
-
-    maintainer("")
 
     url = "https://www.lammps.org/"
 

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -41,10 +41,6 @@ class Lammps(
 
     url = "https://www.lammps.org/"
 
-    spack_name = "lammps"
-
-    ramble_name = "lammps"
-
     def compute_applications_section(self):
         if self.spec.satisfies("+openmp"):
             problem_sizes = {"x": 8, "y": 8, "z": 8}

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -36,6 +36,14 @@ class Lammps(
         when=("+cuda" or "+rocm"),
         description="Enable GPU-aware MPI",
     )
+
+    maintainer("")
+
+    url = "https://www.lammps.org/"
+
+    spack_name = "lammps"
+
+    ramble_name = "lammps"
 
     def compute_applications_section(self):
         if self.spec.satisfies("+openmp"):

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -37,6 +37,7 @@ class Lammps(
         description="Enable GPU-aware MPI",
     )
 
+    maintainers("simongdg", "rfhaque")
     url = "https://www.lammps.org/"
 
     def compute_applications_section(self):

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -38,7 +38,6 @@ class Lammps(
     )
 
     maintainers("simongdg", "rfhaque")
-    url = "https://www.lammps.org/"
 
     def compute_applications_section(self):
         if self.spec.satisfies("+openmp"):

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -95,7 +95,6 @@ class OsuMicroBenchmarks(
     )
 
     maintainers("nhanford")
-    url = "https://mvapich.cse.ohio-state.edu/benchmarks/"
 
     def compute_applications_section(self):
 

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.cuda import CudaExperiment
@@ -93,8 +93,6 @@ class OsuMicroBenchmarks(
         multi=True,
         description="workloads available",
     )
-
-    maintainer("")
 
     url = "https://mvapich.cse.ohio-state.edu/benchmarks/"
 

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -98,10 +98,6 @@ class OsuMicroBenchmarks(
 
     url = "https://mvapich.cse.ohio-state.edu/benchmarks/"
 
-    spack_name = "osu-micro-benchmarks"
-
-    ramble_name = "osu-micro-benchmarks"
-
     def compute_applications_section(self):
 
         num_nodes = {"n_nodes": 2}

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.cuda import CudaExperiment
@@ -93,6 +93,14 @@ class OsuMicroBenchmarks(
         multi=True,
         description="workloads available",
     )
+
+    maintainer("")
+
+    url = "https://mvapich.cse.ohio-state.edu/benchmarks/"
+
+    spack_name = "osu-micro-benchmarks"
+
+    ramble_name = "osu-micro-benchmarks"
 
     def compute_applications_section(self):
 

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -94,6 +94,7 @@ class OsuMicroBenchmarks(
         description="workloads available",
     )
 
+    maintainers("nhanford")
     url = "https://mvapich.cse.ohio-state.edu/benchmarks/"
 
     def compute_applications_section(self):

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -23,7 +23,6 @@ class Phloem(Experiment, StrongScaling):
     )
 
     maintainers("nhanford")
-    url = "https://github.com/LLNL/phloem"
 
     def compute_applications_section(self):
         if self.spec.satisfies("workload=sqmr"):

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -22,6 +22,7 @@ class Phloem(Experiment, StrongScaling):
         description="app version",
     )
 
+    maintainers("nhanford")
     url = "https://github.com/LLNL/phloem"
 
     def compute_applications_section(self):

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -26,10 +26,6 @@ class Phloem(Experiment, StrongScaling):
 
     url = "https://github.com/LLNL/phloem"
 
-    spack_name = "phloem"
-
-    ramble_name = "phloem"
-
     def compute_applications_section(self):
         if self.spec.satisfies("workload=sqmr"):
             self.add_experiment_variable(

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -21,8 +21,6 @@ class Phloem(Experiment, StrongScaling):
         default="master",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/LLNL/phloem"
 

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -21,6 +21,14 @@ class Phloem(Experiment, StrongScaling):
         default="master",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/LLNL/phloem"
+
+    spack_name = "phloem"
+
+    ramble_name = "phloem"
 
     def compute_applications_section(self):
         if self.spec.satisfies("workload=sqmr"):

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.scaling import StrongScaling
@@ -27,8 +27,6 @@ class Quicksilver(
         default="master",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://codesign.llnl.gov/quicksilver.php"
 

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -28,6 +28,7 @@ class Quicksilver(
         description="app version",
     )
 
+    maintainers("rfhaque")
     url = "https://codesign.llnl.gov/quicksilver.php"
 
     def compute_applications_section(self):

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -32,10 +32,6 @@ class Quicksilver(
 
     url = "https://codesign.llnl.gov/quicksilver.php"
 
-    spack_name = "quicksilver"
-
-    ramble_name = "quicksilver"
-
     def compute_applications_section(self):
         self.add_experiment_variable("n_threads_per_proc", "1")
         self.add_experiment_variable("n_ranks", "{I}*{J}*{K}", True)

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.scaling import StrongScaling
@@ -27,6 +27,14 @@ class Quicksilver(
         default="master",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://codesign.llnl.gov/quicksilver.php"
+
+    spack_name = "quicksilver"
+
+    ramble_name = "quicksilver"
 
     def compute_applications_section(self):
         self.add_experiment_variable("n_threads_per_proc", "1")

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -29,7 +29,6 @@ class Quicksilver(
     )
 
     maintainers("rfhaque")
-    url = "https://codesign.llnl.gov/quicksilver.php"
 
     def compute_applications_section(self):
         self.add_experiment_variable("n_threads_per_proc", "1")

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 
@@ -21,8 +21,6 @@ class Qws(Experiment, OpenMPExperiment):
         default="master",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://www.riken.jp/en/research/labs/r-ccs/field_theor/index.html"
 

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -23,7 +23,6 @@ class Qws(Experiment, OpenMPExperiment):
     )
 
     maintainers("jdomke", "SBA0486")
-    url = "https://www.riken.jp/en/research/labs/r-ccs/field_theor/index.html"
 
     def compute_applications_section(self):
 

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -22,6 +22,7 @@ class Qws(Experiment, OpenMPExperiment):
         description="app version",
     )
 
+    maintainers("jdomke", "SBA0486")
     url = "https://www.riken.jp/en/research/labs/r-ccs/field_theor/index.html"
 
     def compute_applications_section(self):

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 
@@ -21,6 +21,14 @@ class Qws(Experiment, OpenMPExperiment):
         default="master",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://www.riken.jp/en/research/labs/r-ccs/field_theor/index.html"
+
+    spack_name = "qws"
+
+    ramble_name = "qws"
 
     def compute_applications_section(self):
 

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -26,10 +26,6 @@ class Qws(Experiment, OpenMPExperiment):
 
     url = "https://www.riken.jp/en/research/labs/r-ccs/field_theor/index.html"
 
-    spack_name = "qws"
-
-    ramble_name = "qws"
-
     def compute_applications_section(self):
 
         self.add_experiment_variable("experiment_setup", "")

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.openmp import OpenMPExperiment
@@ -31,6 +31,14 @@ class RajaPerf(
         default="develop",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "http://software.llnl.gov/RAJAPerf/"
+
+    spack_name = "raja-perf"
+
+    ramble_name = "raja-perf"
 
     def compute_applications_section(self):
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -34,8 +34,6 @@ class RajaPerf(
 
     maintainers("michaelmckinsey1")
 
-    url = "http://software.llnl.gov/RAJAPerf/"
-
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.openmp import OpenMPExperiment
@@ -32,7 +32,7 @@ class RajaPerf(
         description="app version",
     )
 
-    maintainer("")
+    maintainers("michaelmckinsey1")
 
     url = "http://software.llnl.gov/RAJAPerf/"
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -36,10 +36,6 @@ class RajaPerf(
 
     url = "http://software.llnl.gov/RAJAPerf/"
 
-    spack_name = "raja-perf"
-
-    ramble_name = "raja-perf"
-
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -38,10 +38,6 @@ class Remhos(
 
     url = "https://github.com/CEED/Remhos"
 
-    spack_name = "remhos"
-
-    ramble_name = "remhos"
-
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause
         scaling_modes = {

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -35,7 +35,6 @@ class Remhos(
     )
 
     maintainers("rfhaque")
-    url = "https://github.com/CEED/Remhos"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.caliper import Caliper
@@ -33,6 +33,14 @@ class Remhos(
         values=("1.0", "develop", "gpu-fom", "gpu-opt"),
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/CEED/Remhos"
+
+    spack_name = "remhos"
+
+    ramble_name = "remhos"
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -34,6 +34,7 @@ class Remhos(
         description="app version",
     )
 
+    maintainers("rfhaque")
     url = "https://github.com/CEED/Remhos"
 
     def compute_applications_section(self):

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.error import BenchparkError
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.caliper import Caliper
@@ -33,8 +33,6 @@ class Remhos(
         values=("1.0", "develop", "gpu-fom", "gpu-opt"),
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/CEED/Remhos"
 

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -24,8 +24,6 @@ class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Calipe
         default="1.0.0",
         description="app version",
     )
-
-    maintainer("")
 
     url = ""
 

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
@@ -24,6 +24,14 @@ class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Calipe
         default="1.0.0",
         description="app version",
     )
+
+    maintainer("")
+
+    url = ""
+
+    spack_name = "saxpy"
+
+    ramble_name = "saxpy"
 
     def compute_applications_section(self):
         # GPU tests include some smaller sizes

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -25,7 +25,7 @@ class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Calipe
         description="app version",
     )
 
-    url = ""
+    maintainers("rfhaque")
 
     def compute_applications_section(self):
         # GPU tests include some smaller sizes

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -29,10 +29,6 @@ class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Calipe
 
     url = ""
 
-    spack_name = "saxpy"
-
-    ramble_name = "saxpy"
-
     def compute_applications_section(self):
         # GPU tests include some smaller sizes
         n = ["512", "1024"]

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -23,7 +23,7 @@ class Smb(Experiment, StrongScaling):
     )
 
     maintainers("nhanford")
-    url = "https://github.com/sandialabs/SMB"
+
 
     def compute_applications_section(self):
         if self.spec.satisfies("workload=mpi_overhead"):

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -26,10 +26,6 @@ class Smb(Experiment, StrongScaling):
 
     url = "https://github.com/sandialabs/SMB"
 
-    spack_name = "smb"
-
-    ramble_name = "smb"
-
     def compute_applications_section(self):
         if self.spec.satisfies("workload=mpi_overhead"):
             self.add_experiment_variable("n_ranks", "2")

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -22,6 +22,7 @@ class Smb(Experiment, StrongScaling):
         description="app version",
     )
 
+    maintainers("nhanford")
     url = "https://github.com/sandialabs/SMB"
 
     def compute_applications_section(self):

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -21,8 +21,6 @@ class Smb(Experiment, StrongScaling):
         default="master",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://github.com/sandialabs/SMB"
 

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -21,6 +21,14 @@ class Smb(Experiment, StrongScaling):
         default="master",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://github.com/sandialabs/SMB"
+
+    spack_name = "smb"
+
+    ramble_name = "smb"
 
     def compute_applications_section(self):
         if self.spec.satisfies("workload=mpi_overhead"):

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -24,7 +24,6 @@ class Smb(Experiment, StrongScaling):
 
     maintainers("nhanford")
 
-
     def compute_applications_section(self):
         if self.spec.satisfies("workload=mpi_overhead"):
             self.add_experiment_variable("n_ranks", "2")

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.caliper import Caliper
 
@@ -23,8 +23,6 @@ class Stream(
         default="5.10",
         description="app version",
     )
-
-    maintainer("")
 
     url = "https://www.cs.virginia.edu/stream/ref.html"
 

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -24,6 +24,7 @@ class Stream(
         description="app version",
     )
 
+    maintainers("daboehme","rfhaque")
     url = "https://www.cs.virginia.edu/stream/ref.html"
 
     def compute_applications_section(self):

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -25,7 +25,7 @@ class Stream(
     )
 
     maintainers("daboehme","rfhaque")
-    url = "https://www.cs.virginia.edu/stream/ref.html"
+
 
     def compute_applications_section(self):
 

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainer
 from benchpark.experiment import Experiment
 from benchpark.caliper import Caliper
 
@@ -23,6 +23,14 @@ class Stream(
         default="5.10",
         description="app version",
     )
+
+    maintainer("")
+
+    url = "https://www.cs.virginia.edu/stream/ref.html"
+
+    spack_name = "stream"
+
+    ramble_name = "stream"
 
     def compute_applications_section(self):
 

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -24,8 +24,7 @@ class Stream(
         description="app version",
     )
 
-    maintainers("daboehme","rfhaque")
-
+    maintainers("daboehme", "rfhaque")
 
     def compute_applications_section(self):
 

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -28,10 +28,6 @@ class Stream(
 
     url = "https://www.cs.virginia.edu/stream/ref.html"
 
-    spack_name = "stream"
-
-    ramble_name = "stream"
-
     def compute_applications_section(self):
 
         array_size = {"s": 650000000}

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import textwrap
 
@@ -65,6 +66,31 @@ def info_system(args):
                 else:
                     resource_key = "@*r" + resource_key + "@."
                     color.cprint(f"{indent()*2}{resource_key}: {resource_value}")
+
+    def _handle_query(query):
+        key, value = query.split("=", 1)
+        exclude = {"all_hardware_descriptions", "repo.yaml", "generic-x86"}
+        all_system_specs = []
+        for d in set(os.listdir(benchpark.paths.benchpark_root / "systems")) - exclude:
+            all_system_specs.append(benchpark.spec.SystemSpec(d))
+
+        matching_systems = []
+        for spec in all_system_specs:
+            resources = spec.system_class.id_to_resources
+            for cluster, resource_dict in resources.items():
+                if str(resource_dict.get(key)) == value:
+                    matching_systems.append((spec.name, cluster))
+
+        if matching_systems:
+            gen_header(query)
+            for system_name, cluster in matching_systems:
+                color.cprint(f"{indent()}@*g{system_name}@.: {cluster}")
+        else:
+            print("No matching systems found.")
+
+    if args.query:
+        _handle_query(args.query)
+        return
 
     system_spec = benchpark.spec.SystemSpec(args.name)
     system_class = system_spec.system_class
@@ -153,7 +179,10 @@ def setup_parser(root_parser):
     )
     system_parser.add_argument("--system-site", action="store_true", help="System site")
     system_parser.add_argument("--maintainers", action="store_true", help="Maintainers")
-    system_parser.add_argument("name", help="System name")
+    system_parser.add_argument(
+        "--query", type=str, help="Query systems with key-value pairs (e.g., key=value)"
+    )
+    system_parser.add_argument("name", help="System name", nargs="?")
 
     experiment_parser = info_subparser.add_parser("experiment")
     experiment_parser.add_argument(

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -125,10 +125,10 @@ def info_experiment(args):
     experiment_class = conc.experiment
 
     if args.spack:
-        subprocess.run(["spack", "info", experiment_class.spack_name])
+        subprocess.run(["spack", "info", experiment_class.spack_name if experiment_class.spack_name else experiment_class.name])
         return
     elif args.ramble:
-        subprocess.run(["ramble", "info", experiment_class.ramble_name])
+        subprocess.run(["ramble", "info", experiment_class.ramble_name if experiment_class.ramble_name else experiment_class.name])
         return
     else:
         actions = {

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -1,5 +1,3 @@
-import glob
-import sys
 import textwrap
 
 import yaml
@@ -62,14 +60,6 @@ def info_system(args):
         info_system_variants(system_spec)
         info_system_hardware(system_spec)
 
-    # conc_system_spec = system_spec.concretize()
-    # system = conc_system_spec.system
-    # system.initialize()
-
-    # print("\n\n\n\n")
-    # print([i for i in system.__dict__.keys()])
-    # print(system.sw_description())
-
 
 def setup_parser(root_parser):
     info_subparser = root_parser.add_subparsers(dest="info_subcommand")
@@ -92,7 +82,6 @@ def command(args):
         "system": info_system,
     }
     if args.info_subcommand in actions:
-        print(args)
         actions[args.info_subcommand](args)
     else:
         raise ValueError(f"Unknown subcommand for 'info': {args.info_subcommand}")

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -9,56 +9,56 @@ def gen_header(name):
     print("=" * 20 + f"\n=== {name}\n" + "=" * 20)
 
 
-def info_system_system_site(system_spec):
-    gen_header("System Site")
-    print(system_spec.system_class.system_site)
-
-
-def info_system_maintainer(system_spec):
-    gen_header("Maintainer")
-    print(system_spec.system_class.maintainer)
-
-
-def info_system_variants(system_spec):
-    gen_header("Variants")
-    # Dict with one value
-    all_variants = list(system_spec.system_class.variants.values())[0]
-    for var in all_variants.values():
-        for attr in var.__dict__.keys():
-            print(attr + ":", var.__dict__[attr])
-        print()
-        # print(var.name+":", var.values)
-
-
-def info_system_hardware(system_spec):
-    gen_header("Hardware")
-    for cluster, resource_dict in system_spec.system_class.id_to_resources.items():
-        print("For cluster", cluster + ":")
-        for resource_key, resource_value in resource_dict.items():
-            if isinstance(resource_value, str) and ".yaml" in resource_value:
-                print("\t" + resource_key + ":")
-                data = yaml.safe_load(open(resource_value, "r"))
-                print(textwrap.indent(yaml.dump(data), "\t"))
-            else:
-                print("\t" + resource_key + ":", resource_value)
-
-
 def info_system(args):
+    def _info_system_system_site(system_spec):
+        gen_header("System Site")
+        print(system_spec.system_class.system_site)
+
+    def _info_system_maintainer(system_spec):
+        gen_header("Maintainer")
+        print(system_spec.system_class.maintainer)
+
+    def _info_system_variants(system_spec):
+        gen_header("Variants")
+        all_variants = list(system_spec.system_class.variants.values())[0]
+        for var in all_variants.values():
+            for attr, value in var.__dict__.items():
+                print(f"{attr}: {value}")
+            print()
+
+    def _info_system_hardware(system_spec):
+        gen_header("Hardware")
+        for cluster, resource_dict in system_spec.system_class.id_to_resources.items():
+            print(f"For cluster {cluster}:")
+            for resource_key, resource_value in resource_dict.items():
+                if isinstance(resource_value, str) and ".yaml" in resource_value:
+                    print(f"\t{resource_key}:")
+                    with open(resource_value, "r") as f:
+                        data = yaml.safe_load(f)
+                        print(textwrap.indent(yaml.dump(data), "\t"))
+                else:
+                    print(f"\t{resource_key}: {resource_value}")
+
     system_spec = benchpark.spec.SystemSpec(" ".join(args.spec))
 
-    if args.system_site:
-        info_system_system_site(system_spec)
-    if args.maintainer:
-        info_system_maintainer(system_spec)
-    if args.variants:
-        info_system_variants(system_spec)
-    if args.hardware:
-        info_system_hardware(system_spec)
-    if not args.system_site and not args.variants and not args.hardware:
-        info_system_system_site(system_spec)
-        info_system_maintainer(system_spec)
-        info_system_variants(system_spec)
-        info_system_hardware(system_spec)
+    # Map argument flags to functions
+    actions = {
+        "system_site": _info_system_system_site,
+        "maintainer": _info_system_maintainer,
+        "variants": _info_system_variants,
+        "hardware": _info_system_hardware,
+    }
+
+    # Call functions for enabled options, or all if no flag is set
+    any_flag_set = False
+    for flag, action in actions.items():
+        if getattr(args, flag, False):
+            action(system_spec)
+            any_flag_set = True
+
+    if not any_flag_set:
+        for action in actions.values():
+            action(system_spec)
 
 
 def setup_parser(root_parser):

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -1,6 +1,8 @@
+import subprocess
 import textwrap
 
 import yaml
+import spack.cmd.info as spackinfo
 
 import benchpark.paths
 
@@ -9,26 +11,30 @@ def gen_header(name):
     print("=" * 20 + f"\n=== {name}\n" + "=" * 20)
 
 
+def info_variants(spec_class):
+    """SystemSpec.system_class or ExperimentSpec.experiment_class"""
+    gen_header("Variants")
+    all_variants = list(spec_class.variants.values())[0]
+    for var in all_variants.values():
+        for attr, value in var.__dict__.items():
+            print(f"{attr}: {value}")
+        print()
+
+
+def info_maintainer(spec_class):
+    """SystemSpec.system_class or ExperimentSpec.experiment_class"""
+    gen_header("Maintainer")
+    print(spec_class.maintainer)
+
+
 def info_system(args):
-    def _info_system_system_site(system_spec):
+    def _info_system_system_site(system_class):
         gen_header("System Site")
-        print(system_spec.system_class.system_site)
+        print(system_class.system_site)
 
-    def _info_system_maintainer(system_spec):
-        gen_header("Maintainer")
-        print(system_spec.system_class.maintainer)
-
-    def _info_system_variants(system_spec):
-        gen_header("Variants")
-        all_variants = list(system_spec.system_class.variants.values())[0]
-        for var in all_variants.values():
-            for attr, value in var.__dict__.items():
-                print(f"{attr}: {value}")
-            print()
-
-    def _info_system_hardware(system_spec):
+    def _info_system_hardware(system_class):
         gen_header("Hardware")
-        for cluster, resource_dict in system_spec.system_class.id_to_resources.items():
+        for cluster, resource_dict in system_class.id_to_resources.items():
             print(f"For cluster {cluster}:")
             for resource_key, resource_value in resource_dict.items():
                 if isinstance(resource_value, str) and ".yaml" in resource_value:
@@ -40,25 +46,56 @@ def info_system(args):
                     print(f"\t{resource_key}: {resource_value}")
 
     system_spec = benchpark.spec.SystemSpec(" ".join(args.spec))
+    system_class = system_spec.system_class
 
     # Map argument flags to functions
     actions = {
-        "system_site": _info_system_system_site,
-        "maintainer": _info_system_maintainer,
-        "variants": _info_system_variants,
-        "hardware": _info_system_hardware,
+        "system_site": (_info_system_system_site, [system_class]),
+        "maintainer": (info_maintainer, [system_class]),
+        "variants": (info_variants, [system_class]),
+        "hardware": (_info_system_hardware, [system_class]),
     }
 
     # Call functions for enabled options, or all if no flag is set
     any_flag_set = False
-    for flag, action in actions.items():
+    for flag, (action, aargs) in actions.items():
         if getattr(args, flag, False):
-            action(system_spec)
+            action(*aargs)
             any_flag_set = True
 
     if not any_flag_set:
-        for action in actions.values():
-            action(system_spec)
+        for action, aargs in actions.values():
+            action(*aargs)
+
+
+def info_experiment(args):
+    experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.spec))
+    experiment_class = experiment_spec.experiment_class
+
+    #spackinfo.print_variants(experiment_class)
+
+    if args.spack:
+        subprocess.run(["spack", "info", experiment_class.spack_name])
+        return
+    elif args.ramble:
+        subprocess.run(["ramble", "info", experiment_class.ramble_name])
+        return
+    else:
+        actions = {
+            "variants": (info_variants, [experiment_class]),
+            "maintainer": (info_maintainer, [experiment_class]),
+        }
+
+        # Call functions for enabled options, or all if no flag is set
+        any_flag_set = False
+        for flag, (action, aargs) in actions.items():
+            if getattr(args, flag, False):
+                action(*aargs)
+                any_flag_set = True
+
+        if not any_flag_set:
+            for action, aargs in actions.values():
+                action(*aargs)
 
 
 def setup_parser(root_parser):
@@ -73,13 +110,22 @@ def setup_parser(root_parser):
     )
     system_parser.add_argument("--system-site", action="store_true", help="System site")
     system_parser.add_argument("--maintainer", action="store_true", help="Maintainer")
-
     system_parser.add_argument("spec", nargs="+", help="System spec")
+
+    experiment_parser = info_subparser.add_parser("experiment")
+    experiment_parser.add_argument(
+        "--spack", action="store_true", help="Information from Spack package"
+    )
+    experiment_parser.add_argument(
+        "--ramble", action="store_true", help="Information from Ramble package"
+    )
+    experiment_parser.add_argument("spec", nargs="+", help="Experiment spec")
 
 
 def command(args):
     actions = {
         "system": info_system,
+        "experiment": info_experiment,
     }
     if args.info_subcommand in actions:
         actions[args.info_subcommand](args)

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -26,21 +26,16 @@ def info_variants(spec_class):
         print()
 
 
-def info_maintainer(spec_class):
+def info_maintainers(spec_class):
     """SystemSpec.system_class or ExperimentSpec.experiment_class"""
-    gen_header("Maintainer")
-    mstr = indent()
-    if spec_class.maintainer == "":
-        mstr += "No maintainer"
-    else:
-        mstr += spec_class.maintainer
-    print(mstr)
+    gen_header("Maintainers")
+    print(indent() + ",".join(spec_class.maintainers))
 
 
 def info_system(args):
     def _info_system_system_site(system_class):
         gen_header("System Site")
-        print(indent() + system_class.system_site)
+        print(indent() + getattr(system_class, "system_site", "None"))
 
     def _info_system_hardware(system_class):
         def _replace_keys_with_colors(data, colors, level=0):
@@ -81,7 +76,7 @@ def info_system(args):
     # Map argument flags to functions
     actions = {
         "hardware": (_info_system_hardware, [system_class]),
-        "maintainer": (info_maintainer, [system_class]),
+        "maintainers": (info_maintainers, [system_class]),
         "system_site": (_info_system_system_site, [system_class]),
         "variants": (info_variants, [system_class]),
     }
@@ -101,7 +96,7 @@ def info_system(args):
 def info_experiment(args):
     def _info_url(experiment_class):
         gen_header("URL")
-        print(indent() + experiment_class.url)
+        print(indent() + getattr(experiment_class, "url", "None"))
 
     def _info_spack_name(experiment_class):
         gen_header("Spack Name")
@@ -137,7 +132,7 @@ def info_experiment(args):
         return
     else:
         actions = {
-            "maintainer": (info_maintainer, [experiment_class]),
+            "maintainers": (info_maintainers, [experiment_class]),
             "ramble_name": (_info_ramble_name, [experiment_class]),
             "spack_name": (_info_spack_name, [experiment_class]),
             "url": (_info_url, [experiment_class]),
@@ -167,7 +162,7 @@ def setup_parser(root_parser):
         "--hardware", action="store_true", help="Hardware descriptions per cluster"
     )
     system_parser.add_argument("--system-site", action="store_true", help="System site")
-    system_parser.add_argument("--maintainer", action="store_true", help="Maintainer")
+    system_parser.add_argument("--maintainers", action="store_true", help="Maintainers")
     system_parser.add_argument("name", help="System name")
 
     experiment_parser = info_subparser.add_parser("experiment")
@@ -184,7 +179,7 @@ def setup_parser(root_parser):
         "--variants", action="store_true", help="Available experiment variants"
     )
     experiment_parser.add_argument(
-        "--maintainer", action="store_true", help="Maintainer"
+        "--maintainers", action="store_true", help="Maintainers"
     )
     experiment_parser.add_argument("name", help="Experiment name")
 

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -142,10 +142,30 @@ def info_experiment(args):
     experiment_class = conc.experiment
 
     if args.spack:
-        subprocess.run(["spack", "info", experiment_class.spack_name if experiment_class.spack_name else experiment_class.name])
+        subprocess.run(
+            [
+                "spack",
+                "info",
+                (
+                    experiment_class.spack_name
+                    if experiment_class.spack_name
+                    else experiment_class.name
+                ),
+            ]
+        )
         return
     elif args.ramble:
-        subprocess.run(["ramble", "info", experiment_class.ramble_name if experiment_class.ramble_name else experiment_class.name])
+        subprocess.run(
+            [
+                "ramble",
+                "info",
+                (
+                    experiment_class.ramble_name
+                    if experiment_class.ramble_name
+                    else experiment_class.name
+                ),
+            ]
+        )
         return
     else:
         actions = {

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -103,8 +103,31 @@ def info_experiment(args):
         gen_header("URL")
         print(indent() + experiment_class.url)
 
+    def _info_spack_name(experiment_class):
+        gen_header("Spack Name")
+        print(
+            indent()
+            + (
+                experiment_class.spack_name
+                if experiment_class.spack_name
+                else experiment_class.name
+            )
+        )
+
+    def _info_ramble_name(experiment_class):
+        gen_header("Ramble Name")
+        print(
+            indent()
+            + (
+                experiment_class.ramble_name
+                if experiment_class.ramble_name
+                else experiment_class.name
+            )
+        )
+
     experiment_spec = benchpark.spec.ExperimentSpec(args.name)
-    experiment_class = experiment_spec.experiment_class
+    conc = experiment_spec.concretize()
+    experiment_class = conc.experiment
 
     if args.spack:
         subprocess.run(["spack", "info", experiment_class.spack_name])
@@ -115,6 +138,8 @@ def info_experiment(args):
     else:
         actions = {
             "maintainer": (info_maintainer, [experiment_class]),
+            "ramble_name": (_info_ramble_name, [experiment_class]),
+            "spack_name": (_info_spack_name, [experiment_class]),
             "url": (_info_url, [experiment_class]),
             "variants": (info_variants, [experiment_class]),
         }

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -2,13 +2,19 @@ import subprocess
 import textwrap
 
 import yaml
+import llnl.util.tty.color as color
 import spack.cmd.info as spackinfo
 
 import benchpark.paths
 
 
+def indent():
+    return " " * 4
+
+
 def gen_header(name):
-    print("=" * 20 + f"\n=== {name}\n" + "=" * 20)
+    attr_name = "@*b" + name + "@."
+    color.cprint(f"{attr_name}:")
 
 
 def info_variants(spec_class):
@@ -17,43 +23,69 @@ def info_variants(spec_class):
     all_variants = list(spec_class.variants.values())[0]
     for var in all_variants.values():
         for attr, value in var.__dict__.items():
-            print(f"{attr}: {value}")
+            # print(f"{attr}: {value}")
+            color.cprint(indent() + "@*g" + attr + "@.: " + str(value))
         print()
 
 
 def info_maintainer(spec_class):
     """SystemSpec.system_class or ExperimentSpec.experiment_class"""
     gen_header("Maintainer")
-    print(spec_class.maintainer)
+    mstr = indent()
+    if spec_class.maintainer == "":
+        mstr += "No maintainer"
+    else:
+        mstr += spec_class.maintainer
+    print(mstr)
 
 
 def info_system(args):
     def _info_system_system_site(system_class):
         gen_header("System Site")
-        print(system_class.system_site)
+        print(indent() + system_class.system_site)
 
     def _info_system_hardware(system_class):
+        def _replace_keys_with_colors(data, colors, level=0):
+            if not isinstance(data, dict):
+                return data
+
+            new_data = {}
+            for key, value in data.items():
+                color_prefix = (
+                    colors[level % len(colors)] if level < len(colors) else ""
+                )
+                new_key = color_prefix + key + "@."
+                new_data[new_key] = _replace_keys_with_colors(value, colors, level + 1)
+
+            return new_data
+
         gen_header("Hardware")
         for cluster, resource_dict in system_class.id_to_resources.items():
-            print(f"For cluster {cluster}:")
+            color.cprint(f"{indent()}@*g{cluster}@.:")
             for resource_key, resource_value in resource_dict.items():
-                if isinstance(resource_value, str) and ".yaml" in resource_value:
-                    print(f"\t{resource_key}:")
+                if resource_key == "hardware_key":
                     with open(resource_value, "r") as f:
                         data = yaml.safe_load(f)
-                        print(textwrap.indent(yaml.dump(data), "\t"))
+                        colors = ["@*r", "@*c", "@*m", "@*y"]
+                        data = _replace_keys_with_colors(data, colors)
+                        color.cprint(
+                            textwrap.indent(
+                                yaml.dump(data).replace("'", ""), indent() * 2
+                            )
+                        )
                 else:
-                    print(f"\t{resource_key}: {resource_value}")
+                    resource_key = "@*r" + resource_key + "@."
+                    color.cprint(f"{indent()*2}{resource_key}: {resource_value}")
 
     system_spec = benchpark.spec.SystemSpec(" ".join(args.spec))
     system_class = system_spec.system_class
 
     # Map argument flags to functions
     actions = {
-        "system_site": (_info_system_system_site, [system_class]),
-        "maintainer": (info_maintainer, [system_class]),
-        "variants": (info_variants, [system_class]),
         "hardware": (_info_system_hardware, [system_class]),
+        "maintainer": (info_maintainer, [system_class]),
+        "system_site": (_info_system_system_site, [system_class]),
+        "variants": (info_variants, [system_class]),
     }
 
     # Call functions for enabled options, or all if no flag is set
@@ -71,12 +103,12 @@ def info_system(args):
 def info_experiment(args):
     def _info_url(experiment_class):
         gen_header("URL")
-        print(experiment_class.url)
+        print(indent() + experiment_class.url)
 
     experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.spec))
     experiment_class = experiment_spec.experiment_class
 
-    #spackinfo.print_variants(experiment_class)
+    # spackinfo.print_variants(experiment_class)
 
     if args.spack:
         subprocess.run(["spack", "info", experiment_class.spack_name])
@@ -86,9 +118,9 @@ def info_experiment(args):
         return
     else:
         actions = {
-            "variants": (info_variants, [experiment_class]),
             "maintainer": (info_maintainer, [experiment_class]),
             "url": (_info_url, [experiment_class]),
+            "variants": (info_variants, [experiment_class]),
         }
 
         # Call functions for enabled options, or all if no flag is set
@@ -126,6 +158,12 @@ def setup_parser(root_parser):
     )
     experiment_parser.add_argument(
         "--url", action="store_true", help="URL for experiment"
+    )
+    experiment_parser.add_argument(
+        "--variants", action="store_true", help="Available experiment variants"
+    )
+    experiment_parser.add_argument(
+        "--maintainer", action="store_true", help="Maintainer"
     )
     experiment_parser.add_argument("spec", nargs="+", help="Experiment spec")
 

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -69,6 +69,10 @@ def info_system(args):
 
 
 def info_experiment(args):
+    def _info_url(experiment_class):
+        gen_header("URL")
+        print(experiment_class.url)
+
     experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.spec))
     experiment_class = experiment_spec.experiment_class
 
@@ -84,6 +88,7 @@ def info_experiment(args):
         actions = {
             "variants": (info_variants, [experiment_class]),
             "maintainer": (info_maintainer, [experiment_class]),
+            "url": (_info_url, [experiment_class]),
         }
 
         # Call functions for enabled options, or all if no flag is set
@@ -118,6 +123,9 @@ def setup_parser(root_parser):
     )
     experiment_parser.add_argument(
         "--ramble", action="store_true", help="Information from Ramble package"
+    )
+    experiment_parser.add_argument(
+        "--url", action="store_true", help="URL for experiment"
     )
     experiment_parser.add_argument("spec", nargs="+", help="Experiment spec")
 

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -94,10 +94,6 @@ def info_system(args):
 
 
 def info_experiment(args):
-    def _info_url(experiment_class):
-        gen_header("URL")
-        print(indent() + getattr(experiment_class, "url", "None"))
-
     def _info_spack_name(experiment_class):
         gen_header("Spack Name")
         print(
@@ -135,7 +131,6 @@ def info_experiment(args):
             "maintainers": (info_maintainers, [experiment_class]),
             "ramble_name": (_info_ramble_name, [experiment_class]),
             "spack_name": (_info_spack_name, [experiment_class]),
-            "url": (_info_url, [experiment_class]),
             "variants": (info_variants, [experiment_class]),
         }
 
@@ -171,9 +166,6 @@ def setup_parser(root_parser):
     )
     experiment_parser.add_argument(
         "--ramble", action="store_true", help="Information from Ramble package"
-    )
-    experiment_parser.add_argument(
-        "--url", action="store_true", help="URL for experiment"
     )
     experiment_parser.add_argument(
         "--variants", action="store_true", help="Available experiment variants"

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -75,7 +75,7 @@ def info_system(args):
                     resource_key = "@*r" + resource_key + "@."
                     color.cprint(f"{indent()*2}{resource_key}: {resource_value}")
 
-    system_spec = benchpark.spec.SystemSpec(" ".join(args.spec))
+    system_spec = benchpark.spec.SystemSpec(args.name)
     system_class = system_spec.system_class
 
     # Map argument flags to functions
@@ -103,7 +103,7 @@ def info_experiment(args):
         gen_header("URL")
         print(indent() + experiment_class.url)
 
-    experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.spec))
+    experiment_spec = benchpark.spec.ExperimentSpec(args.name)
     experiment_class = experiment_spec.experiment_class
 
     if args.spack:
@@ -143,7 +143,7 @@ def setup_parser(root_parser):
     )
     system_parser.add_argument("--system-site", action="store_true", help="System site")
     system_parser.add_argument("--maintainer", action="store_true", help="Maintainer")
-    system_parser.add_argument("spec", nargs="+", help="System spec")
+    system_parser.add_argument("name", help="System name")
 
     experiment_parser = info_subparser.add_parser("experiment")
     experiment_parser.add_argument(
@@ -161,7 +161,7 @@ def setup_parser(root_parser):
     experiment_parser.add_argument(
         "--maintainer", action="store_true", help="Maintainer"
     )
-    experiment_parser.add_argument("spec", nargs="+", help="Experiment spec")
+    experiment_parser.add_argument("name", help="Experiment name")
 
 
 def command(args):

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -3,7 +3,6 @@ import textwrap
 
 import yaml
 import llnl.util.tty.color as color
-import spack.cmd.info as spackinfo
 
 import benchpark.paths
 
@@ -23,7 +22,6 @@ def info_variants(spec_class):
     all_variants = list(spec_class.variants.values())[0]
     for var in all_variants.values():
         for attr, value in var.__dict__.items():
-            # print(f"{attr}: {value}")
             color.cprint(indent() + "@*g" + attr + "@.: " + str(value))
         print()
 
@@ -107,8 +105,6 @@ def info_experiment(args):
 
     experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.spec))
     experiment_class = experiment_spec.experiment_class
-
-    # spackinfo.print_variants(experiment_class)
 
     if args.spack:
         subprocess.run(["spack", "info", experiment_class.spack_name])

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -1,0 +1,98 @@
+import glob
+import sys
+import textwrap
+
+import yaml
+
+import benchpark.paths
+
+
+def gen_header(name):
+    print("=" * 20 + f"\n=== {name}\n" + "=" * 20)
+
+
+def info_system_system_site(system_spec):
+    gen_header("System Site")
+    print(system_spec.system_class.system_site)
+
+
+def info_system_maintainer(system_spec):
+    gen_header("Maintainer")
+    print(system_spec.system_class.maintainer)
+
+
+def info_system_variants(system_spec):
+    gen_header("Variants")
+    # Dict with one value
+    all_variants = list(system_spec.system_class.variants.values())[0]
+    for var in all_variants.values():
+        for attr in var.__dict__.keys():
+            print(attr + ":", var.__dict__[attr])
+        print()
+        # print(var.name+":", var.values)
+
+
+def info_system_hardware(system_spec):
+    gen_header("Hardware")
+    for cluster, resource_dict in system_spec.system_class.id_to_resources.items():
+        print("For cluster", cluster + ":")
+        for resource_key, resource_value in resource_dict.items():
+            if isinstance(resource_value, str) and ".yaml" in resource_value:
+                print("\t" + resource_key + ":")
+                data = yaml.safe_load(open(resource_value, "r"))
+                print(textwrap.indent(yaml.dump(data), "\t"))
+            else:
+                print("\t" + resource_key + ":", resource_value)
+
+
+def info_system(args):
+    system_spec = benchpark.spec.SystemSpec(" ".join(args.spec))
+
+    if args.system_site:
+        info_system_system_site(system_spec)
+    if args.maintainer:
+        info_system_maintainer(system_spec)
+    if args.variants:
+        info_system_variants(system_spec)
+    if args.hardware:
+        info_system_hardware(system_spec)
+    if not args.system_site and not args.variants and not args.hardware:
+        info_system_system_site(system_spec)
+        info_system_maintainer(system_spec)
+        info_system_variants(system_spec)
+        info_system_hardware(system_spec)
+
+    # conc_system_spec = system_spec.concretize()
+    # system = conc_system_spec.system
+    # system.initialize()
+
+    # print("\n\n\n\n")
+    # print([i for i in system.__dict__.keys()])
+    # print(system.sw_description())
+
+
+def setup_parser(root_parser):
+    info_subparser = root_parser.add_subparsers(dest="info_subcommand")
+
+    system_parser = info_subparser.add_parser("system")
+    system_parser.add_argument(
+        "--variants", action="store_true", help="Available system variants"
+    )
+    system_parser.add_argument(
+        "--hardware", action="store_true", help="Hardware descriptions per cluster"
+    )
+    system_parser.add_argument("--system-site", action="store_true", help="System site")
+    system_parser.add_argument("--maintainer", action="store_true", help="Maintainer")
+
+    system_parser.add_argument("spec", nargs="+", help="System spec")
+
+
+def command(args):
+    actions = {
+        "system": info_system,
+    }
+    if args.info_subcommand in actions:
+        print(args)
+        actions[args.info_subcommand](args)
+    else:
+        raise ValueError(f"Unknown subcommand for 'info': {args.info_subcommand}")

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -33,10 +33,6 @@ def info_maintainers(spec_class):
 
 
 def info_system(args):
-    def _info_system_system_site(system_class):
-        gen_header("System Site")
-        print(indent() + getattr(system_class, "system_site", "None"))
-
     def _info_system_hardware(system_class):
         def _replace_keys_with_colors(data, colors, level=0):
             if not isinstance(data, dict):
@@ -77,7 +73,6 @@ def info_system(args):
     actions = {
         "hardware": (_info_system_hardware, [system_class]),
         "maintainers": (info_maintainers, [system_class]),
-        "system_site": (_info_system_system_site, [system_class]),
         "variants": (info_variants, [system_class]),
     }
 

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -104,6 +104,34 @@ def _make_when_spec(
     return benchpark.spec.Spec(value)
 
 
+@benchpark_directive("system_site")
+def system_site(name: str):
+    """Define the site where the system is located.
+
+    Arguments:
+        name: Name of the site
+    """
+
+    def _execute_system_site(pkg):
+        pkg.system_site = name
+
+    return _execute_system_site
+
+
+@benchpark_directive("maintainer")
+def maintainer(name: str):
+    """Define the maintainer of the system.
+
+    Arguments:
+        name: Name of the maintainer
+    """
+
+    def _execute_maintainer(pkg):
+        pkg.maintainer = name
+
+    return _execute_maintainer
+
+
 @benchpark_directive("variants")
 def variant(
     name: str,

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -104,20 +104,6 @@ def _make_when_spec(
     return benchpark.spec.Spec(value)
 
 
-@benchpark_directive("system_site")
-def system_site(name: str):
-    """Define the site where the system is located.
-
-    Arguments:
-        name: Name of the site
-    """
-
-    def _execute_system_site(pkg):
-        pkg.system_site = name
-
-    return _execute_system_site
-
-
 @benchpark_directive("maintainer")
 def maintainer(name: str):
     """Define the maintainer of the system.

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -104,18 +104,18 @@ def _make_when_spec(
     return benchpark.spec.Spec(value)
 
 
-@benchpark_directive("maintainer")
-def maintainer(name: str):
-    """Define the maintainer of the system.
+@benchpark_directive("maintainers")
+def maintainers(*names: str):
+    """Define the maintainers of the system/experiment.
 
     Arguments:
-        name: Name of the maintainer
+        names: GitHub usernames for the maintainers
     """
 
-    def _execute_maintainer(pkg):
-        pkg.maintainer = name
+    def _execute_maintainers(pkg):
+        pkg.maintainers = names
 
-    return _execute_maintainer
+    return _execute_maintainers
 
 
 @benchpark_directive("variants")

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -98,6 +98,8 @@ class Experiment(ExperimentSystemBase, SingleNode):
         self.spec: "benchpark.spec.ConcreteExperimentSpec" = spec
         super().__init__()
         self.helpers = []
+        self._spack_name = None
+        self._ramble_name = None
 
         for cls in self.__class__.mro()[1:]:
             if cls is not Experiment and cls is not object:
@@ -113,6 +115,24 @@ class Experiment(ExperimentSystemBase, SingleNode):
             raise BenchparkError(f"No workload variant defined for package {self.name}")
 
         self.package_specs = {}
+
+    @property
+    def spack_name(self):
+        """The name of the spack package that is used to build this benchmark"""
+        return self._spack_name
+
+    @spack_name.setter
+    def spack_name(self, value: str):
+        self._spack_name = value
+
+    @property
+    def ramble_name(self):
+        """The name of the ramble application associated with this benchmark"""
+        return self._ramble_name
+
+    @ramble_name.setter
+    def ramble_name(self, value: str):
+        self._ramble_name = value
 
     def compute_include_section(self):
         # include the config directory

--- a/lib/benchpark/paths.py
+++ b/lib/benchpark/paths.py
@@ -19,3 +19,4 @@ test_path = lib_path / "test"
 benchpark_home = pathlib.Path(os.path.expanduser("~/.benchpark"))
 global_ramble_path = benchpark_home / "ramble"
 global_spack_path = benchpark_home / "spack"
+hardware_descriptions = benchpark_root / "systems" / "all_hardware_descriptions"

--- a/lib/main.py
+++ b/lib/main.py
@@ -44,6 +44,7 @@ import benchpark.cmd.system  # noqa: E402
 import benchpark.cmd.experiment  # noqa: E402
 import benchpark.cmd.setup  # noqa: E402
 import benchpark.cmd.unit_test  # noqa: E402
+import benchpark.cmd.info # noqa: E402
 import benchpark.paths  # noqa: E402
 from benchpark.accounting import (  # noqa: E402
     benchpark_experiments,
@@ -231,11 +232,17 @@ def init_commands(subparsers, actions_dict):
     )
     benchpark.cmd.audit.setup_parser(audit_parser)
 
+    info_parser = subparsers.add_parser(
+        "info", help="Get information about Systems and Experiments"
+    )
+    benchpark.cmd.info.setup_parser(info_parser)
+
     actions_dict["system"] = benchpark.cmd.system.command
     actions_dict["experiment"] = benchpark.cmd.experiment.command
     actions_dict["setup"] = benchpark.cmd.setup.command
     actions_dict["unit-test"] = benchpark.cmd.unit_test.command
     actions_dict["audit"] = benchpark.cmd.audit.command
+    actions_dict["info"] = benchpark.cmd.info.command
 
 
 def run_command(command_str, env=None):

--- a/lib/main.py
+++ b/lib/main.py
@@ -44,7 +44,7 @@ import benchpark.cmd.system  # noqa: E402
 import benchpark.cmd.experiment  # noqa: E402
 import benchpark.cmd.setup  # noqa: E402
 import benchpark.cmd.unit_test  # noqa: E402
-import benchpark.cmd.info # noqa: E402
+import benchpark.cmd.info  # noqa: E402
 import benchpark.paths  # noqa: E402
 from benchpark.accounting import (  # noqa: E402
     benchpark_experiments,

--- a/systems/all_hardware_descriptions/AWS_PCluster-zen-EFA/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/AWS_PCluster-zen-EFA/hardware_description.yaml
@@ -28,5 +28,4 @@ system_definition:
       compiler: gcc
       runtime:
       mpi: openmpi
-  top500-system-instances:
-    - instance-types <https://aws.amazon.com/ec2/instance-types>
+  instance-types: <https://aws.amazon.com/ec2/instance-types>

--- a/systems/all_hardware_descriptions/Atos-rome-A100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Atos-rome-A100-Infiniband/hardware_description.yaml
@@ -30,4 +30,6 @@ system_definition:
       mpi: openmpi
       installation-year: 2020
   top500-system-instances:
-    - JUWELS Booster <https://www.top500.org/system/179894>
+    JUWELS-Booster:
+      benchpark_system: jsc-juwels
+      top500: <https://www.top500.org/system/179894>

--- a/systems/all_hardware_descriptions/Atos-rome-A100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Atos-rome-A100-Infiniband/hardware_description.yaml
@@ -30,4 +30,4 @@ system_definition:
       mpi: openmpi
       installation-year: 2020
   top500-system-instances:
-    - JUWELS Booster (JSC) <https://www.top500.org/system/179894>
+    - JUWELS Booster <https://www.top500.org/system/179894>

--- a/systems/all_hardware_descriptions/DELL-cascadelake-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/DELL-cascadelake-Infiniband/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime: gpu
       mpi: intelmpi
   top500-system-instances:
-    - Grace (TAMU) <https://www.top500.org/system/179905>
+    - Grace <https://www.top500.org/system/179905>

--- a/systems/all_hardware_descriptions/DELL-cascadelake-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/DELL-cascadelake-Infiniband/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime: gpu
       mpi: intelmpi
   top500-system-instances:
-    - Grace <https://www.top500.org/system/179905>
+    Grace:
+      benchpark_system:
+      top500: <https://www.top500.org/system/179905>

--- a/systems/all_hardware_descriptions/DELL-sapphirerapids-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/DELL-sapphirerapids-OmniPath/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Dane <https://www.top500.org/system/180228>
+    Dane:
+      benchpark_system: llnl-cluster
+      top500: <https://www.top500.org/system/180228>

--- a/systems/all_hardware_descriptions/DELL-sapphirerapids-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/DELL-sapphirerapids-OmniPath/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Dane (LLNL) <https://www.top500.org/system/180228>
+    - Dane <https://www.top500.org/system/180228>

--- a/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime:
       mpi: fujitsu-mpi
   top500-system-instances:
-    - Fugaku (R-CCS) <https://www.top500.org/system/179807/>
+    - Fugaku <https://www.top500.org/system/179807/>

--- a/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime:
       mpi: fujitsu-mpi
   top500-system-instances:
-    - Fugaku <https://www.top500.org/system/179807/>
+    Fugaku:
+      benchpark_system: riken-fugaku
+      top500: <https://www.top500.org/system/179807/>

--- a/systems/all_hardware_descriptions/HPECray-haswell-P100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-haswell-P100-Infiniband/hardware_description.yaml
@@ -30,4 +30,4 @@ system_definition:
       mpi: cray-mpich
       installation-year: 2017
   top500-system-instances:
-    - Piz Daint (CSCS) <https://www.top500.org/system/177824>
+    - Piz Daint <https://www.top500.org/system/177824>

--- a/systems/all_hardware_descriptions/HPECray-haswell-P100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-haswell-P100-Infiniband/hardware_description.yaml
@@ -30,4 +30,6 @@ system_definition:
       mpi: cray-mpich
       installation-year: 2017
   top500-system-instances:
-    - Piz Daint <https://www.top500.org/system/177824>
+    Piz Daint:
+      benchpark_system: cscs-daint
+      top500: <https://www.top500.org/system/177824>

--- a/systems/all_hardware_descriptions/HPECray-neoverse-H100-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-neoverse-H100-Slingshot/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime: cuda
       mpi: cray-mpich
   top500-system-instances:
-    - Venado (LANL) <https://www.top500.org/system/180246>
+    - Venado <https://www.top500.org/system/180246>

--- a/systems/all_hardware_descriptions/HPECray-neoverse-H100-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-neoverse-H100-Slingshot/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime: cuda
       mpi: cray-mpich
   top500-system-instances:
-    - Venado <https://www.top500.org/system/180246>
+    Venado:
+      benchpark_system: lanl-venado
+      top500: <https://www.top500.org/system/180246>

--- a/systems/all_hardware_descriptions/HPECray-zen2-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen2-Slingshot/hardware_description.yaml
@@ -30,4 +30,6 @@ system_definition:
       mpi: cray-mpich
       installation-year: 2017
   top500-system-instances:
-    - Eiger <https://www.top500.org/system/177824>
+    Eiger:
+      benchpark_system: cscs-eiger
+      top500: <https://www.top500.org/system/177824>

--- a/systems/all_hardware_descriptions/HPECray-zen2-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen2-Slingshot/hardware_description.yaml
@@ -30,4 +30,4 @@ system_definition:
       mpi: cray-mpich
       installation-year: 2017
   top500-system-instances:
-    - Eiger (CSCS) <https://www.top500.org/system/177824>
+    - Eiger <https://www.top500.org/system/177824>

--- a/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
@@ -36,6 +36,6 @@ system_definition:
       runtime: rocm
       mpi: cray-mpich
   top500-system-instances:
-    - Frontier (ORNL)  <https://www.top500.org/system/180047>
-    - Lumi     (CSC)   <https://www.top500.org/system/180048>
-    - Tioga    (LLNL)  <https://www.top500.org/system/180052>
+    - Frontier <https://www.top500.org/system/180047>
+    - Lumi     <https://www.top500.org/system/180048>
+    - Tioga    <https://www.top500.org/system/180052>

--- a/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
@@ -36,6 +36,12 @@ system_definition:
       runtime: rocm
       mpi: cray-mpich
   top500-system-instances:
-    - Frontier <https://www.top500.org/system/180047>
-    - Lumi     <https://www.top500.org/system/180048>
-    - Tioga    <https://www.top500.org/system/180052>
+    Frontier:
+      benchpark_system:
+      top500: <https://www.top500.org/system/180047>
+    Lumi:
+      benchpark_system: csc-lumi
+      top500: <https://www.top500.org/system/180048>
+    Tioga:
+      benchpark_system: llnl-elcapitan
+      top500: <https://www.top500.org/system/180052>

--- a/systems/all_hardware_descriptions/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml
@@ -29,6 +29,6 @@ system_definition:
       runtime: rocm
       mpi: cray-mpich
   top500-system-instances:
-    - El Capitan (LLNL) <https://www.top500.org/system/180307>
-    - Tuolumne   (LLNL) <https://www.top500.org/system/180308>
-    - rzAdams    (LLNL) <https://www.top500.org/system/180284>
+    - El Capitan <https://www.top500.org/system/180307>
+    - Tuolumne   <https://www.top500.org/system/180308>
+    - rzAdams    <https://www.top500.org/system/180284>

--- a/systems/all_hardware_descriptions/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml
@@ -29,6 +29,12 @@ system_definition:
       runtime: rocm
       mpi: cray-mpich
   top500-system-instances:
-    - El Capitan <https://www.top500.org/system/180307>
-    - Tuolumne   <https://www.top500.org/system/180308>
-    - rzAdams    <https://www.top500.org/system/180284>
+    El Capitan:
+      benchpark_system: llnl-elcapitan
+      top500: <https://www.top500.org/system/180307>
+    Tuolumne:
+      benchpark_system:
+      top500: <https://www.top500.org/system/180308>
+    rzAdams:
+      benchpark_system:
+      top500: <https://www.top500.org/system/180284>

--- a/systems/all_hardware_descriptions/IBM-power9-V100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/IBM-power9-V100-Infiniband/hardware_description.yaml
@@ -29,6 +29,12 @@ system_definition:
       runtime: cuda
       mpi: spectrum-mpi
   top500-system-instances:
-    - Summit <https://www.top500.org/system/179397>
-    - Sierra <https://www.top500.org/system/179398>
-    - Lassen <https://www.top500.org/system/179567>
+    Summit:
+      benchpark_system:
+      top500: <https://www.top500.org/system/179397>
+    Sierra:
+      benchpark_system: llnl-sierra
+      top500: <https://www.top500.org/system/179398>
+    Lassen:
+      benchpark_system: llnl-sierra
+      top500: <https://www.top500.org/system/179567>

--- a/systems/all_hardware_descriptions/IBM-power9-V100-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/IBM-power9-V100-Infiniband/hardware_description.yaml
@@ -29,6 +29,6 @@ system_definition:
       runtime: cuda
       mpi: spectrum-mpi
   top500-system-instances:
-    - Summit (ORNL) <https://www.top500.org/system/179397>
-    - Sierra (LLNL) <https://www.top500.org/system/179398>
-    - Lassen (LLNL) <https://www.top500.org/system/179567>
+    - Summit <https://www.top500.org/system/179397>
+    - Sierra <https://www.top500.org/system/179398>
+    - Lassen <https://www.top500.org/system/179567>

--- a/systems/all_hardware_descriptions/Penguin-icelake-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Penguin-icelake-OmniPath/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Magma <https://www.top500.org/system/179774>
+    Magma:
+      benchpark_system: llnl-cluster
+      top500: <https://www.top500.org/system/179774>

--- a/systems/all_hardware_descriptions/Penguin-icelake-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Penguin-icelake-OmniPath/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Magma (LLNL) <https://www.top500.org/system/179774>
+    - Magma <https://www.top500.org/system/179774>

--- a/systems/all_hardware_descriptions/Supermicro-icelake-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Supermicro-icelake-OmniPath/hardware_description.yaml
@@ -29,4 +29,6 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Ruby <https://www.top500.org/system/179866>
+    Ruby:
+      benchpark_system: llnl-cluster
+      top500: <https://www.top500.org/system/179866>

--- a/systems/all_hardware_descriptions/Supermicro-icelake-OmniPath/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Supermicro-icelake-OmniPath/hardware_description.yaml
@@ -29,4 +29,4 @@ system_definition:
       runtime:
       mpi: mvapich
   top500-system-instances:
-    - Ruby (LLNL) <https://www.top500.org/system/179866>
+    - Ruby <https://www.top500.org/system/179866>

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -6,31 +6,44 @@
 import pathlib
 
 from benchpark.system import System
-from benchpark.directives import variant
-
-# Taken from https://aws.amazon.com/ec2/instance-types/
-# With boto3, we could determine this dynamically vs. storing a static table
-id_to_resources = {
-    "c4.xlarge": {
-        "sys_cores_per_node": 4,
-        "sys_mem_per_node": 7.5,
-    },
-    "c6g.xlarge": {
-        "sys_cores_per_node": 4,
-        "sys_mem_per_node": 8,
-    },
-    "hpc7a.48xlarge": {
-        "sys_cores_per_node": 96,
-        "sys_mem_per_node": 768,
-    },
-    "hpc6a.48xlarge": {
-        "sys_cores_per_node": 96,
-        "sys_mem_per_node": 384,
-    },
-}
+from benchpark.directives import variant, system_site, maintainer
+from benchpark.paths import hardware_descriptions
 
 
 class AwsPcluster(System):
+    # Taken from https://aws.amazon.com/ec2/instance-types/
+    # With boto3, we could determine this dynamically vs. storing a static table
+    id_to_resources = {
+        "c4.xlarge": {
+            "sys_cores_per_node": 4,
+            "sys_mem_per_node": 7.5,
+            "hardware_key": str(hardware_descriptions)
+            + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
+        },
+        "c6g.xlarge": {
+            "sys_cores_per_node": 4,
+            "sys_mem_per_node": 8,
+            "hardware_key": str(hardware_descriptions)
+            + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
+        },
+        "hpc7a.48xlarge": {
+            "sys_cores_per_node": 96,
+            "sys_mem_per_node": 768,
+            "hardware_key": str(hardware_descriptions)
+            + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
+        },
+        "hpc6a.48xlarge": {
+            "sys_cores_per_node": 96,
+            "sys_mem_per_node": 384,
+            "hardware_key": str(hardware_descriptions)
+            + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
+        },
+    }
+
+    system_site("aws")
+
+    maintainer("")
+
     variant(
         "instance_type",
         values=("c6g.xlarge", "c4.xlarge", "hpc7a.48xlarge", "hpc6a.48xlarge"),
@@ -42,7 +55,7 @@ class AwsPcluster(System):
         super().initialize()
         self.scheduler = "slurm"
         # TODO: for some reason I have to index to get value, even if multi=False
-        attrs = id_to_resources.get(self.spec.variants["instance_type"][0])
+        attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -15,7 +15,7 @@ class AwsPcluster(System):
     # With boto3, we could determine this dynamically vs. storing a static table
 
     maintainers("wdhawkins")
-    
+
     id_to_resources = {
         "c4.xlarge": {
             "sys_cores_per_node": 4,

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -51,6 +51,8 @@ class AwsPcluster(System):
         description="AWS instance type",
     )
 
+    maintainers("wdhawkins")
+
     def initialize(self):
         super().initialize()
         self.scheduler = "slurm"

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -17,30 +17,32 @@ class AwsPcluster(System):
         "c4.xlarge": {
             "sys_cores_per_node": 4,
             "sys_mem_per_node": 7.5,
+            "system_site": "aws",
             "hardware_key": str(hardware_descriptions)
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "c6g.xlarge": {
             "sys_cores_per_node": 4,
             "sys_mem_per_node": 8,
+            "system_site": "aws",
             "hardware_key": str(hardware_descriptions)
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "hpc7a.48xlarge": {
             "sys_cores_per_node": 96,
             "sys_mem_per_node": 768,
+            "system_site": "aws",
             "hardware_key": str(hardware_descriptions)
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "hpc6a.48xlarge": {
             "sys_cores_per_node": 96,
             "sys_mem_per_node": 384,
+            "system_site": "aws",
             "hardware_key": str(hardware_descriptions)
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
     }
-
-    system_site = "aws"
 
     variant(
         "instance_type",

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -13,6 +13,9 @@ from benchpark.paths import hardware_descriptions
 class AwsPcluster(System):
     # Taken from https://aws.amazon.com/ec2/instance-types/
     # With boto3, we could determine this dynamically vs. storing a static table
+
+    maintainers("wdhawkins")
+    
     id_to_resources = {
         "c4.xlarge": {
             "sys_cores_per_node": 4,
@@ -50,8 +53,6 @@ class AwsPcluster(System):
         default="c4.xlarge",
         description="AWS instance type",
     )
-
-    maintainers("wdhawkins")
 
     def initialize(self):
         super().initialize()

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -6,7 +6,7 @@
 import pathlib
 
 from benchpark.system import System
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.paths import hardware_descriptions
 
 
@@ -40,7 +40,7 @@ class AwsPcluster(System):
         },
     }
 
-    system_site("aws")
+    system_site = "aws"
 
     maintainer("")
 

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -6,7 +6,7 @@
 import pathlib
 
 from benchpark.system import System
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.paths import hardware_descriptions
 
 
@@ -41,8 +41,6 @@ class AwsPcluster(System):
     }
 
     system_site = "aws"
-
-    maintainer("")
 
     variant(
         "instance_type",

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -20,7 +20,7 @@ class CscLumi(System):
             "sys_mem_per_node": 512,
             "system_site": "csc",
             "hardware_key": str(hardware_descriptions)
-            + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml"
+            + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml",
         }
     }
 

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -8,9 +8,21 @@ import pathlib
 from benchpark.directives import variant
 from benchpark.system import System
 from packaging.version import Version
+from benchpark.paths import hardware_descriptions
 
 
 class CscLumi(System):
+
+    id_to_resources = {
+        "lumi": {
+            "sys_cores_per_node": 64,
+            "sys_gpus_per_node": 8,
+            "sys_mem_per_node": 512,
+            "system_site": "csc",
+            "hardware_key": str(hardware_descriptions)
+            + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml"
+        }
+    }
 
     variant(
         "compiler",
@@ -40,14 +52,9 @@ class CscLumi(System):
             if key == self.spec.variants["compiler"][0]:
                 self.compiler_version = Version(value)
 
-        sys_variables = {
-            "sys_cores_per_node": 64,
-            "sys_gpus_per_node": 8,
-            "sys_mem_per_node": 512,
-        }
-
         self.scheduler = "slurm"
-        for k, v in sys_variables.items():
+        attrs = self.id_to_resources.get("lumi")
+        for k, v in attrs.items():
             setattr(self, k, v)
 
     def generate_description(self, output_dir):

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -20,7 +20,7 @@ class CscsDaint(System):
             "sys_mem_per_node": 64,
             "system_site": "cscs",
             "hardware_key": str(hardware_descriptions)
-            + "/HPECray-haswell-P100-Infiniband/hardware_description.yaml"
+            + "/HPECray-haswell-P100-Infiniband/hardware_description.yaml",
         }
     }
 

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -8,9 +8,21 @@ import pathlib
 from benchpark.directives import variant
 from benchpark.system import System
 from packaging.version import Version
+from benchpark.paths import hardware_descriptions
 
 
 class CscsDaint(System):
+
+    id_to_resources = {
+        "daint": {
+            "sys_cores_per_node": 12,
+            "sys_gpus_per_node": 1,
+            "sys_mem_per_node": 64,
+            "system_site": "cscs",
+            "hardware_key": str(hardware_descriptions)
+            + "/CSCS-Daint-HPECray-haswell-P100-Infiniband/hardware_description.yaml"
+        }
+    }
 
     variant(
         "compiler",
@@ -41,14 +53,10 @@ class CscsDaint(System):
         for key, value in full_versions.items():
             if key == self.spec.variants["compiler"][0]:
                 self.compiler_version = Version(value)
-        sys_variables = {
-            "sys_cores_per_node": 12,
-            "sys_gpus_per_node": 1,
-            "sys_mem_per_node": 64,
-        }
 
         self.scheduler = "slurm"
-        for k, v in sys_variables.items():
+        attrs = self.id_to_resources.get("daint")
+        for k, v in attrs.items():
             setattr(self, k, v)
 
     def generate_description(self, output_dir):

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -20,7 +20,7 @@ class CscsDaint(System):
             "sys_mem_per_node": 64,
             "system_site": "cscs",
             "hardware_key": str(hardware_descriptions)
-            + "/CSCS-Daint-HPECray-haswell-P100-Infiniband/hardware_description.yaml"
+            + "/HPECray-haswell-P100-Infiniband/hardware_description.yaml"
         }
     }
 

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -8,9 +8,20 @@ from benchpark.directives import variant
 
 from benchpark.system import System
 from packaging.version import Version
+from benchpark.paths import hardware_descriptions
 
 
 class CscsEiger(System):
+
+    id_to_resources = {
+        "eiger": {
+            "sys_cores_per_node": 128,
+            "timeout": 30,
+            "system_site": "cscs",
+            "hardware_key": str(hardware_descriptions)
+            + "/CSCS-Eiger-HPECray-zen2-Slingshot/hardware_description.yaml"
+        }
+    }
 
     variant(
         "compiler",
@@ -23,13 +34,9 @@ class CscsEiger(System):
 
         self.gcc_version = Version("12.3.0")
 
-        sys_variables = {
-            "sys_cores_per_node": 128,
-            "timeout": 30,
-        }
-
         self.scheduler = "slurm"
-        for k, v in sys_variables.items():
+        attrs = self.id_to_resources.get("eiger")
+        for k, v in attrs.items():
             setattr(self, k, v)
 
     def generate_description(self, output_dir):

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -19,7 +19,7 @@ class CscsEiger(System):
             "timeout": 30,
             "system_site": "cscs",
             "hardware_key": str(hardware_descriptions)
-            + "/CSCS-Eiger-HPECray-zen2-Slingshot/hardware_description.yaml"
+            + "/HPECray-zen2-Slingshot/hardware_description.yaml"
         }
     }
 

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -19,7 +19,7 @@ class CscsEiger(System):
             "timeout": 30,
             "system_site": "cscs",
             "hardware_key": str(hardware_descriptions)
-            + "/HPECray-zen2-Slingshot/hardware_description.yaml"
+            + "/HPECray-zen2-Slingshot/hardware_description.yaml",
         }
     }
 

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -21,7 +21,7 @@ class JscJuwels(System):
             "cuda_arch": '"80"',
             "system_site": "jsc",
             "hardware_key": str(hardware_descriptions)
-            + "/JSC-JUWELS-Booster-rome-A100-Infiniband/hardware_description.yaml"
+            + "/Atos-rome-A100-Infiniband/hardware_description.yaml"
         }
     }
 

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -8,9 +8,22 @@ from benchpark.directives import variant
 
 from benchpark.system import System
 from packaging.version import Version
+from benchpark.paths import hardware_descriptions
 
 
 class JscJuwels(System):
+
+    id_to_resources = {
+        "juwels": {
+            "sys_cores_per_node": 48,
+            "timeout": 120,
+            "sys_gpus_per_node": 4,
+            "cuda_arch": '"80"',
+            "system_site": "jsc",
+            "hardware_key": str(hardware_descriptions)
+            + "/JSC-JUWELS-Booster-rome-A100-Infiniband/hardware_description.yaml"
+        }
+    }
 
     variant(
         "compiler",
@@ -26,15 +39,10 @@ class JscJuwels(System):
         if self.spec.satisfies("compiler=gcc"):
             self.gcc_version = Version("12.3.0")
             self.nvhpc_version = Version("23.7")
-        sys_variables = {
-            "sys_cores_per_node": 48,
-            "timeout": 120,
-            "sys_gpus_per_node": 4,
-            "cuda_arch": '"80"',
-        }
 
         self.scheduler = "slurm"
-        for k, v in sys_variables.items():
+        attrs = self.id_to_resources.get("juwels")
+        for k, v in attrs.items():
             setattr(self, k, v)
 
     def generate_description(self, output_dir):

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -21,7 +21,7 @@ class JscJuwels(System):
             "cuda_arch": '"80"',
             "system_site": "jsc",
             "hardware_key": str(hardware_descriptions)
-            + "/Atos-rome-A100-Infiniband/hardware_description.yaml"
+            + "/Atos-rome-A100-Infiniband/hardware_description.yaml",
         }
     }
 

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -12,8 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class LanlVenado(System):
 
-    maintainers("rfhaque","gshipman")
-    
+    maintainers("rfhaque", "gshipman")
+
     id_to_resources = {
         "grace-hopper": {
             "sys_cores_per_node": 144,

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -15,17 +15,17 @@ class LanlVenado(System):
         "grace-hopper": {
             "sys_cores_per_node": 144,
             "sys_gpus_per_node": 4,
+            "system_site": "lanl",
             "hardware_key": str(hardware_descriptions)
             + "/HPECray-neoverse-H100-Slingshot/hardware_description.yaml",
         },
         "grace-grace": {
             "sys_cores_per_node": 144,
+            "system_site": "lanl",
             "hardware_key": str(hardware_descriptions)
             + "/HPECray-neoverse-H100-Slingshot/hardware_description.yaml",
         },
     }
-
-    system_site = "lanl"
 
     variant(
         "cluster",

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -26,8 +26,6 @@ class LanlVenado(System):
     }
 
     system_site = "lanl"
-
-    maintainer("")
 
     variant(
         "cluster",

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -25,7 +25,7 @@ class LanlVenado(System):
         },
     }
 
-    system_site("lanl")
+    system_site = "lanl"
 
     maintainer("")
 

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -11,6 +11,9 @@ from benchpark.paths import hardware_descriptions
 
 
 class LanlVenado(System):
+
+    maintainers("rfhaque","gshipman")
+    
     id_to_resources = {
         "grace-hopper": {
             "sys_cores_per_node": 144,

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -5,21 +5,30 @@
 
 import pathlib
 
-from benchpark.directives import variant
+from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
-
-id_to_resources = {
-    "grace-hopper": {
-        "sys_cores_per_node": 144,
-        "sys_gpus_per_node": 4,
-    },
-    "grace-grace": {
-        "sys_cores_per_node": 144,
-    },
-}
+from benchpark.paths import hardware_descriptions
 
 
 class LanlVenado(System):
+    id_to_resources = {
+        "grace-hopper": {
+            "sys_cores_per_node": 144,
+            "sys_gpus_per_node": 4,
+            "hardware_key": str(hardware_descriptions)
+            + "/HPECray-neoverse-H100-Slingshot/hardware_description.yaml",
+        },
+        "grace-grace": {
+            "sys_cores_per_node": 144,
+            "hardware_key": str(hardware_descriptions)
+            + "/HPECray-neoverse-H100-Slingshot/hardware_description.yaml",
+        },
+    }
+
+    system_site("lanl")
+
+    maintainer("")
+
     variant(
         "cluster",
         default="grace-hopper",
@@ -66,7 +75,7 @@ class LanlVenado(System):
         super().initialize()
 
         self.scheduler = "slurm"
-        attrs = id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlCluster(System):
 
+    maintainers("nhanford","rfhaque")
+
     id_to_resources = {
         "ruby": {
             "sys_cores_per_node": 56,

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -30,7 +30,7 @@ class LlnlCluster(System):
         },
     }
 
-    system_site("llnl")
+    system_site = "llnl"
 
     maintainer("")
 

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -7,7 +7,7 @@ import pathlib
 
 from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
-import benchpark.paths
+from benchpark.paths import hardware_descriptions
 
 
 class LlnlCluster(System):
@@ -15,17 +15,17 @@ class LlnlCluster(System):
     id_to_resources = {
         "ruby": {
             "sys_cores_per_node": 56,
-            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            "hardware_key": str(hardware_descriptions)
             + "/Supermicro-icelake-OmniPath/hardware_description.yaml",
         },
         "magma": {
             "sys_cores_per_node": 96,
-            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            "hardware_key": str(hardware_descriptions)
             + "/Penguin-icelake-OmniPath/hardware_description.yaml",
         },
         "dane": {
             "sys_cores_per_node": 112,
-            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            "hardware_key": str(hardware_descriptions)
             + "/DELL-sapphirerapids-OmniPath/hardware_description.yaml",
         },
     }
@@ -52,7 +52,7 @@ class LlnlCluster(System):
         super().initialize()
 
         self.scheduler = "slurm"
-        attrs = LlnlCluster.id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -15,22 +15,23 @@ class LlnlCluster(System):
     id_to_resources = {
         "ruby": {
             "sys_cores_per_node": 56,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/Supermicro-icelake-OmniPath/hardware_description.yaml",
         },
         "magma": {
             "sys_cores_per_node": 96,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/Penguin-icelake-OmniPath/hardware_description.yaml",
         },
         "dane": {
             "sys_cores_per_node": 112,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/DELL-sapphirerapids-OmniPath/hardware_description.yaml",
         },
     }
-
-    system_site = "llnl"
 
     variant(
         "cluster",

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -31,8 +31,6 @@ class LlnlCluster(System):
     }
 
     system_site = "llnl"
-
-    maintainer("")
 
     variant(
         "cluster",

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -12,7 +12,7 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlCluster(System):
 
-    maintainers("nhanford","rfhaque")
+    maintainers("nhanford", "rfhaque")
 
     id_to_resources = {
         "ruby": {

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -5,23 +5,34 @@
 
 import pathlib
 
-from benchpark.directives import variant
+from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
-
-id_to_resources = {
-    "ruby": {
-        "sys_cores_per_node": 56,
-    },
-    "magma": {
-        "sys_cores_per_node": 96,
-    },
-    "dane": {
-        "sys_cores_per_node": 112,
-    },
-}
+import benchpark.paths
 
 
 class LlnlCluster(System):
+
+    id_to_resources = {
+        "ruby": {
+            "sys_cores_per_node": 56,
+            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            + "/Supermicro-icelake-OmniPath/hardware_description.yaml",
+        },
+        "magma": {
+            "sys_cores_per_node": 96,
+            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            + "/Penguin-icelake-OmniPath/hardware_description.yaml",
+        },
+        "dane": {
+            "sys_cores_per_node": 112,
+            "hardware_key": str(benchpark.paths.hardware_descriptions)
+            + "/DELL-sapphirerapids-OmniPath/hardware_description.yaml",
+        },
+    }
+
+    system_site("llnl")
+
+    maintainer("")
 
     variant(
         "cluster",
@@ -41,7 +52,7 @@ class LlnlCluster(System):
         super().initialize()
 
         self.scheduler = "slurm"
-        attrs = id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = LlnlCluster.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -6,7 +6,7 @@
 import pathlib
 from packaging.version import Version
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -31,8 +31,6 @@ class LlnlElcapitan(System):
     }
 
     system_site = "llnl"
-
-    maintainer("")
 
     variant(
         "cluster",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -6,7 +6,7 @@
 import pathlib
 from packaging.version import Version
 
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -30,7 +30,7 @@ class LlnlElcapitan(System):
         },
     }
 
-    system_site("llnl")
+    system_site = "llnl"
 
     maintainer("")
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -6,24 +6,33 @@
 import pathlib
 from packaging.version import Version
 
-from benchpark.directives import variant
+from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
-
-id_to_resources = {
-    "tioga": {
-        "rocm_arch": "gfx90a",
-        "sys_cores_per_node": 64,
-        "sys_gpus_per_node": 8,
-    },
-    "elcapitan": {
-        "rocm_arch": "gfx940",
-        "sys_cores_per_node": 128,
-        "sys_gpus_per_node": 4,
-    },
-}
+from benchpark.paths import hardware_descriptions
 
 
 class LlnlElcapitan(System):
+
+    id_to_resources = {
+        "tioga": {
+            "rocm_arch": "gfx90a",
+            "sys_cores_per_node": 64,
+            "sys_gpus_per_node": 8,
+            "hardware_key": str(hardware_descriptions)
+            + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml",
+        },
+        "elcapitan": {
+            "rocm_arch": "gfx940",
+            "sys_cores_per_node": 128,
+            "sys_gpus_per_node": 4,
+            "hardware_key": str(hardware_descriptions)
+            + "/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml",
+        },
+    }
+
+    system_site("llnl")
+
+    maintainer("")
 
     variant(
         "cluster",
@@ -94,7 +103,7 @@ class LlnlElcapitan(System):
         # TODO: Replace this with lookups into the working set
 
         self.scheduler = "flux"
-        attrs = id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -13,7 +13,7 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlElcapitan(System):
 
-    maintainers("pearce8","nhanford","rfhaque")
+    maintainers("pearce8", "nhanford", "rfhaque")
 
     id_to_resources = {
         "tioga": {

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -18,6 +18,7 @@ class LlnlElcapitan(System):
             "rocm_arch": "gfx90a",
             "sys_cores_per_node": 64,
             "sys_gpus_per_node": 8,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml",
         },
@@ -25,12 +26,11 @@ class LlnlElcapitan(System):
             "rocm_arch": "gfx940",
             "sys_cores_per_node": 128,
             "sys_gpus_per_node": 4,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/HPECray-zen4-MI300A-Slingshot/hardware_description.yaml",
         },
     }
-
-    system_site = "llnl"
 
     variant(
         "cluster",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -13,6 +13,8 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlElcapitan(System):
 
+    maintainers("pearce8","nhanford","rfhaque")
+
     id_to_resources = {
         "tioga": {
             "rocm_arch": "gfx90a",

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -28,8 +28,6 @@ class LlnlSierra(System):
     }
 
     system_site = "llnl"
-
-    maintainer("")
 
     variant(
         "cluster",

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -34,7 +34,7 @@ class LlnlSierra(System):
     variant(
         "cluster",
         default="lassen",
-        values=( "lassen", "sierra"),
+        values=("lassen", "sierra"),
         description="Which cluster to run on",
     )
 

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -12,7 +12,7 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlSierra(System):
 
-    maintainers("pearce8","nhanford","rfhaque")
+    maintainers("pearce8", "nhanford", "rfhaque")
 
     id_to_resources = {
         "lassen": {

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -27,7 +27,7 @@ class LlnlSierra(System):
         },
     }
 
-    system_site("llnl")
+    system_site = "llnl"
 
     maintainer("")
 

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -19,22 +19,10 @@ class LlnlSierra(System):
             "hardware_key": str(hardware_descriptions)
             + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
         },
-        "sierra": {
-            "sys_cores_per_node": 44,
-            "sys_gpus_per_node": 4,
-            "hardware_key": str(hardware_descriptions)
-            + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
-        },
     }
+    id_to_resources["sierra"] = id_to_resources["lassen"]
 
     system_site = "llnl"
-
-    variant(
-        "cluster",
-        default="lassen",
-        values=("lassen", "sierra"),
-        description="Which cluster to run on",
-    )
 
     variant(
         "cuda",
@@ -68,7 +56,7 @@ class LlnlSierra(System):
         super().initialize()
 
         self.scheduler = "lsf"
-        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = self.id_to_resources.get("lassen")
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -16,13 +16,12 @@ class LlnlSierra(System):
         "lassen": {
             "sys_cores_per_node": 44,
             "sys_gpus_per_node": 4,
+            "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
         },
     }
     id_to_resources["sierra"] = id_to_resources["lassen"]
-
-    system_site = "llnl"
 
     variant(
         "cuda",

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class LlnlSierra(System):
 
+    maintainers("pearce8","nhanford","rfhaque")
+
     id_to_resources = {
         "lassen": {
             "sys_cores_per_node": 44,

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -5,11 +5,32 @@
 
 import pathlib
 
-from benchpark.directives import variant
+from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
+from benchpark.paths import hardware_descriptions
 
 
 class LlnlSierra(System):
+
+    id_to_resources = {
+        "sierra": {
+            "sys_cores_per_node": 44,
+            "sys_gpus_per_node": 4,
+            "hardware_key": str(hardware_descriptions)
+            + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
+        },
+        "lassen": {
+            "sys_cores_per_node": 44,
+            "sys_gpus_per_node": 4,
+            "hardware_key": str(hardware_descriptions)
+            + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
+        },
+    }
+
+    system_site("llnl")
+
+    maintainer("")
+
     variant(
         "cuda",
         default="11-8-0",

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -13,13 +13,13 @@ from benchpark.paths import hardware_descriptions
 class LlnlSierra(System):
 
     id_to_resources = {
-        "sierra": {
+        "lassen": {
             "sys_cores_per_node": 44,
             "sys_gpus_per_node": 4,
             "hardware_key": str(hardware_descriptions)
             + "/IBM-power9-V100-Infiniband/hardware_description.yaml",
         },
-        "lassen": {
+        "sierra": {
             "sys_cores_per_node": 44,
             "sys_gpus_per_node": 4,
             "hardware_key": str(hardware_descriptions)
@@ -30,6 +30,13 @@ class LlnlSierra(System):
     system_site("llnl")
 
     maintainer("")
+
+    variant(
+        "cluster",
+        default="lassen",
+        values=( "lassen", "sierra"),
+        description="Which cluster to run on",
+    )
 
     variant(
         "cuda",
@@ -63,8 +70,9 @@ class LlnlSierra(System):
         super().initialize()
 
         self.scheduler = "lsf"
-        self.sys_cores_per_node = "44"
-        self.sys_gpus_per_node = "4"
+        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
+        for k, v in attrs.items():
+            setattr(self, k, v)
 
     def generate_description(self, output_dir):
         super().generate_description(output_dir)

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, system_site, maintainer
+from benchpark.directives import variant, maintainer
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -20,7 +20,7 @@ class RikenFugaku(System):
         },
     }
 
-    system_site("riken")
+    system_site = "riken"
 
     maintainer("")
 

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -11,6 +11,9 @@ from benchpark.paths import hardware_descriptions
 
 
 class RikenFugaku(System):
+
+    maintainers("jdomke", "SBA0486")
+    
     id_to_resources = {
         "fugaku": {
             "sys_cores_per_node": 48,

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -15,12 +15,11 @@ class RikenFugaku(System):
         "fugaku": {
             "sys_cores_per_node": 48,
             "sys_mem_per_node": 32,
+            "system_site": "riken",
             "hardware_key": str(hardware_descriptions)
             + "/Fujitsu-A64FX-TofuD/hardware_description.yaml",
         },
     }
-
-    system_site = "riken"
 
     variant(
         "compiler",

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -13,7 +13,7 @@ from benchpark.paths import hardware_descriptions
 class RikenFugaku(System):
 
     maintainers("jdomke", "SBA0486")
-    
+
     id_to_resources = {
         "fugaku": {
             "sys_cores_per_node": 48,

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -25,6 +25,13 @@ class RikenFugaku(System):
     maintainer("")
 
     variant(
+        "cluster",
+        default="fugaku",
+        values=("fugaku"),
+        description="Which cluster to run on",
+    )
+
+    variant(
         "compiler",
         default="clang",
         values=("clang", "gcc", "fj"),

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -23,13 +23,6 @@ class RikenFugaku(System):
     system_site = "riken"
 
     variant(
-        "cluster",
-        default="fugaku",
-        values=("fugaku",),
-        description="Which cluster to run on",
-    )
-
-    variant(
         "compiler",
         default="clang",
         values=("clang", "gcc", "fj"),
@@ -40,7 +33,7 @@ class RikenFugaku(System):
         super().initialize()
 
         self.scheduler = "pjm"
-        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
+        attrs = self.id_to_resources.get("fugaku")
         for k, v in attrs.items():
             setattr(self, k, v)
 

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -27,7 +27,7 @@ class RikenFugaku(System):
     variant(
         "cluster",
         default="fugaku",
-        values=("fugaku"),
+        values=("fugaku",),
         description="Which cluster to run on",
     )
 

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from benchpark.directives import variant, maintainer
+from benchpark.directives import variant, maintainers
 from benchpark.system import System
 from benchpark.paths import hardware_descriptions
 
@@ -21,8 +21,6 @@ class RikenFugaku(System):
     }
 
     system_site = "riken"
-
-    maintainer("")
 
     variant(
         "cluster",

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -5,11 +5,24 @@
 
 import pathlib
 
-from benchpark.directives import variant
+from benchpark.directives import variant, system_site, maintainer
 from benchpark.system import System
+from benchpark.paths import hardware_descriptions
 
 
 class RikenFugaku(System):
+    id_to_resources = {
+        "fugaku": {
+            "sys_cores_per_node": 48,
+            "sys_mem_per_node": 32,
+            "hardware_key": str(hardware_descriptions)
+            + "/Fujitsu-A64FX-TofuD/hardware_description.yaml",
+        },
+    }
+
+    system_site("riken")
+
+    maintainer("")
 
     variant(
         "compiler",
@@ -22,8 +35,9 @@ class RikenFugaku(System):
         super().initialize()
 
         self.scheduler = "pjm"
-        self.sys_cores_per_node = "48"
-        self.sys_mem_per_node = "32"
+        attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
+        for k, v in attrs.items():
+            setattr(self, k, v)
 
     def generate_description(self, output_dir):
         super().generate_description(output_dir)


### PR DESCRIPTION
## Description

resolves [benchpark/569](https://github.com/LLNL/benchpark/issues/569) by implementing the `benchpark info` command, and adding new directives.

## Adding/modifying a system

- [x] Modify `systems/llnl-cluster/system.py` (and presumably other systems): to refactor `id_to_resources`, adding the `hardware_key`, unless this becomes a separate directive.
- [x] Modify `systems/*/system.py` for `id_to_resources`, `system_site`, `maintainer`
- [x] Modify `experiments/*/experiment.py`

## Adding/modifying core functionality

- [x] Add `lib/benchpark/cmd/info.py` & modify `lib/main.py`: enables `benchpark info ...`
   - [x] Add `benchpark info system`
   - [x] Add `benchpark info experiment_name`
- [x] Modify `lib/benchpark/directives.py`: to add the `system_site` and `maintainer` directives.

## Docs

- [x] Modify `docs/basic-usage.rst`

## Uses
```
$ benchpark info experiment -h
usage: main.py info experiment [-h] [--spack] [--ramble] [--url] [--variants] [--maintainer] spec [spec ...]

positional arguments:
  spec          Experiment spec

options:
  -h, --help    show this help message and exit
  --spack       Information from Spack package
  --ramble      Information from Ramble package
  --url         URL for experiment
  --variants    Available experiment variants
  --maintainer  Maintainer
```

```
$ benchpark info system -h
usage: main.py info system [-h] [--variants] [--hardware] [--system-site] [--maintainer] spec [spec ...]

positional arguments:
  spec           System spec

options:
  -h, --help     show this help message and exit
  --variants     Available system variants
  --hardware     Hardware descriptions per cluster
  --system-site  System site
  --maintainer   Maintainer
```

## Examples

### `benchpark info system`
![image](https://github.com/user-attachments/assets/b7abcb3e-9c20-4602-9943-f7b6e7ddf108)
...
![image](https://github.com/user-attachments/assets/62da6b6d-0a99-42b2-87eb-b8d08639fded)



### `benchpark info experiment`
![image](https://github.com/user-attachments/assets/95415852-5ed2-4823-8f65-053701dfb394)

### `benchpark info system --query`
Query the id_to_resources dictionary for key/value pairs.
![image](https://github.com/user-attachments/assets/4b0532cb-ad9f-476d-a447-f19424e07b8a)
![image](https://github.com/user-attachments/assets/cbb1d18e-7f44-45b0-bd47-ff210d79150f)


