### PR TITLE
Fix laghos to use zlib instead of zlib-ng

### DIFF
--- a/repo/laghos/package.py
+++ b/repo/laghos/package.py
@@ -35,14 +35,13 @@ class Laghos(MakefilePackage, CudaPackage, ROCmPackage):
 
     depends_on("zlib@1.3.1+optimize+pic+shared")
     #depends_on("zlib@1.3.1+optimize+pic+shared", when="@develop")
-    #depends_on("mfem@develop^zlib@1.3.1+optimize+pic+shared", when="@develop")
     depends_on("mfem@4.2.0:", when="@3.1")
     depends_on("mfem@4.1.0:4.1", when="@3.0")
     # Recommended mfem version for laghos v2.0 is: ^mfem@3.4.1-laghos-v2.0
     depends_on("mfem@3.4.1-laghos-v2.0", when="@2.0")
     # Recommended mfem version for laghos v1.x is: ^mfem@3.3.1-laghos-v1.0
     depends_on("mfem@3.3.1-laghos-v1.0", when="@1.0,1.1")
-    depends_on("mfem@4.4")
+    depends_on("mfem@4.4^zlib@1.3.1+optimize+pic+shared", when="mfem^zlib-api")
     depends_on("mfem+caliper", when="+caliper")
     depends_on("mfem cxxstd=14")
 


### PR DESCRIPTION
## Description
Change laghos/package.py to use the zlib library in mfem instead of zlib-ng on dane

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [X] (optional) If package upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py`