### PR TITLE
[WIP] Replicate RAJAPerf Experiments

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -53,15 +53,15 @@ class RajaPerf(
         description="Number of ranks before scaling."
     )
 
-    # variant(
-    #     "variants",
-    #     default="None",
-    # )
+    variant(
+        "variants",
+        default="None",
+    )
 
-    # variant(
-    #     "tunings",
-    #     default="None",
-    # )
+    variant(
+        "tunings",
+        default="None",
+    )
 
     def compute_applications_section(self):
 
@@ -93,12 +93,15 @@ class RajaPerf(
 
         self.add_experiment_variable("repfact", self.spec.variants["repfact"][0], True)
 
-        # rajaperf_variants = self.spec.variants["variants"][0].replace("-", " ")
-        # rajaperf_tunings = self.spec.variants["tunings"][0].replace("-", " ")
-        # if rajaperf_variants != "None":
-        #     execute += " --variants " + rajaperf_variants
-        # if rajaperf_tunings != "None":
-        #     execute += " --tunings " + rajaperf_tunings
+        variants = self.spec.variants["variants"][0].replace("-", " ")
+        if variants == "None":
+            variants = ""
+        self.add_experiment_variable("variants", variants, True)
+
+        tunings = self.spec.variants["tunings"][0].replace("-", " ")
+        if tunings == "None":
+            tunings = ""
+        self.add_experiment_variable("tunings", tunings, True)
 
         self.add_experiment_variable("execute", execute, True)
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -47,6 +47,12 @@ class RajaPerf(
         description="Multiplier on number of repitions to run each kernel",
     )
 
+    variant(
+        "n_ranks",
+        default=1,
+        description="Number of ranks before scaling."
+    )
+
     # variant(
     #     "variants",
     #     default="None",
@@ -59,15 +65,11 @@ class RajaPerf(
 
     def compute_applications_section(self):
 
-        n_resources = {"n_ranks": 1}
+        n_resources = int(self.spec.variants["n_ranks"][0])
         total_size = int(self.spec.variants["total_size"][0])
         execute = "raja-perf.exe"
 
-        if self.spec.satisfies("+single_node"):
-            for pk, pv in n_resources.items():
-                n_resources = pv
-
-        elif self.spec.satisfies("+strong"):
+        if self.spec.satisfies("+strong"):
             scaled_variables = self.generate_strong_scaling_params(
                 {tuple(n_resources.keys()): list(n_resources.values())},
                 int(self.spec.variants["scaling-factor"][0]),

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -41,10 +41,27 @@ class RajaPerf(
         description="total problem size (will be divided by ranks)",
     )
 
+    variant(
+        "repfact",
+        default=1,
+        description="Multiplier on number of repitions to run each kernel",
+    )
+
+    variant(
+        "variants",
+        default="None",
+    )
+
+    variant(
+        "tunings",
+        default="None",
+    )
+
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}
         total_size = int(self.spec.variants["total_size"][0])
+        execute = "raja-perf.exe"
 
         if self.spec.satisfies("+single_node"):
             for pk, pv in n_resources.items():
@@ -71,6 +88,19 @@ class RajaPerf(
         else:
             size = total_size
         self.add_experiment_variable("size", size, True)
+
+        self.add_experiment_variable("repfact", self.spec.variants["repfact"][0], True)
+
+        rajaperf_variants = self.spec.variants["variants"][0].replace("-", " ")
+        rajaperf_tunings = self.spec.variants["tunings"][0].replace("-", " ")
+        if rajaperf_variants != "None":
+            execute += " --variants " + rajaperf_variants
+        if rajaperf_tunings != "None":
+            execute += " --tunings " + rajaperf_tunings
+
+        self.add_experiment_variable("execute", execute, True)
+        self.add_experiment_variable("variants", self.spec.variants["variants"][0], True)
+        self.add_experiment_variable("tunings", self.spec.variants["tunings"][0], True)
 
     def compute_package_section(self):
         # get package version

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -48,12 +48,6 @@ class RajaPerf(
     )
 
     variant(
-        "n_ranks",
-        default=1,
-        description="Number of ranks before scaling."
-    )
-
-    variant(
         "variants",
         default="None",
     )
@@ -65,7 +59,7 @@ class RajaPerf(
 
     def compute_applications_section(self):
 
-        n_resources = int(self.spec.variants["n_ranks"][0])
+        n_resources = {"n_ranks": 1}
         total_size = int(self.spec.variants["total_size"][0])
         execute = "raja-perf.exe"
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -36,9 +36,9 @@ class RajaPerf(
     )
 
     variant(
-        "total_size",
+        "per_process_problem_size",
         default=1048576,
-        description="total problem size (will be divided by ranks)",
+        description="per-process problem size",
     )
 
     variant(
@@ -60,7 +60,7 @@ class RajaPerf(
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}
-        total_size = int(self.spec.variants["total_size"][0])
+        per_proc_size = int(self.spec.variants["per_process_problem_size"][0])
         execute = "raja-perf.exe"
 
         if self.spec.satisfies("+strong"):
@@ -70,6 +70,11 @@ class RajaPerf(
                 int(self.spec.variants["scaling-iterations"][0]),
             )
             n_resources = scaled_variables["n_ranks"]
+            if isinstance(n_resources, list):
+                size = [int(per_proc_size / res) for res in n_resources]
+            else:
+                size = per_proc_size
+            self.add_experiment_variable("size", size, True)
 
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             self.add_experiment_variable("n_gpus", n_resources, True)
@@ -79,25 +84,17 @@ class RajaPerf(
         else:
             self.add_experiment_variable("n_ranks", n_resources, True)
 
-        if isinstance(n_resources, list):
-            size = [int(total_size / res) for res in n_resources]
-        else:
-            size = total_size
-        self.add_experiment_variable("size", size, True)
-
         self.add_experiment_variable("repfact", self.spec.variants["repfact"][0], True)
 
         variants = self.spec.variants["variants"][0].replace("-", " ")
         if variants == "None":
             variants = ""
-        self.add_experiment_variable("variants", variants, True)
+        self.add_experiment_variable("variants", variants, False)
 
         tunings = self.spec.variants["tunings"][0].replace("-", " ")
         if tunings == "None":
             tunings = ""
-        self.add_experiment_variable("tunings", tunings, True)
-
-        self.add_experiment_variable("execute", execute, True)
+        self.add_experiment_variable("tunings", tunings, False)
 
     def compute_package_section(self):
         # get package version

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -20,6 +20,9 @@ class RajaPerf(
     OpenMPExperiment,
     Caliper,
 ):
+
+    maintainers("michaelmckinsey1")
+
     variant(
         "workload",
         default="suite",
@@ -32,11 +35,16 @@ class RajaPerf(
         description="app version",
     )
 
-    maintainers("michaelmckinsey1")
+    variant(
+        "total_size",
+        default=1048576,
+        description="total problem size (will be divided by ranks)",
+    )
 
     def compute_applications_section(self):
 
         n_resources = {"n_ranks": 1}
+        total_size = int(self.spec.variants["total_size"][0])
 
         if self.spec.satisfies("+single_node"):
             for pk, pv in n_resources.items():
@@ -57,6 +65,12 @@ class RajaPerf(
             self.add_experiment_variable("n_threads_per_proc", 1, True)
         else:
             self.add_experiment_variable("n_ranks", n_resources, True)
+
+        if isinstance(n_resources, list):
+            size = [int(total_size / res) for res in n_resources]
+        else:
+            size = total_size
+        self.add_experiment_variable("size", size, True)
 
     def compute_package_section(self):
         # get package version

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -47,15 +47,15 @@ class RajaPerf(
         description="Multiplier on number of repitions to run each kernel",
     )
 
-    variant(
-        "variants",
-        default="None",
-    )
+    # variant(
+    #     "variants",
+    #     default="None",
+    # )
 
-    variant(
-        "tunings",
-        default="None",
-    )
+    # variant(
+    #     "tunings",
+    #     default="None",
+    # )
 
     def compute_applications_section(self):
 
@@ -91,16 +91,14 @@ class RajaPerf(
 
         self.add_experiment_variable("repfact", self.spec.variants["repfact"][0], True)
 
-        rajaperf_variants = self.spec.variants["variants"][0].replace("-", " ")
-        rajaperf_tunings = self.spec.variants["tunings"][0].replace("-", " ")
-        if rajaperf_variants != "None":
-            execute += " --variants " + rajaperf_variants
-        if rajaperf_tunings != "None":
-            execute += " --tunings " + rajaperf_tunings
+        # rajaperf_variants = self.spec.variants["variants"][0].replace("-", " ")
+        # rajaperf_tunings = self.spec.variants["tunings"][0].replace("-", " ")
+        # if rajaperf_variants != "None":
+        #     execute += " --variants " + rajaperf_variants
+        # if rajaperf_tunings != "None":
+        #     execute += " --tunings " + rajaperf_tunings
 
         self.add_experiment_variable("execute", execute, True)
-        self.add_experiment_variable("variants", self.spec.variants["variants"][0], True)
-        self.add_experiment_variable("tunings", self.spec.variants["tunings"][0], True)
 
     def compute_package_section(self):
         # get package version

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -35,11 +35,9 @@ class RajaPerf(ExecutableApplication):
         "sycl",
     ]
 
-    executable("run", "raja-perf.exe" + " --size {size}", use_mpi=True)
+    executable("run", "{execute}" + " --size {size}" + " --repfact {repfact}", use_mpi=True)
 
     workload("suite", executables=["run"])
-
-    # workload_variable('size', default='1048576', description='Problem size per rank', workloads=['suite'])
 
     figure_of_merit(
         "All tests pass",

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -10,18 +10,48 @@ from ramble.appkit import *
 
 class RajaPerf(ExecutableApplication):
     """RAJA Performance suite"""
+
     name = "raja-perf"
 
-    tags = ['asc','single-node','sub-node','structured-grid',
-            'atomics','simd','vectorization','register-pressure',
-            'high-memory-bandwidth','regular-memory-access',
-            'mpi','network-point-to-point','network-latency-bound',
-            'c++','raja','sycl']
+    tags = [
+        "asc",
+        "single-node",
+        "sub-node",
+        "structured-grid",
+        "atomics",
+        "simd",
+        "vectorization",
+        "register-pressure",
+        "high-memory-bandwidth",
+        "regular-memory-access",
+        "mpi",
+        "network-point-to-point",
+        "network-latency-bound",
+        "c++",
+        "raja",
+        "cuda",
+        "hip",
+        "openmp",
+        "sycl",
+    ]
 
-    executable('run', 'raja-perf.exe', use_mpi=True)
+    executable("run", "raja-perf.exe" + " --size {size}", use_mpi=True)
 
-    workload('suite', executables=['run'])
+    workload("suite", executables=["run"])
 
-    figure_of_merit('All tests pass', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'(?P<tpass>DONE)!!!...', group_name='tpass', units='')
+    # workload_variable('size', default='1048576', description='Problem size per rank', workloads=['suite'])
 
-    success_criteria('pass', mode='string', match=r'DONE!!!....', file='{experiment_run_dir}/{experiment_name}.out')
+    figure_of_merit(
+        "All tests pass",
+        log_file="{experiment_run_dir}/{experiment_name}.out",
+        fom_regex=r"(?P<tpass>DONE)!!!...",
+        group_name="tpass",
+        units="",
+    )
+
+    success_criteria(
+        "pass",
+        mode="string",
+        match=r"DONE!!!....",
+        file="{experiment_run_dir}/{experiment_name}.out",
+    )

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -37,7 +37,7 @@ class RajaPerf(ExecutableApplication):
 
     executable(
         "run",
-        template=["{execute}" + " --size {size}" + " --repfact {repfact}" + " --variants {variants}" + " --tunings {tunings}"],
+        template=["raja-perf.exe" + " --size {size}" + " --repfact {repfact}" + " --variants {variants}" + " --tunings {tunings}"],
         use_mpi=True
     )
 

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -35,9 +35,31 @@ class RajaPerf(ExecutableApplication):
         "sycl",
     ]
 
-    executable("run", "{execute}" + " --size {size}" + " --repfact {repfact}", use_mpi=True)
+    executable(
+        "run",
+        template=["{execute}" + " --size {size}" + " --repfact {repfact}"],
+        use_mpi=True
+    )
+
+    # executable(
+    #     "run",
+    #     template=["{execute}" + " --size {size}" + " --repfact {repfact}" + " {additional_args}"],
+    #     use_mpi=True
+    # )
 
     workload("suite", executables=["run"])
+
+    # workload_variable(
+    #     "additional_args",
+    #     default="--variants {variants} --tunings {tunings}",
+    #     workloads=["suite"],
+    #     description="",
+    # )
+
+    # workload_variable("variants", default="", workloads=["suite"], description="")
+
+    # workload_variable("tunings", default="", workloads=["suite"], description="")
+
 
     figure_of_merit(
         "All tests pass",

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -37,29 +37,11 @@ class RajaPerf(ExecutableApplication):
 
     executable(
         "run",
-        template=["{execute}" + " --size {size}" + " --repfact {repfact}"],
+        template=["{execute}" + " --size {size}" + " --repfact {repfact}" + " --variants {variants}" + " --tunings {tunings}"],
         use_mpi=True
     )
 
-    # executable(
-    #     "run",
-    #     template=["{execute}" + " --size {size}" + " --repfact {repfact}" + " {additional_args}"],
-    #     use_mpi=True
-    # )
-
     workload("suite", executables=["run"])
-
-    # workload_variable(
-    #     "additional_args",
-    #     default="--variants {variants} --tunings {tunings}",
-    #     workloads=["suite"],
-    #     description="",
-    # )
-
-    # workload_variable("variants", default="", workloads=["suite"], description="")
-
-    # workload_variable("tunings", default="", workloads=["suite"], description="")
-
 
     figure_of_merit(
         "All tests pass",

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -126,6 +126,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     homepage = "http://software.llnl.gov/RAJAPerf/"
     git      = "https://github.com/LLNL/RAJAPerf.git"
 
+    version("fixcali_config", branch="fix/cali_config", submodules="True")
     version("develop", branch="develop", submodules="True")
     version("main",  branch="main",  submodules="True")
     version("2024.07.0", tag="v2024.07.0", submodules="True")

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -128,6 +128,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop", submodules="True")
     version("main",  branch="main",  submodules="True")
+    version("2024.07.0", tag="v2024.07.0", submodules="True")
     version("2022.10.0", tag="v2022.10.0", submodules="True")
     version("0.12.0", tag="v0.12.0", submodules="True")
     version("0.11.0", tag="v0.11.0", submodules="True")


### PR DESCRIPTION
## Description

Enable replication of RAJAPerf experiments from recent Jan 2025 paper. These experiments were not ran in Benchpark, but were built with cmake & build scripts and ran manually.

- [x] Enable passing additional command line arguments to `raja-perf` binary
- [ ] Caliper configs we need to be able to use:
   - [x] time
   - [ ] topdown
   - [ ] gpu-side calls (cuda-activity-profile)
   - [ ] ncu 
- [ ] Replicate Datasets:
   - [x] V100
   - [ ] MI250x
   - [ ] MI300a
   - [ ] A100
   - [ ] GH200

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Modify `experiments/raja-perf/experiment.py`
- [x] Modify `repo/raja-perf/application.py`


## V100 setup reproducer

```
benchpark system init --dest=lassen llnl-sierra
benchpark experiment init --dest=raja-perf raja-perf+cuda+strong~single_node caliper=time version=2024.07.0 scaling-factor=4 scaling-iterations=2 total_size=33554432 repfact=5 variants="Base_Seq-RAJA_Seq" tunings="default-library"
benchpark setup ./raja-perf/ ./lassen/ wkp/
```
![image](https://github.com/user-attachments/assets/6a144620-d8ea-47a5-8806-099e306309c9)
(text values shown on figure are raw values, not speedup)
