### PR TITLE
Remove hardcoded python spack spec path in llnl-cluster

### DIFF
--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -141,10 +141,6 @@ class LlnlCluster(System):
                             "spec": "python@3.9.12+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
                             "prefix": "/usr/tce",
                         },
-                        {
-                            "spec": "python@3.12.8+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl+tix+tkinter+uuid+zlib",
-                            "prefix": "/usr/workspace/wsa/mckinsey/venv/benchpark-3.12.8",
-                        },
                     ],
                     "buildable": False,
                 },


### PR DESCRIPTION
Remove hardcoded python spack spec path in llnl-cluster

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Add/modify `systems/system_name/system.py` file