### PR TITLE
[WIP] Kripke: Fix CUDA version

### DIFF
--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -134,17 +134,17 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
             # Ensure build with hip is disabled
             args.append("-DENABLE_HIP=OFF")
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("-DENABLE_CUDA=ON")
             args.append(self.define("CMAKE_CUDA_HOST_COMPILER", self.spec["mpi"].mpicxx))
             if not spec.satisfies("cuda_arch=none"):
                 cuda_arch = spec.variants["cuda_arch"].value
                 args.append("-DCUDA_ARCH={0}".format(cuda_arch[0]))
                 args.append("-DCMAKE_CUDA_ARCHITECTURES={0}".format(cuda_arch[0]))
-            args.append(
-                "-DCMAKE_CUDA_FLAGS=--extended-lambda -I%s -I=%s"
-                % (self.spec["cub"].prefix.include, self.spec["mpi"].prefix.include)
-            )
+                args.append(
+                    "-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I%s -I=%s"
+                    % (self.spec["cub"].prefix.include, self.spec["mpi"].prefix.include)
+                )
         else:
             args.append("-DENABLE_CUDA=OFF")
 

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -142,8 +142,8 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
                 args.append("-DCUDA_ARCH={0}".format(cuda_arch[0]))
                 args.append("-DCMAKE_CUDA_ARCHITECTURES={0}".format(cuda_arch[0]))
                 args.append(
-                    "-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I%s -I=%s"
-                    % (self.spec["cub"].prefix.include, self.spec["mpi"].prefix.include)
+                    "-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I=%s"
+                    % (self.spec["mpi"].prefix.include)
                 )
         else:
             args.append("-DENABLE_CUDA=OFF")

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -134,17 +134,17 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
             # Ensure build with hip is disabled
             args.append("-DENABLE_HIP=OFF")
 
-        if spec.satisfies("+cuda"):
+        if "+cuda" in spec:
             args.append("-DENABLE_CUDA=ON")
             args.append(self.define("CMAKE_CUDA_HOST_COMPILER", self.spec["mpi"].mpicxx))
             if not spec.satisfies("cuda_arch=none"):
                 cuda_arch = spec.variants["cuda_arch"].value
                 args.append("-DCUDA_ARCH={0}".format(cuda_arch[0]))
                 args.append("-DCMAKE_CUDA_ARCHITECTURES={0}".format(cuda_arch[0]))
-                args.append(
-                    "-DCMAKE_CUDA_FLAGS=--expt-extended-lambda -I=%s"
-                    % (self.spec["mpi"].prefix.include)
-                )
+            args.append(
+                "-DCMAKE_CUDA_FLAGS=--extended-lambda -I=%s"
+                % (self.spec["mpi"].prefix.include)
+            )
         else:
             args.append("-DENABLE_CUDA=OFF")
 

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -53,20 +53,14 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     variant("openmp", default=False, description="Build with OpenMP enabled.")
     variant("caliper", default=False, description="Build with Caliper support enabled.")
 
-    depends_on('chai@2024.02', when='@develop')
+    depends_on("chai@2024.07.0+raja", when="@develop")
+    depends_on("fmt@9.1", when=f"^chai@2024.07.0")
 
     depends_on("mpi", when="+mpi")
     depends_on("chai+mpi", when="+mpi")
     depends_on("caliper", when="+caliper")
     depends_on("adiak@0.4:", when="+caliper")
     conflicts("^blt@:0.3.6", when="+rocm")
-
-    aligned_versions = ["2024.02"]
-    for v in aligned_versions:
-      depends_on(f"raja@{v}~exercises~examples", when=f"^chai@{v}")
-      depends_on(f"umpire@{v}~examples", when=f"^chai@{v}")
-      depends_on(f"chai@{v}~examples+raja", when=f"^chai@{v}")
-      depends_on(f"camp@{v}", when=f"^chai@{v}")
 
     depends_on("blt@0.6.2:", type="build", when=f"@1.2.7:")
 


### PR DESCRIPTION
- [X] Kripke on lassen broken after spack update (https://github.com/LLNL/benchpark/pull/762) https://lc.llnl.gov/gitlab/benchpark/benchpark/-/jobs/2622868
- [x] `cub` no longer showing as dependency of `camp`, so removing `cub` prefix include in `kripke/package.py` fixes the build. ~Still unknown why dependency dissapeared in the first place.~ Gone because of this change https://github.com/spack/spack/commit/c213a8c2a727e494b2f5ebc1c17e22b239312738 which happened as a result of #762, so this is expected.
- [x] why is kripke being built with gcc in CI? `kripke@develop%gcc@8.3.1` instead of `kripke@develop%clang@16.0.6-ibm-cuda-11.8.0-gcc-11.2.1`
   - caused by `software_install_requested_compilers` ramble phase, need to disable this phase 