### PR TITLE
Fix Benchmark Builds for Default Specs

### DIFF
--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -128,10 +128,12 @@ class Amg2023(
                 self.add_experiment_variable(k, v, True)
 
         if self.spec.satisfies("+openmp"):
-            self.add_experiment_variable("n_ranks", n_resources, True)
             self.add_experiment_variable("n_threads_per_proc", 1, True)
-        elif self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             self.add_experiment_variable("n_gpus", n_resources, True)
+        else:
+            self.add_experiment_variable("n_ranks", n_resources, True)
 
     def compute_package_section(self):
         # get package version

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -128,6 +128,8 @@ class Kripke(
             self.add_experiment_variable("n_threads_per_proc", 1, True)
         elif self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             self.add_experiment_variable("n_gpus", n_resources, True)
+        else:
+            self.add_experiment_variable("n_ranks", n_resources, True)
 
         if self.spec.satisfies("+openmp"):
             self.add_experiment_variable("arch", "OpenMP")

--- a/repo/amg2023/package.py
+++ b/repo/amg2023/package.py
@@ -35,6 +35,7 @@ class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hypre+mixedint~fortran")
 
     depends_on("hypre+cuda", when="+cuda")
+    depends_on("hypre+openmp", when="+openmp")
     requires("+cuda", when="^hypre+cuda")
     for arch in ("none", "50", "60", "70", "80", "90"):
         depends_on(f"hypre cuda_arch={arch}", when=f"cuda_arch={arch}")

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -77,20 +77,6 @@ class LlnlCluster(System):
                     "externals": [{"spec": "unwind@8.0.1", "prefix": "/usr"}],
                     "buildable": False,
                 },
-                "tar": {
-                    "buildable": False,
-                    "externals": [{"spec": "tar@1.30", "prefix": "/usr"}],
-                },
-                "cmake": {
-                    "buildable": False,
-                    "externals": [
-                        {
-                            "spec": "cmake@3.26.3",
-                            "prefix": "/usr/tce/packages/cmake/cmake-3.26.3",
-                        }
-                    ],
-                },
-                "gmake": {"externals": [{"spec": "gmake@4.2.1", "prefix": "/usr"}]},
                 "blas": {
                     "buildable": False,
                     "externals": [
@@ -109,19 +95,6 @@ class LlnlCluster(System):
                         }
                     ],
                 },
-                "python": {
-                    "buildable": False,
-                    "externals": [
-                        {
-                            "spec": "python@3.9.12",
-                            "prefix": "/usr/tce/packages/python/python-3.9.12/",
-                        }
-                    ],
-                },
-                "hwloc": {
-                    "buildable": False,
-                    "externals": [{"spec": "hwloc@2.9.1", "prefix": "/usr"}],
-                },
                 "fftw": {
                     "buildable": False,
                     "externals": [
@@ -130,6 +103,68 @@ class LlnlCluster(System):
                             "prefix": "/usr/tce/packages/fftw/fftw-3.3.10",
                         }
                     ],
+                },
+                "diffutils": {
+                    "externals": [
+                        {"spec": "diffutils@3.6", "prefix": "/usr"}
+                    ],
+                    "buildable": False
+                },
+                "cmake": {
+                    "externals": [
+                        {"spec": "cmake@3.26.5", "prefix": "/usr"},
+                        {"spec": "cmake@3.23.1", "prefix": "/usr/tce"}
+                    ],
+                    "buildable": False
+                },
+                "tar": {
+                    "externals": [
+                        {"spec": "tar@1.30", "prefix": "/usr"}
+                    ],
+                    "buildable": False
+                },
+                "autoconf": {
+                    "externals": [
+                        {"spec": "autoconf@2.69", "prefix": "/usr"}
+                    ],
+                    "buildable": False
+                },
+                "python": {
+                    "externals": [
+                        {
+                            "spec": "python@2.7.18+bz2+crypt+ctypes+dbm~lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib",
+                            "prefix": "/usr"
+                        },
+                        {
+                            "spec": "python@3.6.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
+                            "prefix": "/usr"
+                        },
+                        {
+                            "spec": "python@2.7.18+bz2+crypt+ctypes+dbm~lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
+                            "prefix": "/usr/tce"
+                        },
+                        {
+                            "spec": "python@3.9.12+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
+                            "prefix": "/usr/tce"
+                        },
+                        {
+                            "spec": "python@3.12.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
+                            "prefix": "/usr/workspace/wsa/mckinsey/venv/benchpark-3.12.8"
+                        }
+                    ],
+                    "buildable": False
+                },
+                "hwloc": {
+                    "externals": [
+                        {"spec": "hwloc@2.11.2", "prefix": "/usr"}
+                    ],
+                    "buildable": False
+                },
+                "gmake": {
+                    "externals": [
+                        {"spec": "gmake@4.2.1", "prefix": "/usr"}
+                    ],
+                    "buildable": False
                 },
             }
         }

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -105,66 +105,56 @@ class LlnlCluster(System):
                     ],
                 },
                 "diffutils": {
-                    "externals": [
-                        {"spec": "diffutils@3.6", "prefix": "/usr"}
-                    ],
-                    "buildable": False
+                    "externals": [{"spec": "diffutils@3.6", "prefix": "/usr"}],
+                    "buildable": False,
                 },
                 "cmake": {
                     "externals": [
                         {"spec": "cmake@3.26.5", "prefix": "/usr"},
-                        {"spec": "cmake@3.23.1", "prefix": "/usr/tce"}
+                        {"spec": "cmake@3.23.1", "prefix": "/usr/tce"},
                     ],
-                    "buildable": False
+                    "buildable": False,
                 },
                 "tar": {
-                    "externals": [
-                        {"spec": "tar@1.30", "prefix": "/usr"}
-                    ],
-                    "buildable": False
+                    "externals": [{"spec": "tar@1.30", "prefix": "/usr"}],
+                    "buildable": False,
                 },
                 "autoconf": {
-                    "externals": [
-                        {"spec": "autoconf@2.69", "prefix": "/usr"}
-                    ],
-                    "buildable": False
+                    "externals": [{"spec": "autoconf@2.69", "prefix": "/usr"}],
+                    "buildable": False,
                 },
                 "python": {
                     "externals": [
                         {
                             "spec": "python@2.7.18+bz2+crypt+ctypes+dbm~lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib",
-                            "prefix": "/usr"
+                            "prefix": "/usr",
                         },
                         {
                             "spec": "python@3.6.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
-                            "prefix": "/usr"
+                            "prefix": "/usr",
                         },
                         {
                             "spec": "python@2.7.18+bz2+crypt+ctypes+dbm~lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
-                            "prefix": "/usr/tce"
+                            "prefix": "/usr/tce",
                         },
                         {
                             "spec": "python@3.9.12+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
-                            "prefix": "/usr/tce"
+                            "prefix": "/usr/tce",
                         },
                         {
                             "spec": "python@3.12.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
-                            "prefix": "/usr/workspace/wsa/mckinsey/venv/benchpark-3.12.8"
-                        }
+                            "prefix": "/usr/workspace/wsa/mckinsey/venv/benchpark-3.12.8",
+                        },
                     ],
