### PR TITLE
Update Bootstrapped ramble/spack and Fix gitlab CI

### DIFF
--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -3,7 +3,7 @@
     matrix:
       - HOST: tioga
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 1h
+        SCHEDULER_PARAMETERS: -N 1 -t 10m
         BENCHMARK:
           - amg2023
           - kripke
@@ -12,7 +12,7 @@
           - rocm
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
+        SCHEDULER_PARAMETERS: -N 1 -t 00:10:00
         BENCHMARK:
           - amg2023
           - kripke
@@ -21,7 +21,7 @@
           - openmp
       - HOST: ruby
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
+        SCHEDULER_PARAMETERS: -N 1 -t 00:10:00
         BENCHMARK:
           - amg2023
           - kripke

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -75,10 +75,8 @@ test_run:
     - |
         if [ "$HOST" == "tioga" ]; then
             ./bin/benchpark system init --dest=tioga-system ${ARCHCONFIG} ~gtl
-            system_id=$(./bin/benchpark system id ./tioga-system)
         else
             ./bin/benchpark system init --dest=$HOST-system ${ARCHCONFIG} cluster=$HOST
-            system_id=$(./bin/benchpark system id ./$HOST-system)
         fi
     # Initialize Experiment
     - ./bin/benchpark experiment init --dest=${BENCHMARK}-benchmark ${BENCHMARK}+${VARIANT}
@@ -87,7 +85,7 @@ test_run:
     # Setup Ramble & Spack
     - . workspace/setup.sh
     # Setup Workspace
-    - cd ./workspace/${BENCHMARK}-benchmark/${system_id}/workspace/
+    - cd ./workspace/${BENCHMARK}-benchmark/$HOST-system/workspace/
     - ramble --workspace-dir . --disable-progress-bar --disable-logger workspace setup
     # Run Experiments
     - ramble --workspace-dir . --disable-progress-bar --disable-logger
@@ -96,4 +94,4 @@ test_run:
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json yaml text
     # Check Experiment Exit Codes
     - cd -
-    - python ./.gitlab/ci/bin/exit-codes ./workspace/${BENCHMARK}-benchmark/${system_id}/workspace/results.latest.json
+    - python ./.gitlab/ci/bin/exit-codes ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/results.latest.json

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -5,6 +5,7 @@
         ARCHCONFIG: llnl-elcapitan
         SCHEDULER_PARAMETERS: -N 1 -t 1h
         BENCHMARK:
+          - amg2023
           - kripke
           - saxpy
         VARIANT:
@@ -13,6 +14,7 @@
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
         BENCHMARK:
+          - amg2023
           - kripke
           - saxpy
         VARIANT:
@@ -21,6 +23,7 @@
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
         BENCHMARK:
+          - amg2023
           - kripke
           - saxpy
         VARIANT:
@@ -73,11 +76,11 @@ test_run:
     - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     # Initialize System
     - |
+        EXTRA_ARGS=""
         if [ "$HOST" == "tioga" ]; then
-            ./bin/benchpark system init --dest=tioga-system ${ARCHCONFIG} ~gtl
-        else
-            ./bin/benchpark system init --dest=$HOST-system ${ARCHCONFIG} cluster=$HOST
+            EXTRA_ARGS="~gtl"
         fi
+        ./bin/benchpark system init --dest=$HOST-system ${ARCHCONFIG} cluster=$HOST $EXTRA_ARGS
     # Initialize Experiment
     - ./bin/benchpark experiment init --dest=${BENCHMARK}-benchmark ${BENCHMARK}+${VARIANT}
     # Build Workspace

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -80,7 +80,7 @@ test_run:
         if [ "$HOST" == "tioga" ]; then
             EXTRA_ARGS="~gtl"
         fi
-        ./bin/benchpark system init --dest=$HOST-system ${ARCHCONFIG} cluster=$HOST $EXTRA_ARGS
+        ./bin/benchpark system init --dest=${HOST}-system ${ARCHCONFIG} cluster=$HOST $EXTRA_ARGS
     # Initialize Experiment
     - ./bin/benchpark experiment init --dest=${BENCHMARK}-benchmark ${BENCHMARK}+${VARIANT}
     # Build Workspace
@@ -88,7 +88,7 @@ test_run:
     # Setup Ramble & Spack
     - . workspace/setup.sh
     # Setup Workspace
