### PR TITLE
[ARCHIVED] Adding basic mpibind modifier

### DIFF
--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -13,6 +13,7 @@ from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
 from benchpark.scaling import ThroughputScaling
 from benchpark.caliper import Caliper
+from benchpark.mpibind import Mpibind
 
 
 class Kripke(
@@ -24,6 +25,7 @@ class Kripke(
     WeakScaling,
     ThroughputScaling,
     Caliper,
+    Mpibind,
 ):
     variant(
         "workload",

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -13,13 +13,13 @@ from benchpark.caliper import Caliper
 from benchpark.mpibind import Mpibind
 
 class Saxpy(
-        Experiment,
-        OpenMPExperiment,
-        CudaExperiment,
-        ROCmExperiment, 
-        Caliper,
-        Mpibind,
-    ):
+    Experiment,
+    OpenMPExperiment,
+    CudaExperiment,
+    ROCmExperiment, 
+    Caliper,
+    Mpibind,
+):
     variant(
         "workload",
         default="problem",

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -12,11 +12,12 @@ from benchpark.rocm import ROCmExperiment
 from benchpark.caliper import Caliper
 from benchpark.mpibind import Mpibind
 
+
 class Saxpy(
     Experiment,
     OpenMPExperiment,
     CudaExperiment,
-    ROCmExperiment, 
+    ROCmExperiment,
     Caliper,
     Mpibind,
 ):

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -10,9 +10,9 @@ from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.caliper import Caliper
+from benchpark.mpibind import Mpibind
 
-
-class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Caliper):
+class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Caliper, Mpibind):
     variant(
         "workload",
         default="problem",

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -12,7 +12,14 @@ from benchpark.rocm import ROCmExperiment
 from benchpark.caliper import Caliper
 from benchpark.mpibind import Mpibind
 
-class Saxpy(Experiment, OpenMPExperiment, CudaExperiment, ROCmExperiment, Caliper, Mpibind):
+class Saxpy(
+        Experiment,
+        OpenMPExperiment,
+        CudaExperiment,
+        ROCmExperiment, 
+        Caliper,
+        Mpibind,
+    ):
     variant(
         "workload",
         default="problem",

--- a/lib/benchpark/mpibind.py
+++ b/lib/benchpark/mpibind.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from benchpark.directives import variant
+from benchpark.experiment import ExperimentHelper
+
+
+class Mpibind:
+    variant(
+        "mpibind",
+        default="on",
+        values=(
+            "on",
+            "off",
+            "v",
+            "vv",
+        ),
+        multi=False,
+        description="Toggle mpibind and set verbosity",
+    )
+
+    class Helper(ExperimentHelper):
+        def compute_modifiers_section(self):
+            modifier_list = []
+            if not self.spec.satisfies("mpibind=off"):
+                mpibind_modifier_modes = {}
+                mpibind_modifier_modes["name"] = "mpibind"
+                mpibind_modifier_modes["mode"] = self.spec.variants["mpibind"][0]
+                modifier_list.append(mpibind_modifier_modes)
+            return modifier_list

--- a/lib/benchpark/mpibind.py
+++ b/lib/benchpark/mpibind.py
@@ -17,6 +17,7 @@ class Mpibind:
             "off",
             "v",
             "vv",
+            "greedy:0",
         ),
         multi=False,
         description="Toggle mpibind and set verbosity",

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -1,0 +1,164 @@
+#Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+from .allocation import Allocation
+from ramble.modkit import *
+
+
+class Mpibind(Allocation, BasicModifier):
+    """Define a modifier for printing the thread/gpu affinity for each mpi rank"""
+
+    name = "mpibind"
+
+    maintainers("knox10")
+
+    _default_mode = "on"
+
+    mode(
+        name="off",
+        description="Turn off mpibind",
+    )
+
+    mode(
+        name="on",
+        description="Turn on mpibind",
+    )
+
+    mode(
+        name="v",
+        description="Run mpibind in verbose mode",
+    )
+
+    mode(
+        name="vv",
+        description="Run mpibind in very verbose mode",
+    )
+    #executable_modifier("mpibind")
+    env_var_modification(
+        "test",
+        "v",
+        method="append",
+        #separator=",",
+        modes=["v"],
+    )
+
+    modifier_variable(
+        "flux",
+        default= False,
+        modes=["all"],
+        description="mpibind on default val",
+    )
+
+    modifier_variable(
+        "mpibind_flag",
+        default="on",
+        modes=["on"],
+        description="mpibind on default val",
+    )
+
+    modifier_variable(
+        "mpibind_flag",
+        default="off",
+        modes=["off"],
+        description="mpibind off default val",
+    )
+
+    modifier_variable(
+        "mpibind_flag",
+        default="v",
+        modes=["v"],
+        description="mpibind v default flag",
+    )
+
+    modifier_variable(
+        "mpibind_flag",
+        default="vv",
+        modes=["all"],
+        description="mpibind vv default flag",
+    )
+    
+    #variable_modification(
+     #   "{mpi_command}",
+     #   "{mpi_command} --mpibind=v",
+     #   method="set",
+     #   modes=["v"],
+    #)
+    
+    def set_mode(self, scheduler, base_string):
+        
+        handler = {
+            "slurm": "--mpibind=",
+            "flux": "-o mpibind=",
+            "mpi": "--mpibind=",
+            "lsf": "--mpibind=",
+            "pjm": "--mpibind=",
+        }
+        mpi_string = handler.get(scheduler)
+        if scheduler == "flux":
+            flags = {
+                "v": "verbose:1",
+                "vv": "verbose:2",
+                "on": "on",
+                "off": "off",
+            }
+            mpi_end = flags.get(self.expander.expand_var(self._usage_mode)) 
+            return f"{base_string} {mpi_string}{mpi_end}"
+        else:
+            mpi_end = self.expander.expand_var(self._usage_mode) 
+            return f"{base_string} {mpi_string}{mpi_end}"
+
+    def inherit_from_application(self, app):
+        super().inherit_from_application(app)
+        base_string = app.variables.get("mpi_command")
+        scheduler = app.variables.get("scheduler")
+        handler = {
+            "slurm": "--mpibind=",
+            "flux": "-o mpibind=",
+            "mpi": "--mpibind=",
+            "lsf": "--mpibind=",
+            "pjm": "--mpibind=",
+        }
+        
+        mpi_string = handler.get(scheduler)
+        #app.variables["mpi_command"] = (f"{base_string} {mpi_string}{self.mode}")
+        app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
+
+
+         
+
+
+'''
+    def add_mpibind_flags(self,v):
+
+    	handler = {
+            "slurm": "--mpibind=v",
+            "flux": "--setopt=mpibind="
+            "mpi": "--mpibind=",
+            "lsf": "--mpibind=",
+            "pjm": "--mpibind=",
+        }
+	original_string= v.mpi_command
+	v.mpi_command = (f" {original_string} {mpibind_string}")
+
+    def mpibind(self, app):
+
+        #result=super().inherit_from_application(app)
+        #print(result)
+
+
+        pre_exec = []
+         post_exec = []
+        pre_exec.append(
+            CommandExecutable(
+                f"foo",
+                template=[f"--mpibind=v"],
+                mpi=True,
+
+            )
+        )
+
+        return pre_exec, post_exec
+        '''

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -5,6 +5,8 @@
 
 from .allocation import Allocation
 from ramble.modkit import *
+import os
+from ramble.util.executable import CommandExecutable
 
 
 class Mpibind(Allocation, BasicModifier):
@@ -46,6 +48,22 @@ class Mpibind(Allocation, BasicModifier):
         modes=["all"],
         description="mpibind on default val",
     )
