### PR TITLE
Fix Function Name in Affinity modifier

### DIFF
--- a/lib/benchpark/affinity.py
+++ b/lib/benchpark/affinity.py
@@ -32,7 +32,7 @@ class Affinity:
                 modifier_list.append(affinity_modifier_modes)
             return modifier_list
 
-        def compute_spack_section(self):
+        def compute_package_section(self):
             # set package versions
             affinity_version = "master"
 


### PR DESCRIPTION
## Description

Bug caused by incorrect rebase/merge probably, as `compute_spack_section` no longer exists in develop. Affinity will not install without this change.

Example `saxpy+openmp affinity=mpi` 8 ranks, 2 threads/proc, 1 node
```
affinity test for 8 MPI ranks
rank      0 @ dane1514
  thread   0 on cores [112]
  thread   1 on cores [119]
rank      1 @ dane1514
  thread   0 on cores [126]
  thread   1 on cores [133]
rank      2 @ dane1514
  thread   0 on cores [140]
  thread   1 on cores [147]
rank      3 @ dane1514
  thread   0 on cores [154]
  thread   1 on cores [161]
rank      4 @ dane1514
  thread   0 on cores [168]
  thread   1 on cores [175]
rank      5 @ dane1514
  thread   0 on cores [182]
  thread   1 on cores [189]
rank      6 @ dane1514
  thread   0 on cores [196]
  thread   1 on cores [203]
rank      7 @ dane1514
  thread   0 on cores [210]
  thread   1 on cores [217]
```