### PR TITLE
Use Current Directory to Search for Experiment and System

### DIFF
--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -125,8 +125,8 @@ def command(args):
 
     template_name = "execute_experiment.tpl"
     experiment_template_options = [
-        configs_src_dir + "/" + template_name,
-        experiment_src_dir + "/" + template_name,
+        configs_src_dir / template_name,
+        experiment_src_dir / template_name,
         source_dir / "common-resources" / template_name,
     ]
     for choice_template in experiment_template_options:

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -77,8 +77,8 @@ def command(args):
     debug_print(f"specified experiment = {experiment_id}")
     debug_print(f"specified system = {system_id}")
 
-    experiment_src_dir = str(experiment_id)
-    configs_src_dir = str(system_id)
+    experiment_src_dir = pathlib.Path(os.path.abspath(str(experiment_id)))
+    configs_src_dir = pathlib.Path(os.path.abspath(str(system_id)))
     workspace_dir = experiments_root / str(experiment_id) / str(system_id)
 
     if workspace_dir.exists():

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -77,8 +77,8 @@ def command(args):
     debug_print(f"specified experiment = {experiment_id}")
     debug_print(f"specified system = {system_id}")
 
-    experiment_src_dir = benchpark.paths.benchpark_root / str(experiment_id)
-    configs_src_dir = benchpark.paths.benchpark_root / str(system_id)
+    experiment_src_dir = str(experiment_id)
+    configs_src_dir = str(system_id)
     workspace_dir = experiments_root / str(experiment_id) / str(system_id)
 
     if workspace_dir.exists():
@@ -125,8 +125,8 @@ def command(args):
 
     template_name = "execute_experiment.tpl"
     experiment_template_options = [
-        configs_src_dir / template_name,
-        experiment_src_dir / template_name,
+        configs_src_dir+"/"+template_name,
+        experiment_src_dir+"/"+template_name,
         source_dir / "common-resources" / template_name,
     ]
     for choice_template in experiment_template_options:

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -125,8 +125,8 @@ def command(args):
 
     template_name = "execute_experiment.tpl"
     experiment_template_options = [
-        configs_src_dir+"/"+template_name,
-        experiment_src_dir+"/"+template_name,
+        configs_src_dir + "/" + template_name,
+        experiment_src_dir + "/" + template_name,
         source_dir / "common-resources" / template_name,
     ]
     for choice_template in experiment_template_options:


### PR DESCRIPTION
## Description

- [x] On develop, there is a limitation that the full path from the benchpark root directory must be specified in the setup command. This change allows for either the full path to be specified, or just the path from the current directory.

If I am working out of `benchpark/test`
```
test/
├── amg2023
├── ruby
└── wkp
```
I can do either
`benchpark setup amg2023 ruby wkp`
or from the `benchpark` directory
`benchpark setup test/amg2023 test/ruby wkp`

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `lib/benchpark/cmd/setup.py`
