### PR TITLE
use /usr/workspace/benchpark for gitlab data files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,8 @@ variables:
 # Override the pattern describing branches that will skip the "draft PR filter
 # test".  Add protected branches here. See default value in
 # preliminary-ignore-draft-pr.yml.
-  ALWAYS_RUN_PATTERN: "^develop$|^master$|^v[0-9.]*$|^releases/$"
+  ALWAYS_RUN_PATTERN: ^develop$|^master$|^v[0-9.]*$|^releases/$
   CUSTOM_CI_BUILDS_DIR: "/usr/workspace/benchpark/gitlab_ci/${CI_PIPELINE_ID}"
-
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,9 @@ variables:
 # Override the pattern describing branches that will skip the "draft PR filter
 # test".  Add protected branches here. See default value in
 # preliminary-ignore-draft-pr.yml.
-  ALWAYS_RUN_PATTERN: ^develop$|^master$|^v[0-9.]*$|^releases/$
+  ALWAYS_RUN_PATTERN: "^develop$|^master$|^v[0-9.]*$|^releases/$"
+  CUSTOM_CI_BUILDS_DIR: "/usr/workspace/benchpark/gitlab_ci/${CI_PIPELINE_ID}"
+
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,3 +8,6 @@ spack:
   view: true
   concretizer:
     unify: true
+  config:
+    install_tree:
+      root: $spack/o


### PR DESCRIPTION
The gitlab CI has filled up the `benchpark` user's disk quota. See example https://lc.llnl.gov/gitlab/benchpark/benchpark/-/jobs/2487244
```
=> Warning: Errors occurred when archiving files.
	See: /g/g0/benchpark/.jacamar-ci/builds/jyvWCxYV/001/gitlab/benchpark/benchpark/workspace/spack/opt/spack/linux-rhel8-zen3/cce-18.0.1-rocm6.2.4/chai-2024.02.2-nzn47myhb5jp5vplnoeboyfw6ma5tlw2/.spack/archived-files/errors.txt
==> Error: OSError: [Errno 122] Disk quota exceeded
```

This change would put the CI files in `/usr/workspace/benchpark`.