### PR TITLE
[WIP] Re-use Bootstrapped Spack and Ramble

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         bin/benchpark system init --dest=generic-x86 generic-x86
         bin/benchpark setup saxpy generic-x86 /tmp/workspace
         # this is gross and we should better setup ramble for people or make it a Spack package
-        pip install -r /tmp/workspace/ramble/requirements.txt
+        pip install -r ~/.benchpark/ramble/requirements.txt
 
     - name: Build with sphinx
       run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -102,12 +102,12 @@ jobs:
           ./bin/benchpark experiment init --dest=saxpy/binary saxpy+openmp package_manager="environment-modules" append_path="$SAXPY_PATH"
           ./bin/benchpark setup saxpy/openmp generic-x86 workspace-binary/
 
-          ./workspace-binary/ramble/bin/ramble \
+          ramble \
             --disable-progress-bar \
             --workspace-dir \
             /home/runner/work/benchpark/benchpark/workspace-binary/saxpy/openmp/generic-x86/workspace \
             workspace setup
-          ./workspace-binary/ramble/bin/ramble \
+          ramble \
             --disable-progress-bar \
             --workspace-dir \
             /home/runner/work/benchpark/benchpark/workspace-binary/saxpy/openmp/generic-x86/workspace \

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -14,7 +14,9 @@ import benchpark.repo
 import benchpark.system as system
 from benchpark.runtime import RuntimeResources
 
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper = RuntimeResources(
+    benchpark.paths.benchpark_home, benchpark.paths.benchpark_root
+)  # noqa
 bootstrapper.bootstrap()  # noqa
 
 import ramble.config as cfg  # noqa

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -142,8 +142,7 @@ def command(args):
     initializer_script = experiments_root / "setup.sh"
 
     per_workspace_setup = RuntimeResources(
-        pathlib.Path(os.path.abspath(benchpark.paths.benchpark_home)),
-        source_dir
+        pathlib.Path(os.path.abspath(benchpark.paths.benchpark_home)), source_dir
     )
 
     # Parse experiment YAML for package_manager

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -161,9 +161,7 @@ def command(args):
 
     pkg_str = ""
     if pkg_manager == "spack":
-        spack, first_time_spack = per_workspace_setup.spack_first_time_setup()
-        if first_time_spack:
-            spack("repo", "add", "--scope=site", f"{source_dir}/repo")
+        per_workspace_setup.spack_first_time_setup()
 
         pkg_str = f"""\
 . {per_workspace_setup.spack_location}/share/spack/setup-env.sh
@@ -171,7 +169,7 @@ def command(args):
 export SPACK_DISABLE_LOCAL_CONFIG=1
 """
 
-    ramble, first_time_ramble = per_workspace_setup.ramble_first_time_setup()
+    per_workspace_setup.ramble_first_time_setup()
 
     if not initializer_script.exists():
         with open(initializer_script, "w") as f:

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -142,7 +142,8 @@ def command(args):
     initializer_script = experiments_root / "setup.sh"
 
     per_workspace_setup = RuntimeResources(
-        pathlib.Path(os.path.abspath(benchpark.paths.benchpark_home))
+        pathlib.Path(os.path.abspath(benchpark.paths.benchpark_home)),
+        source_dir
     )
 
     # Parse experiment YAML for package_manager
