### PR TITLE
[[WIP]] [[DO NOT MERGE]] Feature ramble required variable validators

### DIFF
--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -3,5 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 versions:
-  ramble: f5970aa  # develop on 1/08/2025 (newer than 0.5.0 release)
+  ramble: 52695da  # develop on 4/25/2025 (newer than 0.5.0 release)
   spack: 0b3b49b  # develop-2024-06-28 (newer than 0.22.0 release)

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -55,20 +55,6 @@ class Amg2023(
     # )
 
     def compute_applications_section(self):
-        # TODO: Replace with conflicts clause
-        scaling_modes = {
-            "strong": self.spec.satisfies("+strong"),
-            "weak": self.spec.satisfies("+weak"),
-            "throughput": self.spec.satisfies("+throughput"),
-            "single_node": self.spec.satisfies("+single_node"),
-        }
-
-        scaling_mode_enabled = [key for key, value in scaling_modes.items() if value]
-        if len(scaling_mode_enabled) != 1:
-            raise BenchparkError(
-                f"Only one type of scaling per experiment is allowed for application package {self.name}"
-            )
-
         # Number of processes in each dimension
         num_procs = {"px": 2, "py": 2, "pz": 2}
 
@@ -127,6 +113,7 @@ class Amg2023(
             for k, v in scaled_variables.items():
                 self.add_experiment_variable(k, v, True)
 
+        self.add_experiment_variable("nprocs", n_resources, True)
         if self.spec.satisfies("+openmp"):
             self.add_experiment_variable("n_ranks", n_resources, True)
             self.add_experiment_variable("n_threads_per_proc", 1, True)

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -113,7 +113,7 @@ class Amg2023(
             for k, v in scaled_variables.items():
                 self.add_experiment_variable(k, v, True)
 
-        self.add_experiment_variable("nprocs", n_resources, True)
+        self.add_experiment_variable("nprocs", n_resources)
         if self.spec.satisfies("+openmp"):
             self.add_experiment_variable("n_ranks", n_resources, True)
             self.add_experiment_variable("n_threads_per_proc", 1, True)

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -15,6 +15,92 @@ import benchpark.repo
 import benchpark.runtime
 import benchpark.variant
 
+import ast
+import astor
+import sys
+import re
+import os
+
+def get_ramble_app_class_name(name):
+    # Replace hyphens and underscores with spaces
+    name = re.sub(r'[-_]', ' ', name)
+    # Capitalize each word and join them
+    return ''.join(word.capitalize() for word in name.split())
+
+def add_validator(benchpark_root_dir, app_name):
+    app_spec_file = os.path.join(benchpark_root_dir, "repo", app_name, "application.py")
+
+    # Read the file
+    with open(app_spec_file, "r") as f:
+        source = f.read()
+    
+    # Parse the file
+    tree = ast.parse(source)
+
+    validator_class_name = "BenchparkValidator"
+
+    validator_class = None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == validator_class_name:
+            validator_class = node
+            break
+
+    if validator_class:
+        tree.body.remove(validator_class)
+
+    validator_class = ast.ClassDef(
+        name=validator_class_name,
+        bases=[],
+        keywords=[],
+        body=[
+            ast.Expr(
+                value=ast.Call(
+                    func=ast.Name(id="register_validator", ctx=ast.Load()),
+                    args=[],
+                    keywords=[
+                        ast.keyword(arg="name", value=ast.Constant(value="benchpark_validator")),
+                        ast.keyword(arg="predicate", value=ast.Constant(value="{validation_checks}")),
+                        ast.keyword(
+                            arg="message",
+                            value=ast.Constant(
+                                value="Benchpark validation checks failed. Please review "
+                                      "validation_checks variable in ramble.yaml for "
+                                      "the failing check"
+                            )
+                        ),
+                        ast.keyword(arg="fail_on_invalid", value=ast.Constant(value=True)),
+                    ],
+                )
+            )
+        ],
+        decorator_list=[]
+    )
+
+    # Insert the new class at the end
+    tree.body.append(validator_class)
+
+    # Add BenchparkValidator as a base class of the application class
+    app_class_name = get_ramble_app_class_name(app_name)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == app_class_name:
+            app_class = node
+            if not any(isinstance(base, ast.Name) and base.id == validator_class_name for base in node.bases):
+                node.bases.append(ast.Name(id=validator_class_name, ctx=ast.Load()))
+            break
+
+    vc = tree.body.index(validator_class)
+    ac = tree.body.index(app_class)
+
+    tree.body[ac], tree.body[vc] = tree.body[vc], tree.body[ac]
+
+    # Unparse back to source
+    #new_source = ast.unparse(tree)
+    new_source = astor.to_source(tree)
+
+    # Write back to file
+    with open(app_spec_file, "w") as f:
+        f.write(new_source)
+
 bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 bootstrapper.bootstrap()
 
@@ -133,6 +219,7 @@ class Experiment(ExperimentSystemBase, SingleNode):
         self.helpers = []
         self._spack_name = None
         self._ramble_name = None
+        self._validation_checks = []
 
         for cls in self.__class__.mro()[1:]:
             if cls is not Experiment and cls is not object:
@@ -148,6 +235,11 @@ class Experiment(ExperimentSystemBase, SingleNode):
             raise BenchparkError(f"No workload variant defined for package {self.name}")
 
         self.package_specs = {}
+
+        if self.spec.satisfies("+single_node"):
+            self._validation_checks.append("{n_nodes} == 1")
+
+        add_validator(benchpark.paths.benchpark_root, self.name)
 
     @property
     def spack_name(self):
@@ -253,6 +345,14 @@ class Experiment(ExperimentSystemBase, SingleNode):
             self.env_vars["append"][0] |= env_vars["append"][0]
 
         self.compute_applications_section()
+
+        if self._validation_checks:
+            if len(self._validation_checks) > 1:
+                self.variables["validation_checks"] = "(" + ") and (".join(self._validation_checks) + ")"
+            else:
+                self.variables["validation_checks"] = self._validation_checks[0]
+        else:
+            self.variables["validation_checks"] = "True"
 
         expr_helper_list = []
         for cls in self.helpers:

--- a/lib/benchpark/ramble-required-variables.patch
+++ b/lib/benchpark/ramble-required-variables.patch
@@ -1,0 +1,63 @@
+diff --git a/lib/ramble/ramble/application.py b/lib/ramble/ramble/application.py
+index 215822c9..305844d6 100644
+--- a/lib/ramble/ramble/application.py
++++ b/lib/ramble/ramble/application.py
+@@ -922,6 +922,15 @@ class ApplicationBase(metaclass=ApplicationMeta):
+                 self.expander.add_no_expand_var(var)
+                 mod_inst.expander.add_no_expand_var(var)
+ 
++    def get_required_variables(self):
++        """Get all the required variables based on the mode."""
++        required_vars = self.required_vars
++        filtered_vars = {}
++        if required_vars:
++            for var_name, var_props in required_vars.items():
++                filtered_vars[var_name] = var_props
++        return filtered_vars
++
+     def validate_experiment(self, warn_validation=True, die_on_validate_error=True):
+         # Validate the new modifiers variables exist
+         # (note: the base ramble variables are checked earlier too)
+diff --git a/lib/ramble/ramble/experiment_set.py b/lib/ramble/ramble/experiment_set.py
+index 2315cbee..4d1f4153 100644
+--- a/lib/ramble/ramble/experiment_set.py
++++ b/lib/ramble/ramble/experiment_set.py
+@@ -355,6 +355,9 @@ class ExperimentSet:
+         )
+ 
+         app_inst.add_expand_vars(self._workspace)
++
++        self.keywords.update_keys(app_inst.get_required_variables())
++
+         app_inst.read_status()
+ 
+         return app_inst
+diff --git a/lib/ramble/ramble/language/application_language.py b/lib/ramble/ramble/language/application_language.py
+index 80b363d7..ab4e45da 100644
+--- a/lib/ramble/ramble/language/application_language.py
++++ b/lib/ramble/ramble/language/application_language.py
+@@ -193,6 +193,24 @@ def input_file(
+     return _execute_input_file
+ 
+ 
++@application_directive("required_vars")
++def required_variable(var: str, results_level="variable", modes=None, description=None):
++    """Mark a variable as being required by this modifier
++
++    Args:
++        var (str): Variable name to mark as required
++        description (str | None): Description of the required variable.
++    """
++
++    def _mark_required_var(app):
++        app.required_vars[var] = {
++            "type": ramble.keywords.key_type.required,
++            "description": description,
++        }
++
++    return _mark_required_var
++
++
+ @application_directive("workload_group_vars")
+ def workload_variable(
+     name,

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -5,6 +5,7 @@
 
 from contextlib import contextmanager
 import os
+import shutil
 import pathlib
 import shlex
 import subprocess
@@ -109,6 +110,16 @@ class RuntimeResources:
             self.ramble_commit,
             self.ramble_location,
         )
+        cdir = os.getcwd()
+        patch_file = "ramble-required-variables.patch"
+        patch_src = os.path.join(self.root, "lib/benchpark", patch_file)
+        patch_dest = os.path.join(self.ramble_location, patch_file)
+        try: 
+            shutil.copy(patch_src, patch_dest)
+            os.chdir(self.ramble_location)
+            subprocess.run(['git', 'apply', patch_file], check=True)
+        finally:
+            os.chdir(cdir)
         debug_print(f"Done cloning Ramble ({self.ramble_location})")
 
     def _install_spack(self):

--- a/repo/amg2023/application.py
+++ b/repo/amg2023/application.py
@@ -53,6 +53,8 @@ class Amg2023(ExecutableApplication):
                       description='nz',
                       workloads=['problem1', 'problem2'])
 
+    required_variable("nprocs", description="px*py*pz")
+
     figure_of_merit('Figure of Merit (FOM)', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'Figure of Merit \(FOM\):\s+(?P<fom>[0-9]+\.[0-9]*(e^[0-9]*)?)', group_name='fom', units='')
 
     #TODO: Fix the FOM success_criteria(...)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ google-cloud-bigquery
 tqdm
 deprecation
 deepdiff
+astor


### PR DESCRIPTION
## Description
Proof of concept implementation. This PR 
- [ ] Adds a`required_variable` construct to Ramble applications (similar to the existing `required_variable` construct for modifiers) that enforces definition of specified variables in application.py.
- [ ] Usage: in `repo/amg2023/application.py` add `required_variable("nprocs", description="px*py*pz")` 
- [ ] Dynamically registers a validation check for a single node experiment using Ramble's `register_validator` construct. The single_node check is controlled by the `single_node` variant in benchpark. 
- [ ] Requires updating Ramble to the latest develop version
- [ ] Requires patching Ramble (is this to add the code in the application.py?)
- [ ] Docs, eventually.