### PR TITLE
Avoid using CALI_CONFIG for RAJAPerf

### DIFF
--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -9,6 +9,7 @@ _default_mode = "time"
 
 _cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
 
+
 class Caliper(BasicModifier):
     """Define a modifier for Caliper"""
 

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -48,7 +48,7 @@ class Caliper(BasicModifier):
             "CALI_CONFIG_MODE",
             mode_option,
             method="append",
-            separator="," if app.name != "raja-perf" else "",
+            separator="," if app.name != "raja-perf" else " ",
             modes=[mode_name],
         )
 

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -7,6 +7,7 @@ from ramble.modkit import *
 
 _default_mode = "time"
 
+_cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
 
 class Caliper(BasicModifier):
     """Define a modifier for Caliper"""
@@ -16,8 +17,6 @@ class Caliper(BasicModifier):
     tags("profiler", "performance-analysis")
 
     maintainers("pearce8")
-
-    _cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
 
     def determine_cali_config(self):
         if self.app.name != "raja-perf":

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -5,20 +5,7 @@
 
 from ramble.modkit import *
 
-
-def add_mode(mode_name, mode_option, description):
-    mode(
-        name=mode_name,
-        description=description,
-    )
-
-    env_var_modification(
-        "CALI_CONFIG_MODE",
-        mode_option,
-        method="append",
-        separator=",",
-        modes=[mode_name],
-    )
+_default_mode = "time"
 
 
 class Caliper(BasicModifier):
@@ -32,56 +19,88 @@ class Caliper(BasicModifier):
 
     _cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
 
-    _default_mode = "time"
+    def determine_cali_config(self):
+        if self.app.name != "raja-perf":
+            self.env_var_modification(
+                "CALI_CONFIG",
+                "spot(output={}{})".format(_cali_datafile, "${CALI_CONFIG_MODE}"),
+                method="set",
+                modes=[_default_mode],
+            )
+        else:
+            pass
 
-    add_mode(
-        mode_name=_default_mode,
-        mode_option="time.exclusive",
-        description="Platform-independent collection of time (default mode)",
-    )
+    def inherit_from_application(self, app):
+        super().inherit_from_application(app)
+        self.app = app
 
-    env_var_modification(
-        "CALI_CONFIG",
-        "spot(output={}{})".format(_cali_datafile, "${CALI_CONFIG_MODE}"),
-        method="set",
-        modes=[_default_mode],
-    )
+        self.determine_cali_config()
 
-    add_mode(
-        mode_name="mpi",
-        mode_option="profile.mpi",
-        description="Profile MPI functions",
-    )
+        self.add_modes()
 
-    add_mode(
-        mode_name="cuda",
-        mode_option="profile.cuda",
-        description="Profile CUDA API functions",
-    )
+    def add_mode(self, mode_name, mode_option, description, app):
+        self.mode(
+            name=mode_name,
+            description=description,
+        )
 
-    add_mode(
-        mode_name="topdown-counters-all",
-        mode_option="topdown-counters.all",
-        description="Raw counter values for Intel top-down analysis (all levels)",
-    )
+        self.env_var_modification(
+            "CALI_CONFIG_MODE",
+            mode_option,
+            method="append",
+            separator="," if app.name != "raja-perf" else "",
+            modes=[mode_name],
+        )
 
-    add_mode(
-        mode_name="topdown-counters-toplevel",
-        mode_option="topdown-counters.toplevel",
-        description="Raw counter values for Intel top-down analysis (top level)",
-    )
+    def add_modes(self):
+        self.add_mode(
+            mode_name=_default_mode,
+            mode_option="time.exclusive",
+            description="Platform-independent collection of time (default mode)",
+            app=self.app,
+        )
 
-    add_mode(
-        mode_name="topdown-all",
-        mode_option="topdown.all",
-        description="Top-down analysis for Intel CPUs (all levels)",
-    )
+        self.add_mode(
+            mode_name="mpi",
+            mode_option="profile.mpi",
+            description="Profile MPI functions",
+            app=self.app,
+        )
 
-    add_mode(
-        mode_name="topdown-toplevel",
-        mode_option="topdown.toplevel",
-        description="Top-down analysis for Intel CPUs (top level)",
-    )
+        self.add_mode(
+            mode_name="cuda",
+            mode_option="profile.cuda",
+            description="Profile CUDA API functions",
+            app=self.app,
+        )
+
+        self.add_mode(
+            mode_name="topdown-counters-all",
+            mode_option="topdown-counters.all",
+            description="Raw counter values for Intel top-down analysis (all levels)",
+            app=self.app,
+        )
+
+        self.add_mode(
+            mode_name="topdown-counters-toplevel",
+            mode_option="topdown-counters.toplevel",
+            description="Raw counter values for Intel top-down analysis (top level)",
+            app=self.app,
+        )
+
+        self.add_mode(
+            mode_name="topdown-all",
+            mode_option="topdown.all",
+            description="Top-down analysis for Intel CPUs (all levels)",
+            app=self.app,
+        )
+
+        self.add_mode(
+            mode_name="topdown-toplevel",
+            mode_option="topdown.toplevel",
+            description="Top-down analysis for Intel CPUs (top level)",
+            app=self.app,
+        )
 
     archive_pattern(_cali_datafile)
 

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -21,7 +21,7 @@ class RajaPerf(ExecutableApplication):
     executable(
         "run",
         "raja-perf.exe"
-        + " --add-to-spot-config $CALI_CONFIG_MODE"
+        + " --add-to-spot-config '$CALI_CONFIG_MODE'"
         + " --outdir {experiment_run_dir}",
         use_mpi=True,
     )

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -31,4 +31,3 @@ class RajaPerf(ExecutableApplication):
     figure_of_merit('All tests pass', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'(?P<tpass>DONE)!!!...', group_name='tpass', units='')
 
     success_criteria('pass', mode='string', match=r'DONE!!!....', file='{experiment_run_dir}/{experiment_name}.out')
-   

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -18,10 +18,17 @@ class RajaPerf(ExecutableApplication):
             'mpi','network-point-to-point','network-latency-bound',
             'c++','raja','cuda','hip','openmp','sycl']
 
-    executable('run', 'raja-perf.exe', use_mpi=True)
+    executable(
+        "run",
+        "raja-perf.exe"
+        + " --add-to-spot-config $CALI_CONFIG_MODE"
+        + " --outdir {experiment_run_dir}",
+        use_mpi=True,
+    )
 
     workload('suite', executables=['run'])
 
     figure_of_merit('All tests pass', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'(?P<tpass>DONE)!!!...', group_name='tpass', units='')
 
     success_criteria('pass', mode='string', match=r'DONE!!!....', file='{experiment_run_dir}/{experiment_name}.out')
+   

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -140,6 +140,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     version("0.5.1", tag="v0.5.1", submodules="True")
     version("0.5.0", tag="v0.5.0", submodules="True")
     version("0.4.0", tag="v0.4.0", submodules="True")
+    version("fixcaliconfig", branch="fix/cali_config", submodules="True")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Build OpenMP backend")


### PR DESCRIPTION
## Description

Corresponds to change in [LLNL/RAJAPerf#501 (See explanation)](https://github.com/LLNL/RAJAPerf/pull/501)

- [x] Modifies `modifiers/caliper/modifier.py` the Caliper modifier to disable `CALI_CONFIG` being generated for the `raja-perf` application.
- [x] Modifies `repo/raja-perf/application.py` to pass variables directly to the Caliper config manager in `raja-perf`.
- [x] Modifies `repo/raja-perf/package.py` to add corresponding branch of RAJAPerf (Can be removed after merge in RAJAPerf develop)  
