### PR TITLE
Fail CI if Pytest Fails

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -902,4 +902,4 @@ jobs:
 
       - name: Run
         run: |
-          ./bin/benchpark unit-test
+          python -m pytest


### PR DESCRIPTION
## Description

- [x] On develop, there is a bug where if the `benchpark unit-test` wrapper fails, the CI still passes. This change uses pytest directly to ensure the right exit code is returned to github, and it appropriately fails
