### PR TITLE
Add checkout-versions.yaml to yaml check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
               - 'var/**'
               - 'pyproject.toml'
               - '.flake8'
+              - 'checkout-versions.yaml'
             run:
               - 'bin/**'
               - 'configs/**'

--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 versions:
   ramble: 6b4ecac  # develop on 5/06/2025 (newer than 0.6.0 release)
-  spack: 7e4b8aa   # develop on 2/22/2025 (pre-breaking changes on 1.0)
+  spack: 7e4b8aa  # develop on 2/22/2025 (pre-breaking changes on 1.0)


### PR DESCRIPTION
## Description

- [x] https://github.com/LLNL/benchpark/pull/778 Made a change that should have failed lint, but didn't because `checkout-versions.yaml` was not included in the paths to check for the CI `style` check.