### PR TITLE
Fix Script Name in CI

### DIFF
--- a/.github/workflows/diffpackages.yml
+++ b/.github/workflows/diffpackages.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: Check Packages Against Spack
         run: |
-          ./bin/benchpark-python lib/scripts/diffPackages.py --packages "${{ inputs.modified_repo_dirs }}"
+          ./bin/benchpark-python lib/scripts/diffPackageCommits.py --packages "${{ inputs.modified_repo_dirs }}"


### PR DESCRIPTION
## Description

Rename of script in #709 Broke this test. It did not run because no `package.py`'s were changed, so we didn't notice.