### PR TITLE
Update llnl-elcapitan system.py

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -24,7 +24,7 @@ class LlnlElcapitan(System):
             + "/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml",
         },
         "elcapitan": {
-            "rocm_arch": "gfx940",
+            "rocm_arch": "gfx942",
             "sys_cores_per_node": 96,
             "sys_gpus_per_node": 4,
             "system_site": "llnl",


### PR DESCRIPTION
## Description

I was getting a runtime error `'std::runtime_error' what(): HIPassert: invalid device function /var/tmp/mckinsey/spack-stage/spack-stage-raja-perf-2024.07.0-ptdqty7ymebdg67v2joo2xsheayizz7r/spack-src/tpl/RAJA/include/RAJA/policy/hip/MemUtils_HIP.hpp:262` , running raja-perf on tuolumne, which updating the arch fixed.