### PR TITLE
Standardize blas lapack handles

### DIFF
--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -140,8 +140,8 @@ class Amg2023(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["lapack"] = "lapack"
-        system_specs["blas"] = "blas"
+        system_specs["lapack"] = "default-lapack"
+        system_specs["blas"] = "default-blas"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -53,7 +53,7 @@ class Genesis(Experiment, OpenMPExperiment):
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["lapack"] = "lapack"
+        system_specs["lapack"] = "default-lapack"
 
         # if package_spec left empty spack will use external
         self.add_spack_spec(system_specs["mpi"])
@@ -61,7 +61,4 @@ class Genesis(Experiment, OpenMPExperiment):
 
         self.add_spack_spec(
             self.name, [f"genesis@{app_version} +mpi", system_specs["compiler"]]
-        )
-        self.add_spack_spec(
-            system_specs["lapack"], [system_specs["lapack"], system_specs["compiler"]]
         )

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -93,8 +93,8 @@ class Gromacs(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["blas"] = "blas"
-        system_specs["lapack"] = "lapack"
+        system_specs["blas"] = "default-blas"
+        system_specs["lapack"] = "default-lapack"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -105,7 +105,7 @@ class Hpl(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["blas"] = "blas"
+        system_specs["blas"] = "default-blas"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -66,8 +66,8 @@ class Laghos(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["lapack"] = "lapack"
-        system_specs["blas"] = "blas"
+        system_specs["lapack"] = "default-lapack"
+        system_specs["blas"] = "default-blas"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -98,7 +98,7 @@ class Lammps(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["blas"] = "blas"
+        system_specs["blas"] = "default-blas"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -92,8 +92,8 @@ class Remhos(
         system_specs = {}
         system_specs["compiler"] = "default-compiler"
         system_specs["mpi"] = "default-mpi"
-        system_specs["blas"] = "blas"
-        system_specs["lapack"] = "lapack"
+        system_specs["blas"] = "default-blas"
+        system_specs["lapack"] = "default-lapack"
 
         # set package spack specs
         # empty package_specs value implies external package

--- a/legacy/systems/LLNL-Ruby-icelake-OmniPath/software.yaml
+++ b/legacy/systems/LLNL-Ruby-icelake-OmniPath/software.yaml
@@ -17,6 +17,10 @@ software:
       pkg_spec: intel-oneapi-mkl@2022.1.0
     lapack:
       pkg_spec: intel-oneapi-mkl@2022.1.0
+    default-blas:
+      pkg_spec: intel-oneapi-mkl@2022.1.0
+    default-lapack:
+      pkg_spec: intel-oneapi-mkl@2022.1.0
     mpi-gcc:
       pkg_spec: mvapich2@2.3.7-gcc1211
     mpi-intel:

--- a/legacy/systems/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/software.yaml
+++ b/legacy/systems/LLNL-Tioga-HPECray-zen3-MI250X-Slingshot/software.yaml
@@ -23,6 +23,10 @@ software:
       pkg_spec: rocsolver@5.5.1
     lapack:
       pkg_spec: cray-libsci@23
+    default-blas:
+      pkg_spec: rocblas@5.5.1
+    default-lapack:
+      pkg_spec: cray-libsci@23
     mpi-rocm-gtl:
       pkg_spec: cray-mpich@8.1.26%cce@16.0.0 +gtl
     mpi-rocm-no-gtl:

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -91,4 +91,8 @@ software:
       pkg_spec: lapack@3.4.2
     mpi-gcc:
       pkg_spec: openmpi@4.1.5%gcc@7.3.1
+    default-blas:
+      pkg_spec: blas@3.4.2
+    default-lapack:
+      pkg_spec: lapack@3.4.2
 """

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -44,4 +44,8 @@ software:
       pkg_spec: openblas
     lapack:
       pkg_spec: openblas
+    default-blas:
+      pkg_spec: openblas
+    default-lapack:
+      pkg_spec: openblas
 """

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -96,6 +96,10 @@ software:
       pkg_spec: intel-oneapi-mkl
     lapack:
       pkg_spec: intel-oneapi-mkl
+    default-blas:
+      pkg_spec: intel-oneapi-mkl
+    default-lapack:
+      pkg_spec: intel-oneapi-mkl
     mpi-gcc:
       pkg_spec: mvapich2
     mpi-intel:

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -455,4 +455,8 @@ software:
       pkg_spec: intel-oneapi-mkl
     lapack-rocm:
       pkg_spec: rocsolver
+    default-blas:
+      pkg_spec: "{self.spec.variants["blas"][0]}"
+    default-lapack:
+      pkg_spec: "{self.spec.variants["lapack"][0]}"
 """

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -333,4 +333,8 @@ software:
       pkg_spec: "{self.spec.variants["lapack"][0]}"
     lapack-cuda:
       pkg_spec: cusolver
+    default-blas:
+      pkg_spec: "{self.spec.variants["blas"][0]}"
+    default-lapack:
+      pkg_spec: "{self.spec.variants["lapack"][0]}"
 """

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -85,4 +85,8 @@ software:
       pkg_spec: fujitsu-ssl2
     lapack:
       pkg_spec: fujitsu-ssl2
+    default-blas:
+      pkg_spec: fujitsu-ssl2
+    default-lapack:
+      pkg_spec: fujitsu-ssl2
 """


### PR DESCRIPTION
This PR standardizes the names of the blas and lapack handles for all application `experiment.py` files tp 'default-blas` and 'default-lapack`. It also adds these handles to each `system.py` if needed.

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Add/modify `systems/system_name/system.py` file

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define a single node and multi-node experiments