### PR TITLE
Fix Badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
     :target: https://codecov.io/gh/llnl/benchpark
 
 .. image:: https://github.com/llnl/benchpark/workflows/ci/badge.svg
-    :target: https://github.com/llnl/benchpark/actions/workflows/ci.yaml
+    :target: https://github.com/LLNL/benchpark/actions/workflows/ci.yml
 
 .. image:: https://github.com/LLNL/benchpark/actions/workflows/run.yml/badge.svg
     :target: https://github.com/LLNL/benchpark/actions/workflows/run.yml

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
     :target: https://github.com/LLNL/benchpark/actions/workflows/run.yml
 
 .. image:: https://github.com/llnl/benchpark/workflows/nightly/badge.svg
-    :target: https://github.com/llnl/benchpark/actions/workflows/nightly.yaml
+    :target: https://github.com/LLNL/benchpark/actions/workflows/nightly.yml
 
 .. image:: https://github.com/LLNL/benchpark/actions/workflows/docs.yml/badge.svg
     :target: https://github.com/LLNL/benchpark/actions/workflows/docs.yml

--- a/README.rst
+++ b/README.rst
@@ -16,14 +16,8 @@
 .. image:: https://github.com/llnl/benchpark/workflows/ci/badge.svg
     :target: https://github.com/LLNL/benchpark/actions/workflows/ci.yml
 
-.. image:: https://github.com/LLNL/benchpark/actions/workflows/run.yml/badge.svg
-    :target: https://github.com/LLNL/benchpark/actions/workflows/run.yml
-
 .. image:: https://github.com/llnl/benchpark/workflows/nightly/badge.svg
     :target: https://github.com/LLNL/benchpark/actions/workflows/nightly.yml
-
-.. image:: https://github.com/LLNL/benchpark/actions/workflows/docs.yml/badge.svg
-    :target: https://github.com/LLNL/benchpark/actions/workflows/docs.yml
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black


### PR DESCRIPTION
## Description

- [x] `yaml` vs `yml` results in different link, so badge must reference exact link to get correct status.
- [x] `run.yml` and `docs.yml` won't have status updates for badges, because they are called from `ci.yml`, so remove their badges.
![image](https://github.com/user-attachments/assets/789424da-4773-4add-a2bb-9bab79b2d1eb)
