### PR TITLE
Fix gtl flags in kripke package.py

### DIFF
--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -107,6 +107,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
                 "-DRAJA_DIR=%s" % self.spec["raja"].prefix,
                 "-Dchai_DIR=%s" % self.spec["chai"].prefix,
                 "-DENABLE_CHAI=ON",
+                "-DMPI_CXX_LINK_FLAGS='%s'" % self.spec['mpi'].libs.ld_flags,
             ]
         )
 


### PR DESCRIPTION
This PR adds the ld flags to kripke package.py to enable gtl

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))
- [x] (optional) If package upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py`