### PR TITLE
Fix for Benchpark tags and Tags Table in Benchpark Docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,6 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
-WORKSPACE_PATH ?=
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -17,7 +16,7 @@ systemconfigs:
 	./generate-sys-defs-list.py
 
 tags:
-	./generate-benchmark-list.py $(WORKSPACE_PATH)
+	./generate-benchmark-list.py
 
 .PHONY: help systemconfigs tags Makefile
 

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -2,8 +2,6 @@
 
 import pandas as pd
 import yaml
-import os
-import shutil
 import sys
 import subprocess
 
@@ -71,10 +69,6 @@ def main():
                     print("appending", t, "at key", k)
                     tags_taggroups[bmark][k].append(t)
         main[bmark] = tags_taggroups[bmark]
-
-    check_dir = "tmp"
-    if os.path.isdir(check_dir):
-        shutil.rmtree(check_dir)
 
     df = pd.DataFrame(main)
     df.to_csv("benchmark-list.csv")

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -3,8 +3,13 @@
 import pandas as pd
 import yaml
 import os
+import shutil
 import sys
 import subprocess
+
+sys.path.append("../lib/")
+import benchpark.accounting  # noqa: E402
+import benchpark.paths  # noqa: E402
 
 
 def construct_tag_groups(tag_groups, tag_dicts, dictionary):
@@ -17,16 +22,8 @@ def construct_tag_groups(tag_groups, tag_dicts, dictionary):
             print("ERROR in construct_tag_groups")
 
 
-def benchpark_benchmarks(benchmarks):
-    experiments_dir = "../legacy/experiments"
-    for x in os.listdir(experiments_dir):
-        benchmarks.append(f"{x}")
-    return benchmarks
-
-
-def main(workspace):
-    benchmarks = list()
-    benchpark_benchmarks(benchmarks)
+def main():
+    benchmarks = benchpark.accounting.benchpark_benchmarks()
 
     f = "../taxonomy.yaml"
     with open(f, "r") as stream:
@@ -53,7 +50,7 @@ def main(workspace):
 
     for bmark in benchmarks:
         # call benchpark tags -a bmark workspace
-        cmd = ["../bin/benchpark", "tags", "-a", bmark, workspace]
+        cmd = ["../bin/benchpark", "tags", "-a", bmark]
         try:
             byte_data = subprocess.run(cmd, capture_output=True, check=True)
         except subprocess.CalledProcessError as e:
@@ -75,6 +72,10 @@ def main(workspace):
                     tags_taggroups[bmark][k].append(t)
         main[bmark] = tags_taggroups[bmark]
 
+    check_dir = "tmp"
+    if os.path.isdir(check_dir):
+        shutil.rmtree(check_dir)
+
     df = pd.DataFrame(main)
     df.to_csv("benchmark-list.csv")
 
@@ -85,10 +86,4 @@ def main(workspace):
 
 
 if __name__ == "__main__":
-    try:
-        workspace = sys.argv[1]
-    except IndexError:
-        print("Usage: " + os.path.basename(__file__) + " <workspace>")
-        sys.exit(1)
-
-    main(workspace)
+    main()

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -5,13 +5,10 @@
 
 import subprocess
 
+
 def test_list():
     subprocess.run(["benchpark", "list"], check=True)
 
+
 def test_tags():
-    subprocess.run([
-        "benchpark",
-        "tags",
-        "-a",
-        "ad"
-    ], check=True)
+    subprocess.run(["benchpark", "tags", "-a", "ad"], check=True)

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -5,10 +5,17 @@
 
 import subprocess
 
+import benchpark.paths
+
 
 def test_list():
-    subprocess.run(["benchpark", "list"], check=True)
+    subprocess.run(
+        [benchpark.paths.benchpark_root / "bin/benchpark", "list"], check=True
+    )
 
 
 def test_tags():
-    subprocess.run(["benchpark", "tags", "-a", "ad"], check=True)
+    subprocess.run(
+        [benchpark.paths.benchpark_root / "bin/benchpark", "tags", "-a", "ad"],
+        check=True,
+    )

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+
+def test_list():
+    subprocess.run(["benchpark", "list"], check=True)
+
+def test_tags():
+    subprocess.run([
+        "benchpark",
+        "tags",
+        "-a",
+        "ad"
+    ], check=True)

--- a/lib/main.py
+++ b/lib/main.py
@@ -308,18 +308,15 @@ def benchpark_tags_handler(args):
     # Check if the "ramble" command exists
     ramble_path = shutil.which("ramble")
     if ramble_path is None:
