### PR TITLE
Fix System Definitions

### DIFF
--- a/lib/scripts/compareyaml.py
+++ b/lib/scripts/compareyaml.py
@@ -34,27 +34,27 @@ def compare_yaml(file1, file2):
     def normalize_types(data):
         """fix to compare strings to int '56' == 56 for yaml purposes"""
         if isinstance(data, dict):
+            # Fix specific keys and recursively normalize values
             tdict = {
                 (k if k != "compilers:" else "compilers"): normalize_types(v)
                 for k, v in data.items()
-            }  # Fix for way "'compilers':": is generated in old yaml
+            }
+            # Filter out problematic entries
             tdict = {
                 k: v
                 for k, v in tdict.items()
-                if (
+                if not (
                     isinstance(v, str)
-                    and (
-                        "{self.cuda_version.major}" not in v
-                        and "{self.cuda_version}" not in v
-                    )
+                    and ("{self.cuda_version.major}" in v or "{self.cuda_version}" in v)
                 )
-            }  # Hacky check for errors in original yaml
+            }
             return tdict
         elif isinstance(data, list):
             return [normalize_types(v) for v in data]
         elif isinstance(data, str) and data.isdigit():
             return int(data)  # Convert numeric strings to integers
         else:
+            # Return other types as-is
             return data
 
     data1 = normalize_types(load_yaml(file1))
@@ -62,6 +62,9 @@ def compare_yaml(file1, file2):
 
     if data1 is None or data2 is None:
         color.cprint("\t\t@*rComparison aborted due to file loading errors.@.")
+        return
+    elif data1 == {} and data2 == {}:
+        color.cprint("\t\t@*rDictionaries empty, aborting.@.")
         return
 
     # Use DeepDiff to find differences

--- a/lib/scripts/compareyaml.py
+++ b/lib/scripts/compareyaml.py
@@ -115,7 +115,7 @@ def main():
             "cscs-eiger",
             "generic-x86",
             "jsc-juwels",
-            #"lanl-venado",
+            # "lanl-venado",
             "llnl-cluster",
             "llnl-elcapitan",
             "llnl-sierra",
@@ -176,17 +176,15 @@ def main():
                     var = "instance_type"
                 for cluster in sysd[system]:
                     spec_list = [
-                            "python",
-                            f"{name}/lib/main.py",
-                            "system",
-                            "init",
-                            f"--dest={name}/{cluster}",
-                            system,
-                            f"{var}={cluster}",
-                        ]
-                    subprocess.run(
-                        spec_list
-                    )
+                        "python",
+                        f"{name}/lib/main.py",
+                        "system",
+                        "init",
+                        f"--dest={name}/{cluster}",
+                        system,
+                        f"{var}={cluster}",
+                    ]
+                    subprocess.run(spec_list)
 
     # Compare the YAML files
     for system in sysd.keys():

--- a/lib/scripts/compareyaml.py
+++ b/lib/scripts/compareyaml.py
@@ -93,15 +93,15 @@ def main():
         "-o",
         "--old",
         type=str,