@@ -172,11 +173,6 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
 """
 
     ramble, first_time_ramble = per_workspace_setup.ramble_first_time_setup()
-    if first_time_ramble:
-        ramble(f"repo add --scope=site {source_dir}/repo")
-        ramble('config --scope=site add "config:disable_progress_bar:true"')
-        ramble(f"repo add -t modifiers --scope=site {source_dir}/modifiers")
-        ramble("config --scope=site add \"config:spack:global:args:'-d'\"")
 
     if not initializer_script.exists():
         with open(initializer_script, "w") as f:

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -141,7 +141,9 @@ def command(args):
 
     initializer_script = experiments_root / "setup.sh"
 
-    per_workspace_setup = RuntimeResources(experiments_root)
+    per_workspace_setup = RuntimeResources(
+        pathlib.Path(os.path.abspath(benchpark.paths.benchpark_home))
+    )
 
     # Parse experiment YAML for package_manager
     def find(d, tag):

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -15,7 +15,9 @@ import benchpark.repo
 import benchpark.runtime
 import benchpark.variant
 
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = benchpark.runtime.RuntimeResources(
+    benchpark.paths.benchpark_home, benchpark.paths.benchpark_root
+)
 bootstrapper.bootstrap()
 
 import ramble.language.language_base  # noqa

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -15,7 +15,7 @@ import benchpark.runtime
 # isort: off
 
 bootstrapper = benchpark.runtime.RuntimeResources(
-    benchpark.paths.benchpark_home
+    benchpark.paths.benchpark_home, benchpark.paths.benchpark_root
 )  # noqa
 bootstrapper.bootstrap()  # noqa
 

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -84,7 +84,7 @@ class RuntimeResources:
 
     def bootstrap(self):
         if not self.ramble_location.exists():
-            self._install_ramble()
+            self._ramble()
         else:
             with working_dir(self.ramble_location):
                 run_command("git fetch --all")
@@ -101,7 +101,7 @@ class RuntimeResources:
         # The reason for this oddity is that spack modules will compete with the internal
         # spack modules from ramble
         if not self.spack_location.exists():
-            self._install_spack()
+            self._spack()
 
     def _install_ramble(self):
         print(f"Cloning Ramble to {self.ramble_location}")

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -68,9 +68,10 @@ class Command:
 
 
 class RuntimeResources:
-    def __init__(self, dest):
+    def __init__(self, dest, source_dir):
         self.root = benchpark.paths.benchpark_root
         self.dest = pathlib.Path(dest)
+        self.source_dir = source_dir
 
         checkout_versions_location = self.root / "checkout-versions.yaml"
         with open(checkout_versions_location, "r") as yaml_file:
@@ -119,19 +120,20 @@ class RuntimeResources:
         debug_print(f"Done cloning Spack ({self.spack_location})")
 
     def _ramble(self):
-        first_time = False
+        ramble = Command(self.ramble_location / "bin" / "ramble", env={})
         if not self.ramble_location.exists():
-            first_time = True
             self._install_ramble()
-        return Command(self.ramble_location / "bin" / "ramble", env={}), first_time
+            ramble(f"repo add --scope=site {self.source_dir}/repo")
+            ramble('config --scope=site add "config:disable_progress_bar:true"')
+            ramble(f"repo add -t modifiers --scope=site {self.source_dir}/modifiers")
+            ramble("config --scope=site add \"config:spack:global:args:'-d'\"")
+        return ramble
 
     def _spack(self):
         env = {"SPACK_DISABLE_LOCAL_CONFIG": "1"}
         spack = Command(self.spack_location / "bin" / "spack", env)
         spack_cache_location = self.spack_location / "misc-cache"
-        first_time = False
         if not self.spack_location.exists():
-            first_time = True
             self._install_spack()
             spack(
                 "config",
@@ -139,11 +141,12 @@ class RuntimeResources:
                 "add",
                 f"config:misc_cache:{spack_cache_location}",
             )
+            spack("repo", "add", "--scope=site", f"{self.source_dir}/repo")
         else:
             with working_dir(self.spack_location):
                 run_command("git fetch --all")
                 run_command(f"git checkout {self.spack_commit}")
-        return spack, first_time
+        return spack
 
     def spack_first_time_setup(self):
         return self._spack()

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -17,7 +17,9 @@ import benchpark.paths
 import benchpark.repo
 import benchpark.runtime
 
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = benchpark.runtime.RuntimeResources(
+    benchpark.paths.benchpark_home, benchpark.paths.benchpark_root
+)
 bootstrapper.bootstrap()
 
 import llnl.util.lang  # noqa

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -18,7 +18,9 @@ from typing import Dict, Tuple
 import benchpark.spec
 import benchpark.variant
 
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper = RuntimeResources(
+    benchpark.paths.benchpark_home, benchpark.paths.benchpark_root
+)  # noqa
 bootstrapper.bootstrap()  # noqa
 
 import ramble.config as cfg  # noqa


### PR DESCRIPTION
## Description

- [x] Currently in `develop`, every time we set up an experiment in a new workspace (i.e. `benchpark setup` is called with a new workspace) we clone spack and ramble into the workspace directory. Because all of our benchmarks are using the same version of spack/ramble, this should be unecessary. This change only clones spack and ramble one time, to be used across workspaces.
- [x] (Done in #669) Add check along with if the directory already exists, to check if the spack/ramble version in root is different from `checkout-versions.yaml`, so we can update that spack/ramble.
- [x] Depends on #669 
- [x] Add git fetch origin before checkout

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.github/workflows/docs.yml` to support work-around.
- [x] Update `cmd/audit.py`, `cmd/setup.py`, `experiment.py`, `repo.py`, `spec.py`, and `system.py` to add benchpark root as source path.
- [x] Update `lib/benchpark/runtime.py` to change the way bootstrapping works.