### PR TITLE
Add amg2023 for CUDA Tests

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -42,7 +42,7 @@ include:
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
         SCHEDULER_PARAMETERS: -nnodes 1 -W 20 -q pci
-        BENCHMARK: [babelstream, kripke, lammps, osu-micro-benchmarks]
+        BENCHMARK: [amg2023, babelstream, kripke, lammps, osu-micro-benchmarks]
         VARIANT: [+cuda]
         DASHBOARD_NAME: Nightly [benchpark-develop]
 nightly_test_run:

--- a/.gitlab/tests/test.yml
+++ b/.gitlab/tests/test.yml
@@ -31,7 +31,7 @@ workflow:
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
         SCHEDULER_PARAMETERS: -nnodes 1 -W 20 -q pci
-        BENCHMARK: [kripke]
+        BENCHMARK: [amg2023, kripke]
         VARIANT: [+cuda]
         DASHBOARD_NAME: Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system
           llnl-sierra]


### PR DESCRIPTION
## Description

- [x] Passes as of https://github.com/LLNL/benchpark/pull/764

## Adding/modifying core functionality, CI, or documentation:

- [x] Update gitlab tests to add amg2023 for lassen