-        default="6d06ea8cbf6ffd494b30ece1a2e924fd48dd7018",  # develop from 3/4/25
-        help="Commit hash or branch name for the old version of Benchpark (default: 6d06ea8cbf6ffd494b30ece1a2e924fd48dd7018).",
+        default="develop",
+        help="Commit hash or branch name for the old version of Benchpark (default: develop).",
     )
     parser.add_argument(
         "-n",
         "--new",
         type=str,
-        default="refactor/systems-i654",
-        help="Commit hash or branch name for the new version of Benchpark (default: refactor/systems-i654).",
+        required=True,
+        help="Commit hash or branch name for the new version of Benchpark.",
     )
     parser.add_argument(
         "-s",
@@ -115,6 +115,7 @@ def main():
             "cscs-eiger",
             "generic-x86",
             "jsc-juwels",
+            #"lanl-venado",
             "llnl-cluster",
             "llnl-elcapitan",
             "llnl-sierra",
@@ -139,7 +140,7 @@ def main():
         "cscs-eiger": None,
         "generic-x86": None,
         "jsc-juwels": None,
-        # "lanl-venado": ["grace-hopper", "grace-grace"],
+        "lanl-venado": ["grace-hopper", "grace-grace"],
         "llnl-cluster": ["ruby", "magma", "dane"],
         "llnl-elcapitan": ["tioga", "elcapitan"],
         "llnl-sierra": None,
@@ -174,8 +175,7 @@ def main():
                 if system == "aws-pcluster":
                     var = "instance_type"
                 for cluster in sysd[system]:
-                    subprocess.run(
-                        [
+                    spec_list = [
                             "python",
                             f"{name}/lib/main.py",
                             "system",
@@ -184,6 +184,8 @@ def main():
                             system,
                             f"{var}={cluster}",
                         ]
+                    subprocess.run(
+                        spec_list
                     )
 
     # Compare the YAML files

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -312,8 +312,8 @@ class CscsDaint(System):
                     "cuda": {
                         "externals": [
                             {
-                                "spec": f"cuda@{self.cuda_version}",
-                                "prefix": f"/usr/local/cuda-{self.cuda_version.major}",
+                                "spec": "cuda@{self.cuda_version}",
+                                "prefix": "/usr/local/cuda-{self.cuda_version.major}",
                             }
                         ]
                     }

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -17,7 +17,7 @@ class JscJuwels(System):
             "sys_cores_per_node": 48,
             "timeout": 120,
             "sys_gpus_per_node": 4,
-            "cuda_arch": '"80"',
+            "cuda_arch": "80",
             "system_site": "jsc",
             "hardware_key": str(hardware_descriptions)
             + "/Atos-rome-A100-Infiniband/hardware_description.yaml",
@@ -105,9 +105,9 @@ class JscJuwels(System):
                             "spec": "cmake@3.26.3",
                             "prefix": "/p/software/juwelsbooster/stages/2024/software/CMake/3.26.3-GCCcore-12.3.0",
                             "modules": ["Stages/2024", "CMake"],
+                            "buildable": False,
                         }
                     ],
-                    "buildable": False,
                 },
                 "gmake": {
                     "externals": [{"spec": "gmake@4.2.1", "prefix": "/usr"}],
@@ -177,12 +177,12 @@ class JscJuwels(System):
                     "buildable": False,
                     "externals": [
                         {
-                            "spec": f"cuda@{self.cuda_version}",
-                            "prefix": f"/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
+                            "spec": "cuda@{self.cuda_version}",
+                            "prefix": "/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
                             "modules": [
                                 "Stages/2024",
-                                f"CUDA/{self.cuda_version.major}",
-                                f"NVHPC/23.7-CUDA-{self.cuda_version.major}",
+                                "CUDA/{self.cuda_version.major}",
+                                "NVHPC/23.7-CUDA-{self.cuda_version.major}",
                             ],
                         }
                     ],
@@ -190,8 +190,8 @@ class JscJuwels(System):
                 "curand": {
                     "externals": [
                         {
-                            "spec": f"curand@{self.cuda_version}",
-                            "prefix": f"/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
+                            "spec": "curand@{self.cuda_version}",
+                            "prefix": "/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
                         }
                     ],
                     "buildable": False,
@@ -199,8 +199,8 @@ class JscJuwels(System):
                 "cusparse": {
                     "externals": [
                         {
-                            "spec": f"cusparse@{self.cuda_version}",
-                            "prefix": f"/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
+                            "spec": "cusparse@{self.cuda_version}",
+                            "prefix": "/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
                         }
                     ],
                     "buildable": False,
@@ -208,8 +208,8 @@ class JscJuwels(System):
                 "cublas": {
                     "externals": [
                         {
-                            "spec": f"cublas@{self.cuda_version}",
-                            "prefix": f"/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
+                            "spec": "cublas@{self.cuda_version}",
+                            "prefix": "/p/software/juwelsbooster/stages/2024/software/CUDA/{self.cuda_version.major}",
                         }
                     ],
                     "buildable": False,

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -390,19 +390,19 @@ class LlnlSierra(System):
         compiler = self.spec.variants["compiler"][0]
         cuda_ver = self.spec.variants["cuda"][0]
         cfg = mpi_cfgs[(compiler, cuda_ver)]
-        return {
-            "packages": {
-                "blas": {
-                    "require": [self.spec.variants["blas"][0]]  # Replace dynamically
-                },
-                "lapack": {
-                    "require": [self.spec.variants["lapack"][0]]  # Replace dynamically
-                },
-                "mpi": {
-                    "externals": cfg  # Replace dynamically with the value of `cfg`
-                },
-            }
+        selections["packages"] |= {
+            "blas": {
+                "require": [self.spec.variants["blas"][0]]  # Replace dynamically
+            },
+            "lapack": {
+                "require": [self.spec.variants["lapack"][0]]  # Replace dynamically
+            },
+            "mpi": {
+                "externals": cfg,  # Replace dynamically with the value of `cfg`
+                "buildable": False
+            },
         }
+        return selections
 
     def compute_compilers_section(self):
         # values=("clang-ibm", "xl", "xl-gcc", "clang"),

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -391,15 +391,13 @@ class LlnlSierra(System):
         cuda_ver = self.spec.variants["cuda"][0]
         cfg = mpi_cfgs[(compiler, cuda_ver)]
         selections["packages"] |= {
-            "blas": {
-                "require": [self.spec.variants["blas"][0]]  # Replace dynamically
-            },
+            "blas": {"require": [self.spec.variants["blas"][0]]},  # Replace dynamically
             "lapack": {
                 "require": [self.spec.variants["lapack"][0]]  # Replace dynamically
             },
             "mpi": {
                 "externals": cfg,  # Replace dynamically with the value of `cfg`
-                "buildable": False
+                "buildable": False,
             },
         }
         return selections

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -53,7 +53,7 @@ class RikenFugaku(System):
                     },
                     "permissions": {"write": "group"},
                 },
-                "htslib": {"version": ["1.12"]},
+                "htslib": {"version": [1.12]},
                 "python": {
                     "externals": [
                         {
@@ -646,9 +646,9 @@ class RikenFugaku(System):
 
     def system_specific_variables(self):
         return {
-            "extra_cmd_opts": "-std-proc fjmpioutdir/bmexe",
-            "extra_batch_opts": '-x PJM_LLIO_GFSCACHE="/vol0002:/vol0003:/vol0004:/vol0005:/vol0006"',
-            "post_exec_cmds": "for F in $(ls -1v fjmpioutdir/bmexe.*); do cat $F >> {log_file}; done",
+            "extra_cmd_opts": "-std-proc fjmpioutdir/bmexe\n",
+            "extra_batch_opts": '-x PJM_LLIO_GFSCACHE="/vol0002:/vol0003:/vol0004:/vol0005:/vol0006"\n',
+            "post_exec_cmds": "for F in $(ls -1v fjmpioutdir/bmexe.*); do cat $F >> {log_file}; done\n",
         }
 
     def compute_software_section(self):


### PR DESCRIPTION
## Description

- [x] There was an issue with `lib/scripts/compareyaml.py`, which was reporting false-negatives, so bugs with the system configurations were not caught in #658. This PR fixes the script, which I've used to validate that the `system.py` definitions for the modified systems were broken, and applies the fixes.