+    
+    executable_modifier("mpibind")
+
+    def mpibind(self, executable_name, executable, app_inst=None):
+        pre_exec = []
+        post_exec = []
+        output_file = f"{{experiment_run_dir}}/{{experiment_name}}.out"
+        mpibind_parser_dir = os.path.dirname(f"{self._file_path}")
+
+        post_exec.append(
+            CommandExecutable(
+                f"parse-stdout-{executable_name}",
+                template=[f"python3 {mpibind_parser_dir}/parse_mpibind_output.py {output_file}"],
+            )
+        )
+        return pre_exec, post_exec
 
     def inherit_from_application(self, app):
         super().inherit_from_application(app)
@@ -53,6 +71,7 @@ class Mpibind(Allocation, BasicModifier):
         scheduler = app.variables.get("scheduler")
 
         app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
+
 
     def set_mode(self, scheduler, base_string):
 

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -36,13 +36,9 @@ class Mpibind(Allocation, BasicModifier):
         name="vv",
         description="Run mpibind in very verbose mode",
     )
-    #executable_modifier("mpibind")
-    env_var_modification(
-        "test",
-        "v",
-        method="append",
-        #separator=",",
-        modes=["v"],
+    mode(
+            name="greedy:0",
+        description="Run mpibind in very verbose mode",
     )
 
     modifier_variable(
@@ -52,41 +48,21 @@ class Mpibind(Allocation, BasicModifier):
         description="mpibind on default val",
     )
 
-    modifier_variable(
-        "mpibind_flag",
-        default="on",
-        modes=["on"],
-        description="mpibind on default val",
-    )
+    def inherit_from_application(self, app):
+        super().inherit_from_application(app)
+        base_string = app.variables.get("mpi_command")
+        scheduler = app.variables.get("scheduler")
+        handler = {
+            "slurm": "--mpibind=",
+            "flux": "-o mpibind=",
+            "mpi": "--mpibind=",
+            "lsf": "--mpibind=",
+            "pjm": "--mpibind=",
+        }
+        
+        mpi_string = handler.get(scheduler)
+        app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
 
-    modifier_variable(
-        "mpibind_flag",
-        default="off",
-        modes=["off"],
-        description="mpibind off default val",
-    )
-
-    modifier_variable(
-        "mpibind_flag",
-        default="v",
-        modes=["v"],
-        description="mpibind v default flag",
-    )
-
-    modifier_variable(
-        "mpibind_flag",
-        default="vv",
-        modes=["all"],
-        description="mpibind vv default flag",
-    )
-    
-    #variable_modification(
-     #   "{mpi_command}",
-     #   "{mpi_command} --mpibind=v",
-     #   method="set",
-     #   modes=["v"],
-    #)
-    
     def set_mode(self, scheduler, base_string):
         
         handler = {
@@ -103,62 +79,10 @@ class Mpibind(Allocation, BasicModifier):
                 "vv": "verbose:2",
                 "on": "on",
                 "off": "off",
+                "greedy:0": "greedy:0",
             }
             mpi_end = flags.get(self.expander.expand_var(self._usage_mode)) 
             return f"{base_string} {mpi_string}{mpi_end}"
         else:
             mpi_end = self.expander.expand_var(self._usage_mode) 
             return f"{base_string} {mpi_string}{mpi_end}"
-
-    def inherit_from_application(self, app):
-        super().inherit_from_application(app)
-        base_string = app.variables.get("mpi_command")
-        scheduler = app.variables.get("scheduler")
-        handler = {
-            "slurm": "--mpibind=",
-            "flux": "-o mpibind=",
-            "mpi": "--mpibind=",
-            "lsf": "--mpibind=",
-            "pjm": "--mpibind=",
-        }
-        
-        mpi_string = handler.get(scheduler)
-        #app.variables["mpi_command"] = (f"{base_string} {mpi_string}{self.mode}")
-        app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
-
-
-         
-
-
-'''
-    def add_mpibind_flags(self,v):
-
-    	handler = {
-            "slurm": "--mpibind=v",
-            "flux": "--setopt=mpibind="
-            "mpi": "--mpibind=",
-            "lsf": "--mpibind=",
-            "pjm": "--mpibind=",
-        }
-	original_string= v.mpi_command
-	v.mpi_command = (f" {original_string} {mpibind_string}")
-
-    def mpibind(self, app):
-
-        #result=super().inherit_from_application(app)
-        #print(result)
-
-
-        pre_exec = []
-         post_exec = []
-        pre_exec.append(
-            CommandExecutable(
-                f"foo",
-                template=[f"--mpibind=v"],
-                mpi=True,
-
-            )
-        )
-
-        return pre_exec, post_exec
-        '''

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -48,7 +48,7 @@ class Mpibind(Allocation, BasicModifier):
         modes=["all"],
         description="mpibind on default val",
     )
