### PR TITLE
laghos experiment: enforce zlib

### DIFF
--- a/repo/laghos/package.py
+++ b/repo/laghos/package.py
@@ -41,10 +41,11 @@ class Laghos(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("mfem@3.4.1-laghos-v2.0", when="@2.0")
     # Recommended mfem version for laghos v1.x is: ^mfem@3.3.1-laghos-v1.0
     depends_on("mfem@3.3.1-laghos-v1.0", when="@1.0,1.1")
-    depends_on("mfem@4.4^zlib@1.3.1+optimize+pic+shared", when="mfem^zlib-api")
+    depends_on("mfem@4.4", when="@develop")
     depends_on("mfem+caliper", when="+caliper")
     depends_on("mfem cxxstd=14")
 
+    requires("^[virtuals=zlib-api] zlib")
 
     depends_on("mpi")
     depends_on("hypre+mpi")


### PR DESCRIPTION
This is a minor tweak to https://github.com/LLNL/benchpark/pull/696 to get laghos and mfem to both use zlib (when they are concretized with Spack).

The original mfem/zlib constraint also had a version constraint on mfem, which I inferred was based on the newest version of laghos.