### PR TITLE
Adding maintainers

### DIFF
--- a/experiments/ad/experiment.py
+++ b/experiments/ad/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 
 
@@ -19,6 +19,8 @@ class Ad(Experiment):
         default="main",
         description="app version",
     )
+
+    maintainers("rfhaque")
 
     def compute_applications_section(self):
         self.add_experiment_variable("n_ranks", 1, True)

--- a/experiments/gpcnet/experiment.py
+++ b/experiments/gpcnet/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -21,6 +21,8 @@ class Gpcnet(Experiment, StrongScaling):
         default="master",
         description="app version",
     )
+
+    maintainers("rfhaque")
 
     def compute_applications_section(self):
         # TODO: Replace with conflicts clause

--- a/experiments/hpcg/experiment.py
+++ b/experiments/hpcg/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 from benchpark.scaling import WeakScaling
@@ -30,6 +30,8 @@ class Hpcg(
         values=("3.1", "develop", "caliper"),
         description="app version",
     )
+
+    maintainers("pearce8")
 
     def compute_applications_section(self):
 

--- a/experiments/md-test/experiment.py
+++ b/experiments/md-test/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant
+from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.scaling import StrongScaling
 
@@ -23,6 +23,8 @@ class MdTest(
         default="1.9.3",
         description="app version",
     )
+
+    maintainers("rfhaque")
 
     def compute_applications_section(self):
 

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class CscLumi(System):
 
+    maintainers("pszi1ard")
+
     id_to_resources = {
         "lumi": {
             "sys_cores_per_node": 64,

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class CscsDaint(System):
 
+    maintainers("pearce8")
+
     id_to_resources = {
         "daint": {
             "sys_cores_per_node": 12,

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class CscsEiger(System):
 
+    maintainers("pearce8")
+
     id_to_resources = {
         "eiger": {
             "sys_cores_per_node": 128,

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -11,6 +11,8 @@ class GenericX86(System):
     """This is the generic system class for an x86 system, gcc compiler, mpi.
     It can be easily copied and modified to model other systems."""
 
+    maintainers("slabasan")
+
     def __init__(self, spec):
         super().__init__(spec)
 

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -12,6 +12,8 @@ from benchpark.paths import hardware_descriptions
 
 class JscJuwels(System):
 
+    maintainers("pearce8")
+
     id_to_resources = {
         "juwels": {
             "sys_cores_per_node": 48,


### PR DESCRIPTION
## Experiments and Systems now allow maintainers to be listed (Ala Spack package maintainers)

- [x] Add maintainers to all the systems (the people who originated the system description is a good start)
- [x] Add maintainers to all the experiments (ditto)
- [x] For Livermore-owned systems/experiments, if maintainers left the project (Dewi, August), please assign to those who are still on the team.  For this, it might make sense to have a way to see what a specific user maintains (i.e., list what belongs to a maintainer)
- [ ] Both need to be listed in the 2 tables in docs -- @pearce8 This one not easy to do. This data in in `system.py` and `experiment.py`, but the metadata to fill in the systems and experiments tables in the docs pull from the `hardware_description.yaml` and the `benchpark tags` command. Is this critical? Otherwise, this can go in.