-    
+
     executable_modifier("mpibind")
 
     def mpibind(self, executable_name, executable, app_inst=None):
@@ -60,7 +60,9 @@ class Mpibind(Allocation, BasicModifier):
         post_exec.append(
             CommandExecutable(
                 f"parse-stdout-{executable_name}",
-                template=[f"python3 {mpibind_parser_dir}/parse_mpibind_output.py {output_file}"],
+                template=[
+                    f"python3 {mpibind_parser_dir}/parse_mpibind_output.py {output_file}"
+                ],
             )
         )
         return pre_exec, post_exec
@@ -71,7 +73,6 @@ class Mpibind(Allocation, BasicModifier):
         scheduler = app.variables.get("scheduler")
 
         app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
-
 
     def set_mode(self, scheduler, base_string):
 

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -1,4 +1,4 @@
-#Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -37,13 +37,13 @@ class Mpibind(Allocation, BasicModifier):
         description="Run mpibind in very verbose mode",
     )
     mode(
-            name="greedy:0",
+        name="greedy:0",
         description="Run mpibind in very verbose mode",
     )
 
     modifier_variable(
         "flux",
-        default= False,
+        default=False,
         modes=["all"],
         description="mpibind on default val",
     )
@@ -59,12 +59,12 @@ class Mpibind(Allocation, BasicModifier):
             "lsf": "--mpibind=",
             "pjm": "--mpibind=",
         }
