### PR TITLE
dont force zlib as zlib-api provider for llnl-cluster

### DIFF
--- a/systems/llnl-cluster/externals/base/00-packages.yaml
+++ b/systems/llnl-cluster/externals/base/00-packages.yaml
@@ -58,5 +58,3 @@ packages:
     externals:
     - spec: fftw@3.3.10
       prefix: /usr/tce/packages/fftw/fftw-3.3.10
-  zlib-api:                                                                     
-    require: zlib


### PR DESCRIPTION
Closes https://github.com/LLNL/benchpark/issues/453

This only leaves zlib enforcement in `riken-fugaku`, but that has extra constraints that appear relevant.