### PR TITLE
[ARCHIVED] New caliper modifier implementation

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -35,7 +35,7 @@ class RajaPerf(
 
     def compute_applications_section(self):
         if not self.spec.satisfies("caliper=none"):
-          Caliper.Helper.unset_environment_variable(self, "CALI_CONFIG")
+            Caliper.Helper.unset_environment_variable(self, "CALI_CONFIG")
 
         n_resources = {"n_ranks": 1}
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -29,10 +29,13 @@ class RajaPerf(
     variant(
         "version",
         default="develop",
+        values=("develop", "fixcaliconfig"),
         description="app version",
     )
 
     def compute_applications_section(self):
+        if not self.spec.satisfies("caliper=none"):
+          Caliper.Helper.unset_environment_variable(self, "CALI_CONFIG")
 
         n_resources = {"n_ranks": 1}
 

--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -27,18 +27,28 @@ class Caliper:
     )
 
     class Helper(ExperimentHelper):
+        caliper_modes = {
+          "time": "time.exclusive", # Platform-independent collection of time (default mode)
+          "mpi": "profile.mpi", # Profile MPI functions
+          "cuda": "profile.cuda", # Profile CUDA API functions
+          "topdown-counters-all": "topdown-counters.all", # Raw counter values for Intel top-down analysis (all levels)
+          "topdown-counters-toplevel": "topdown-counters.toplevel", # Raw counter values for Intel top-down analysis (top level)
+          "topdown-all": "topdown.all", # Top-down analysis for Intel CPUs (all levels)
+          "topdown-toplevel": "topdown.toplevel", # Top-down analysis for Intel CPUs (top level)
+        }
+
         def compute_modifiers_section(self):
             modifier_list = []
             if not self.spec.satisfies("caliper=none"):
-                for var in list(self.spec.variants["caliper"]):
-                    if var != "time":
-                        caliper_modifier_modes = {}
-                        caliper_modifier_modes["name"] = "caliper"
-                        caliper_modifier_modes["mode"] = var
-                        modifier_list.append(caliper_modifier_modes)
-                # Add time as the last mode
-                modifier_list.append({"name": "caliper", "mode": "time"})
+                modifier_list.append({"name": "caliper"})
             return modifier_list
+
+        def compute_config_variables(self):
+            if not self.spec.satisfies("caliper=none"):
+                modes = [Caliper.Helper.caliper_modes[m] for m in list(self.spec.variants["caliper"])]
+                self.add_experiment_variable("_cali_datafile", "{experiment_run_dir}/{experiment_name}.cali")
+                self.set_environment_variable("CALI_CONFIG_MODES", ' '.join(modes))
+                self.set_environment_variable("CALI_CONFIG", f"spot(output={{_cali_datafile}},{','.join(modes)})")
 
         def compute_spack_section(self):
             # set package versions

--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -28,13 +28,13 @@ class Caliper:
 
     class Helper(ExperimentHelper):
         caliper_modes = {
-          "time": "time.exclusive", # Platform-independent collection of time (default mode)
-          "mpi": "profile.mpi", # Profile MPI functions
-          "cuda": "profile.cuda", # Profile CUDA API functions
-          "topdown-counters-all": "topdown-counters.all", # Raw counter values for Intel top-down analysis (all levels)
-          "topdown-counters-toplevel": "topdown-counters.toplevel", # Raw counter values for Intel top-down analysis (top level)
-          "topdown-all": "topdown.all", # Top-down analysis for Intel CPUs (all levels)
-          "topdown-toplevel": "topdown.toplevel", # Top-down analysis for Intel CPUs (top level)
+            "time": "time.exclusive",  # Platform-independent collection of time (default mode)
+            "mpi": "profile.mpi",  # Profile MPI functions
+            "cuda": "profile.cuda",  # Profile CUDA API functions
+            "topdown-counters-all": "topdown-counters.all",  # Raw counter values for Intel top-down analysis (all levels)
+            "topdown-counters-toplevel": "topdown-counters.toplevel",  # Raw counter values for Intel top-down analysis (top level)
+            "topdown-all": "topdown.all",  # Top-down analysis for Intel CPUs (all levels)
+            "topdown-toplevel": "topdown.toplevel",  # Top-down analysis for Intel CPUs (top level)
         }
 
         def compute_modifiers_section(self):
@@ -45,10 +45,17 @@ class Caliper:
 
         def compute_config_variables(self):
             if not self.spec.satisfies("caliper=none"):
-                modes = [Caliper.Helper.caliper_modes[m] for m in list(self.spec.variants["caliper"])]
-                self.add_experiment_variable("_cali_datafile", "{experiment_run_dir}/{experiment_name}.cali")
-                self.set_environment_variable("CALI_CONFIG_MODES", ' '.join(modes))
-                self.set_environment_variable("CALI_CONFIG", f"spot(output={{_cali_datafile}},{','.join(modes)})")
+                modes = [
+                    Caliper.Helper.caliper_modes[m]
+                    for m in list(self.spec.variants["caliper"])
+                ]
+                self.add_experiment_variable(
+                    "_cali_datafile", "{experiment_run_dir}/{experiment_name}.cali"
+                )
+                self.set_environment_variable("CALI_CONFIG_MODES", " ".join(modes))
+                self.set_environment_variable(
+                    "CALI_CONFIG", f"spot(output={{_cali_datafile}},{','.join(modes)})"
+                )
 
         def compute_spack_section(self):
             # set package versions

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -27,10 +27,10 @@ class ExperimentHelper:
         self.spec = exp.spec
         self.variables = {}
         self.env_vars = {
-            "set": {}, 
-            "append": {}, 
-            "prepend": {}, 
-            "unset": [], 
+            "set": {},
+            "append": {},
+            "prepend": {},
+            "unset": [],
         }
 
     def compute_include_section(self):
@@ -192,10 +192,10 @@ class Experiment(ExperimentSystemBase, SingleNode):
     def compute_applications_section_wrapper(self):
         self.expr_name = []
         self.env_vars = {
-            "set": {}, 
-            "append": {}, 
-            "prepend": {}, 
-            "unset": [], 
+            "set": {},
+            "append": {},
+            "prepend": {},
+            "unset": [],
         }
         self.variables = {}
         self.zips = {}

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -25,6 +25,13 @@ import ramble.language.language_helpers  # noqa
 class ExperimentHelper:
     def __init__(self, exp):
         self.spec = exp.spec
+        self.variables = {}
+        self.env_vars = {
+            "set": {}, 
+            "append": {}, 
+            "prepend": {}, 
+            "unset": [], 
+        }
 
     def compute_include_section(self):
         return []
@@ -34,6 +41,22 @@ class ExperimentHelper:
 
     def compute_modifiers_section(self):
         return []
+
+    def add_experiment_variable(self, name, value):
+        self.variables[name] = value
+
+    def set_environment_variable(self, name, value):
+        self.env_vars["set"][name] = value
+
+    def unset_environment_variable(self, name):
+        self.env_vars["unset"].append(name)
+
+    def compute_config_variables(self):
+        pass
+
+    def compute_config_variables_wrapper(self):
+        self.compute_config_variables()
+        return self.variables, self.env_vars
 
     def compute_applications_section(self):
         return {}
@@ -145,7 +168,7 @@ class Experiment(ExperimentSystemBase, SingleNode):
             self.expr_name.append(f"{{{name}}}")
 
     def set_environment_variable(self, name, values):
-        self.set_env_vars[name] = values
+        self.env_vars["set"][name] = values
 
     def zip_experiment_variables(self, name, variable_names):
         self.zips[name] = list(variable_names)
@@ -168,11 +191,24 @@ class Experiment(ExperimentSystemBase, SingleNode):
 
     def compute_applications_section_wrapper(self):
         self.expr_name = []
-        self.set_env_vars = {}
+        self.env_vars = {
+            "set": {}, 
+            "append": {}, 
+            "prepend": {}, 
+            "unset": [], 
+        }
         self.variables = {}
         self.zips = {}
         self.matrix = []
         self.excludes = []
+
+        for cls in self.helpers:
+            variables, env_vars = cls.compute_config_variables_wrapper()
+            self.variables |= variables
+            self.env_vars["set"] |= env_vars["set"]
+            self.env_vars["append"] |= env_vars["append"]
+            self.env_vars["prepend"] |= env_vars["prepend"]
+            self.env_vars["unset"] += env_vars["unset"]
 
         self.compute_applications_section()
 
@@ -185,6 +221,7 @@ class Experiment(ExperimentSystemBase, SingleNode):
 
         expr_setup = {
             "variants": {"package_manager": "spack"},
+            "env_vars": self.env_vars,
             "variables": self.variables,
             "zips": self.zips,
             "matrix": self.matrix,

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -6,21 +6,6 @@
 from ramble.modkit import *
 
 
-def add_mode(mode_name, mode_option, description):
-    mode(
-        name=mode_name,
-        description=description,
-    )
-
-    env_var_modification(
-        "CALI_CONFIG_MODE",
-        mode_option,
-        method="append",
-        separator=",",
-        modes=[mode_name],
-    )
-
-
 class Caliper(BasicModifier):
     """Define a modifier for Caliper"""
 
@@ -30,60 +15,10 @@ class Caliper(BasicModifier):
 
     maintainers("pearce8")
 
-    _cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
-
-    _default_mode = "time"
-
-    add_mode(
-        mode_name=_default_mode,
-        mode_option="time.exclusive",
-        description="Platform-independent collection of time (default mode)",
+    mode(
+        name="default",
+        description="Enable caliper tracking",
     )
-
-    env_var_modification(
-        "CALI_CONFIG",
-        "spot(output={}{})".format(_cali_datafile, "${CALI_CONFIG_MODE}"),
-        method="set",
-        modes=[_default_mode],
-    )
-
-    add_mode(
-        mode_name="mpi",
-        mode_option="profile.mpi",
-        description="Profile MPI functions",
-    )
-
-    add_mode(
-        mode_name="cuda",
-        mode_option="profile.cuda",
-        description="Profile CUDA API functions",
-    )
-
-    add_mode(
-        mode_name="topdown-counters-all",
-        mode_option="topdown-counters.all",
-        description="Raw counter values for Intel top-down analysis (all levels)",
-    )
-
-    add_mode(
-        mode_name="topdown-counters-toplevel",
-        mode_option="topdown-counters.toplevel",
-        description="Raw counter values for Intel top-down analysis (top level)",
-    )
-
-    add_mode(
-        mode_name="topdown-all",
-        mode_option="topdown.all",
-        description="Top-down analysis for Intel CPUs (all levels)",
-    )
-
-    add_mode(
-        mode_name="topdown-toplevel",
-        mode_option="topdown.toplevel",
-        description="Top-down analysis for Intel CPUs (top level)",
-    )
-
-    archive_pattern(_cali_datafile)
 
     software_spec("caliper", pkg_spec="caliper")
 

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -21,7 +21,7 @@ class RajaPerf(ExecutableApplication):
     executable(
         "run",
         "raja-perf.exe"
-        + " --add-to-spot-config '$CALI_CONFIG_MODES'"
+        + " --add-to-spot-config $CALI_CONFIG_MODES"
         + " --outdir {experiment_run_dir}",
         use_mpi=True,
     )

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -18,7 +18,13 @@ class RajaPerf(ExecutableApplication):
             'mpi','network-point-to-point','network-latency-bound',
             'c++','raja','cuda','hip','openmp','sycl']
 
-    executable('run', 'raja-perf.exe', use_mpi=True)
+    executable(
+        "run",
+        "raja-perf.exe"
+        + " --add-to-spot-config '$CALI_CONFIG_MODES'"
+        + " --outdir {experiment_run_dir}",
+        use_mpi=True,
+    )
 
     workload('suite', executables=['run'])
 

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -140,6 +140,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     version("0.5.1", tag="v0.5.1", submodules="True")
     version("0.5.0", tag="v0.5.0", submodules="True")
     version("0.4.0", tag="v0.4.0", submodules="True")
+    version("fixcaliconfig", branch="fix/cali_config", submodules="True")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Build OpenMP backend")


### PR DESCRIPTION
Work in progress. This PR changes the caliper modifier implementation (Solves #603)
In the existing caliper modifier, we define caliper modes to collect specific metrics (e.g. cuda, mpi, time etc)
The current benchpark implementation sets these modes at experiment init time. Each of these modes creates an environment variable in the experiment bash script to collect the desired metrics. However, this approach does not facilitate benchmark-specific changes as the caliper modifier is processed during the Ramble setup phase.

In the new impementation, we use the caliper modes specified on experiment init to directly set the required variables in the experiment ramble.yaml. The generated ramble.yaml is functionally equivalent to the one generated by the existing caliper modifier. However, this approach allows for changes to the caliper config at benchmark init time.

- [x] Replace with: A short description of the change, including motivation and context.

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Tags in Ramble's `application.py` or in `repo/benchmark_name/application.py` will appear in the [docs catalogue](https://software.llnl.gov/benchpark/benchmark-list.html)
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define a single node and multi-node experiments