### PR TITLE
[WIP] Update Defaults in llnl-elcapitan system.py

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -235,8 +235,8 @@ class LlnlElcapitan(System):
                 "cray-libsci": {
                     "externals": [
                         {
-                            "spec": "cray-libsci@23.05.1.4%cce",
-                            "prefix": "/opt/cray/pe/libsci/23.05.1.4/cray/12.0/x86_64/",
+                            "spec": "cray-libsci@25.03.0%cce",
+                            "prefix": "/opt/cray/pe/libsci/25.03.0/cray/18.0/x86_64/",
                         }
                     ]
                 }
@@ -246,8 +246,8 @@ class LlnlElcapitan(System):
                 "cray-libsci": {
                     "externals": [
                         {
-                            "spec": "cray-libsci@23.05.1.4%gcc",
-                            "prefix": "/opt/cray/pe/libsci/23.05.1.4/gnu/10.3/x86_64/",
+                            "spec": "cray-libsci@25.03.0%gcc",
+                            "prefix": "/opt/cray/pe/libsci/25.03.0/gnu/13.1/x86_64/",
                         }
                     ]
                 }

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -85,7 +85,7 @@ class LlnlElcapitan(System):
             self.mpi_version = Version("8.1.26")
         else:
             if self.rocm_version >= Version("6.0.0"):
-                self.cce_version = Version("18.0.1")
+                self.cce_version = Version("19.0.0")
                 self.mpi_version = Version("8.1.31")
             else:
                 self.cce_version = Version("16.0.0")

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -42,8 +42,8 @@ class LlnlElcapitan(System):
 
     variant(
         "rocm",
-        default="6.2.4",
-        values=("5.7.1", "6.2.4", "6.3.1"),
+        default="6.4.0",
+        values=("5.7.1", "6.2.4", "6.3.1", "6.4.0"),
         description="ROCm version",
     )
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -81,7 +81,7 @@ class LlnlElcapitan(System):
         # TODO: Replace this with lookups into the working set
         self.rocm_version = Version(self.spec.variants["rocm"][0])
         if self.spec.satisfies("compiler=gcc"):
-            self.gcc_version = Version("12.2.0")
+            self.gcc_version = Version("13.3.1")
             self.mpi_version = Version("8.1.26")
         else:
             if self.rocm_version >= Version("6.0.0"):
@@ -274,12 +274,12 @@ class LlnlElcapitan(System):
             "compilers": [
                 {
                     "compiler": {
-                        "spec": "gcc@12.2.0",
+                        "spec": "gcc@13.3.1",
                         "paths": {
-                            "cc": "/opt/cray/pe/gcc/12.2.0/bin/gcc",
-                            "cxx": "/opt/cray/pe/gcc/12.2.0/bin/g++",
-                            "f77": "/opt/cray/pe/gcc/12.2.0/bin/gfortran",
-                            "fc": "/opt/cray/pe/gcc/12.2.0/bin/gfortran",
+                            "cc": "/opt/cray/pe/gcc/13.3.1/bin/gcc",
+                            "cxx": "/opt/cray/pe/gcc/13.3.1/bin/g++",
+                            "f77": "/opt/cray/pe/gcc/13.3.1/bin/gfortran",
+                            "fc": "/opt/cray/pe/gcc/13.3.1/bin/gfortran",
                         },
                         "flags": {},
                         "operating_system": "rhel8",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -86,7 +86,7 @@ class LlnlElcapitan(System):
         else:
             if self.rocm_version >= Version("6.0.0"):
                 self.cce_version = Version("19.0.0")
-                self.mpi_version = Version("8.1.31")
+                self.mpi_version = Version("8.1.32")
             else:
                 self.cce_version = Version("16.0.0")
                 self.mpi_version = Version("8.1.26")


### PR DESCRIPTION
## Description

- [ ] CORAL2 defaults changed 05/16/25
```
The default compiler has changed from cce/18.0.1 (which uses gcc/12.2.1 headers) to cce/19.0.0 (which uses gcc/13.3.1 headers).   
The default rocm has changed from rocm/6.3.1 (which uses gcc/12.2.1 headers) to rocm/6.4.0 (uses gcc/13.3.1 headers).
The default gcc (in /usr/tce/bin) has changed from gcc/12.2.1 to gcc/13.3.1 to match the new default gcc for cce/19.
```