-                    "buildable": False
+                    "buildable": False,
                 },
                 "hwloc": {
-                    "externals": [
-                        {"spec": "hwloc@2.11.2", "prefix": "/usr"}
-                    ],
-                    "buildable": False
+                    "externals": [{"spec": "hwloc@2.11.2", "prefix": "/usr"}],
+                    "buildable": False,
                 },
                 "gmake": {
-                    "externals": [
-                        {"spec": "gmake@4.2.1", "prefix": "/usr"}
-                    ],
-                    "buildable": False
+                    "externals": [{"spec": "gmake@4.2.1", "prefix": "/usr"}],
+                    "buildable": False,
                 },
             }
         }

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -95,9 +95,11 @@ class LlnlElcapitan(System):
             )
         if self.rocm_version >= Version("6.0.0"):
             self.pmi_version = Version("6.1.15.6")
+            self.pals_version = Version("1.2.12")
             self.llvm_version = Version("18.0.1")
         else:
             self.pmi_version = Version("6.1.12")
+            self.pals_version = Version("1.2.9")
             self.llvm_version = Version("16.0.0")
         # TODO: Replace this with lookups into the working set
 
@@ -605,7 +607,7 @@ class LlnlElcapitan(System):
                                     "LD_LIBRARY_PATH": "/opt/cray/pe/gcc-libs"
                                 },
                                 "prepend_path": {
-                                    "LD_LIBRARY_PATH": f"/opt/cray/pe/cce/{self.cce_version}/cce/x86_64/lib:/opt/cray/pe/pmi/{self.pmi_version}/lib",
+                                    "LD_LIBRARY_PATH": f"/opt/cray/pe/cce/{self.cce_version}/cce/x86_64/lib:/opt/cray/pe/pmi/{self.pmi_version}/lib:/opt/cray/pe/pals/{self.pals_version}/lib",
                                     "LIBRARY_PATH": f"/opt/rocm-{self.rocm_version}/lib",
                                 },
                             },
@@ -641,7 +643,7 @@ class LlnlElcapitan(System):
                             "modules": [f"cce/{self.cce_version}"],
                             "environment": {
                                 "prepend_path": {
-                                    "LD_LIBRARY_PATH": f"/opt/cray/pe/cce/{self.cce_version}/cce/x86_64/lib:/opt/rocm-{self.rocm_version}/lib"
+                                    "LD_LIBRARY_PATH": f"/opt/cray/pe/cce/{self.cce_version}/cce/x86_64/lib:/opt/rocm-{self.rocm_version}/lib:/opt/cray/pe/pmi/{self.pmi_version}/lib:/opt/cray/pe/pals/{self.pals_version}/lib"
                                 }
                             },
                             "extra_rpaths": [


### PR DESCRIPTION
## Description

This PR addresses issues with benchmarks on develop, discovered during the hackathon on 05/08. This will enable adding these benchmarks to gitlab CI.

Fixed benchmarks:
- `kripke`
- `amg2023`
- `hypre+rocm` benchmarks on `llnl-elcapitan`
- `mfem` on `llnl-cluster`
- `amg2023+openmp`

## Experiments

- [X] Update `experiments/kripke/experiment.py` to fix `must specify n_ranks` error when running mpi-only
- [X] Update `experiments/amg2023/experiment.py` to fix `must specify n_ranks` error when running mpi-only

## Systems

- [X] Update `systems/llnl-elcapitan/system.py` to fix pmi, pals LD_LIBRARY_PATH on llnl-elcapitan to fix hypre build
- [X] Update `systems/llnl-cluster/system.py` with missing externals, fixing mfem failure to build `diffutils` 

## Packages

- [X] Update `repo/amg2023/package.py` to add openmp dependency for `amg2023`