-        print('"ramble" command not found. Generating Ramble...')
-        targs = argparse.Namespace(
-            experiment="experiments/ad/",
-            system="systems/llnl-cluster/",
-            experiments_root="tmp/tags",
-        )
-        benchpark.cmd.setup.command(targs)
+        ramble, setup = benchpark.runtime.RuntimeResources(
+            "tmp"
+        ).ramble_first_time_setup()
+        source_dir = benchpark.paths.benchpark_root
+        ramble(f"repo add --scope=site {source_dir}/repo")
     else:
         print(f'"ramble" command found at: {ramble_path}.')
 
-    ramble_location = "tmp/tags/ramble"
-    ramble_exe = ramble_location + "/bin/ramble"
+    ramble_exe = "tmp/ramble/bin/ramble"
     benchmarks = benchpark_benchmarks()
 
     if args.tag:

--- a/lib/main.py
+++ b/lib/main.py
@@ -7,9 +7,8 @@
 
 import argparse
 import inspect
-import os
-import pathlib
 import shlex
+import shutil
 import subprocess
 import sys
 import yaml
@@ -270,11 +269,6 @@ def run_command(command_str, env=None):
 def benchpark_tags(subparsers, actions_dict):
     create_parser = subparsers.add_parser("tags", help="Tags in Benchpark experiments")
     create_parser.add_argument(
-        "experiments_root",
-        type=str,
-        help="The experiments_root you specified during Benchpark setup.",
-    )
-    create_parser.add_argument(
         "-a",
         "--application",
         action="store",
@@ -311,9 +305,21 @@ def benchpark_tags_handler(args):
     """
     Filter ramble tags by benchpark benchmarks
     """
-    experiments_root = pathlib.Path(os.path.abspath(args.experiments_root))
-    ramble_location = experiments_root / "ramble"
-    ramble_exe = ramble_location / "bin" / "ramble"
+    # Check if the "ramble" command exists
+    ramble_path = shutil.which("ramble")
+    if ramble_path is None:
+        print('"ramble" command not found. Generating Ramble...')
+        targs = argparse.Namespace(
+            experiment="experiments/ad/",
+            system="systems/llnl-cluster/",
+            experiments_root="tmp/tags",
+        )
+        benchpark.cmd.setup.command(targs)
+    else:
+        print(f'"ramble" command found at: {ramble_path}.')
+
+    ramble_location = "tmp/tags/ramble"
+    ramble_exe = ramble_location + "/bin/ramble"
     benchmarks = benchpark_benchmarks()
 
     if args.tag:

--- a/lib/main.py
+++ b/lib/main.py
@@ -8,7 +8,6 @@
 import argparse
 import inspect
 import shlex
-import shutil
 import subprocess
 import sys
 import yaml
@@ -305,18 +304,9 @@ def benchpark_tags_handler(args):
     """
     Filter ramble tags by benchpark benchmarks
     """
-    # Check if the "ramble" command exists
-    ramble_path = shutil.which("ramble")
-    if ramble_path is None:
-        ramble, setup = benchpark.runtime.RuntimeResources(
-            "tmp"
-        ).ramble_first_time_setup()
-        source_dir = benchpark.paths.benchpark_root
-        ramble(f"repo add --scope=site {source_dir}/repo")
-    else:
-        print(f'"ramble" command found at: {ramble_path}.')
-
-    ramble_exe = "tmp/ramble/bin/ramble"
+    source_dir = benchpark.paths.benchpark_root
+    ramble_exe = benchpark.paths.benchpark_home / "ramble/bin/ramble"
+    subprocess.run([ramble_exe, "repo", "add", "--scope=site", f"{source_dir}/repo"])
     benchmarks = benchpark_benchmarks()
 
     if args.tag:


### PR DESCRIPTION
## Description

- [x] This PR fixes an issue with `benchpark tags` that was introduced from the legacy rework.
- [x] Replace with: A list of any dependencies.
- [x] Resolves #663 
- [x] Complete the checklist for a relevant section(s) below
- [x] Delete sections below that are not relevant to this PR
- [x] Add unit test for commands

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `docs/Makefile` and `docs/generate-benchmark-list.py` to fix the table on the `Benchmarks and Experiments` page.
- [x] Update `lib/main.py` so `benchpark tags` uses information from `benchpark/repo`