-        
+
         mpi_string = handler.get(scheduler)
         app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
 
     def set_mode(self, scheduler, base_string):
-        
+
         handler = {
             "slurm": "--mpibind=",
             "flux": "-o mpibind=",
@@ -81,8 +81,8 @@ class Mpibind(Allocation, BasicModifier):
                 "off": "off",
                 "greedy:0": "greedy:0",
             }
-            mpi_end = flags.get(self.expander.expand_var(self._usage_mode)) 
+            mpi_end = flags.get(self.expander.expand_var(self._usage_mode))
             return f"{base_string} {mpi_string}{mpi_end}"
         else:
-            mpi_end = self.expander.expand_var(self._usage_mode) 
+            mpi_end = self.expander.expand_var(self._usage_mode)
             return f"{base_string} {mpi_string}{mpi_end}"

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -51,13 +51,6 @@ class Mpibind(Allocation, BasicModifier):
         super().inherit_from_application(app)
         base_string = app.variables.get("mpi_command")
         scheduler = app.variables.get("scheduler")
-        handler = {
-            "slurm": "--mpibind=",
-            "flux": "-o mpibind=",
-            "mpi": "--mpibind=",
-            "lsf": "--mpibind=",
-            "pjm": "--mpibind=",
-        }
 
         app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
 

--- a/modifiers/mpibind/modifier.py
+++ b/modifiers/mpibind/modifier.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
 from .allocation import Allocation
 from ramble.modkit import *
 
@@ -60,7 +59,6 @@ class Mpibind(Allocation, BasicModifier):
             "pjm": "--mpibind=",
         }
 
