### PR TITLE
adds --update-head-ok to git fetch to force update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         id: get_modified_repo_dirs
         run: |
           # Fetch develop branch
-          git fetch origin develop:develop
+          git fetch --update-head-ok origin develop:develop
 
           # Get the modified directories under 'repo/'
           MODIFIED_REPO_DIRS=$(git diff --name-only develop | grep 'repo/' | xargs -n1 dirname | sed 's|^repo/||' | tr '\n' ' ')


### PR DESCRIPTION
## Description

- [x] Adds `--update-head-ok` to `git fetch` to force update. By default, git fetch refuses to update the head which corresponds to the current branch. This flag disables the check.

@michaelmckinsey1 I think this should fix CI on `develop` at `e069d61`. Could you take a look?