-    - cd ./workspace/${BENCHMARK}-benchmark/$HOST-system/workspace/
+    - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
     - ramble --workspace-dir . --disable-progress-bar --disable-logger workspace setup
     # Run Experiments
     - ramble --workspace-dir . --disable-progress-bar --disable-logger

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -26,31 +26,6 @@
         VARIANT:
           - openmp
 
-.legacy_test_clusters: &legacy_test_clusters
-  parallel:
-    matrix:
-      - LEGACY_HOST: tioga
-        LEGACY_ARCHCONFIG: LLNL-Tioga-HPECray-zen3-MI250X-Slingshot
-        SCHEDULER_PARAMETERS: -N 1 -t 1h
-        LEGACY_BENCHMARK:
-          - saxpy
-        LEGACY_VARIANT:
-          - openmp
-      - LEGACY_HOST: dane
-        LEGACY_ARCHCONFIG: LLNL-Dane-DELL-sapphirerapids-OmniPath
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
-        LEGACY_BENCHMARK:
-          - saxpy
-        LEGACY_VARIANT:
-          - openmp
-      - LEGACY_HOST: ruby
-        LEGACY_ARCHCONFIG: LLNL-Ruby-icelake-OmniPath
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00
-        LEGACY_BENCHMARK:
-          - saxpy
-        LEGACY_VARIANT:
-          - openmp
-
 .push_status: &push_status
     - |
       curl -X POST --url "https://api.github.com/repos/llnl/${CI_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
@@ -74,43 +49,6 @@
 workflow:
   auto_cancel:
     on_new_commit: conservative
-
-legacy_test_run:
-  resource_group: $LEGACY_HOST
-  stage: test
-  tags:
-    - $LEGACY_HOST
-    - batch
-  <<: *legacy_test_clusters
-  <<: *report_status
-  rules:
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/ci/*
-        - experiments/**
-        - systems/$LEGACY_ARCHCONFIG/**
-        - repo/$LEGACY_BENCHMARK/**
-        - modifiers/**
-        - var/**
-        - lib/**
-  script:
-    # Activate Virtual Environment
-    - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
-    # Build Saxpy Workspace
-    - ./bin/benchpark setup ${LEGACY_BENCHMARK}/${LEGACY_VARIANT} ${LEGACY_ARCHCONFIG} workspace/
-    # Setup Ramble & Spack
-    - . workspace/setup.sh
-    # Setup Saxpy Workspace
-    - cd ./workspace/${LEGACY_BENCHMARK}/${LEGACY_VARIANT}/${LEGACY_ARCHCONFIG}/workspace/
-    - ramble --workspace-dir . --disable-progress-bar --disable-logger workspace setup
-    # Run Saxpy Experiments
-    - ramble --workspace-dir . --disable-progress-bar --disable-logger
-      on --executor '{execute_experiment}' --where '{n_nodes} == 1'
-    # Analyze Experiments
-    - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json yaml text
-    # Check Experiment Exit Codes
-    - cd -
-    - python ./.gitlab/ci/bin/exit-codes ./workspace/${LEGACY_BENCHMARK}/${LEGACY_VARIANT}/${LEGACY_ARCHCONFIG}/workspace/results.latest.json
 
 test_run:
   resource_group: $HOST

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -84,6 +84,9 @@ class RuntimeResources:
     def bootstrap(self):
         if not self.ramble_location.exists():
             self._install_ramble()
+        else:
+            with working_dir(self.ramble_location):
+                run_command(f"git checkout {self.ramble_commit}")
         ramble_lib_path = self.ramble_location / "lib" / "ramble"
         externals = str(ramble_lib_path / "external")
         if externals not in sys.path:
@@ -135,6 +138,9 @@ class RuntimeResources:
                 "add",
                 f"config:misc_cache:{spack_cache_location}",
             )
+        else:
+            with working_dir(self.spack_location):
+                run_command(f"git checkout {self.spack_commit}")
         return spack, first_time
 
     def spack_first_time_setup(self):


### PR DESCRIPTION
## Description

- [x] Gitlab CI was failing partly because the version of the runners `.benchpark/ramble` was out of date with the ramble version we are using in `checkout-versions.yaml`. This PR makes sure to check out the version in `checkout-versions.yaml`, even if `.benchpark/ramble` or `.benchpark/spack` already exist. 
   - [x] Update old bootstrapped ramble/spack, if present. 
   - [x] Delete legacy CI

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/ci/test.yml`
- [x] Update `lib/benchpark/runtime.py`