-        mpi_string = handler.get(scheduler)
         app.variables["mpi_command"] = self.set_mode(scheduler, base_string)
 
     def set_mode(self, scheduler, base_string):

--- a/modifiers/mpibind/parse_mpibind_output.py
+++ b/modifiers/mpibind/parse_mpibind_output.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import re
+import argparse
+from pathlib import Path
+
+
+def parse_mpibind(input_file):
+
+    with open(input_file, "r") as f:
+        lines = f.readlines()
+
+    task_map = {}
+
+    for line in lines:
+
+        # Match lines beginning with "mpibind:"
+        mpibind_match = re.match(r"^mpibind:.*(?:\r?\n|$)", line)
+        if mpibind_match:
+
+            pattern = r"task\s+(\d+)\s+nths\s+([\d,]*)\s+gpus\s+([\d,]*)\s+cpus\s+([\d,]*)"
+            match = re.search(pattern, line)
+            if match:
+                task = match.group(1)  # Task number
+                nths = match.group(2)  # Nths value
+                gpus = match.group(3)  # GPUs value
+                cpus = match.group(4)  # CPUs value
+	
+                task_map["task "+task] = {
+                    "cpus": cpus,
+                    "gpus": gpus,
+                    "nths": nths,
+                }
+
+    output_file = "mpibind_log_file.json"
+    with open(output_file, "w") as json_file:
+        json.dump(task_map, json_file, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="affinity output to JSON")
+    parser.add_argument("output_file", type=str, help="mpibind log file (text)")
+
+    args = parser.parse_args()
+    parse_mpibind(args.output_file)

--- a/modifiers/mpibind/parse_mpibind_output.py
+++ b/modifiers/mpibind/parse_mpibind_output.py
@@ -23,7 +23,7 @@ def parse_mpibind(input_file):
         if mpibind_match:
 
             pattern = (
-                    r"task\s+(\d+)\s+nths\s+([\d,]*)\s+gpus\s+([\d,]*)\s+cpus\s+([\d,]*)"
+                r"task\s+(\d+)\s+nths\s+([\d,]*)\s+gpus\s+([\d,]*)\s+cpus\s+([\d,]*)"
             )
             match = re.search(pattern, line)
             if match:

--- a/modifiers/mpibind/parse_mpibind_output.py
+++ b/modifiers/mpibind/parse_mpibind_output.py
@@ -22,15 +22,17 @@ def parse_mpibind(input_file):
         mpibind_match = re.match(r"^mpibind:.*(?:\r?\n|$)", line)
         if mpibind_match:
 
-            pattern = r"task\s+(\d+)\s+nths\s+([\d,]*)\s+gpus\s+([\d,]*)\s+cpus\s+([\d,]*)"
+            pattern = (
+                    r"task\s+(\d+)\s+nths\s+([\d,]*)\s+gpus\s+([\d,]*)\s+cpus\s+([\d,]*)"
+            )
             match = re.search(pattern, line)
             if match:
                 task = match.group(1)  # Task number
                 nths = match.group(2)  # Nths value
                 gpus = match.group(3)  # GPUs value
                 cpus = match.group(4)  # CPUs value
-	
-                task_map["task "+task] = {
+
+                task_map["task " + task] = {
                     "cpus": cpus,
                     "gpus": gpus,
                     "nths": nths,


### PR DESCRIPTION
## Description

Adding a basic modifier for mpibind. Modes include: on, off, v, vv, greedy:0. Extra modes are available through mpibind, and can be added if necessary. 
So far, mpibind modifier only imported into saxpy and kripke experiment classes.

To build saxpy experiment with mpibind=off:
`benchpark experiment init --dest=saxpy saxpy +openmp mpibind=off` 

Extra (potential) tasks:

- [x] send mpibind output to its own  json file
- [ ] add extra usage modes? (gpu? smt?) (round-robin, one at a time)
- [ ] add some more manual support for setting mpibind configs?