### PR TITLE
Proposed Changes for Benchpark Docs

### DIFF
--- a/docs/for-the-impatient.rst
+++ b/docs/for-the-impatient.rst
@@ -13,6 +13,10 @@ You need git and Python 3.8+::
    cd benchpark
    . setup-env.sh
    benchpark --version
+   
+   python3 -m venv my-env
+   . my-env/bin/activate
+   
    pip install -r requirements.txt
 
 --------------------------------

--- a/docs/llnl-tutorial.rst
+++ b/docs/llnl-tutorial.rst
@@ -14,12 +14,25 @@ Running on an LLNL System
 This tutorial will guide you through the process of using Benchpark on LLNL
 systems. 
 
-To run Benchpark, you will need to install its requirements: go to the
-Benchpark root directory::
+To run Benchpark, you will need to install its requirements:
 
-    python -m venv my-env
-    . my-env/bin/activate
-    pip install -r requirements.txt
+1) Clone LLNL/Benchpark offical repo
+
+You need git and Python 3.8+::
+    
+   git clone https://github.com/LLNL/benchpark.git
+   cd benchpark
+   . setup-env.sh
+   benchpark --version
+
+
+2) Install Dependencies
+
+Create virtual env. and install dependencies::
+
+   python3 -m venv my-env
+   . my-env/bin/activate
+   pip install -r requirements.txt
 
 ------------------------
 CTS (Ruby, Dane, Magma)
@@ -48,7 +61,7 @@ Run the setup script for dependency software, Ramble and Spack::
 
 Then setup the Ramble experiment workspace, this builds all software and may take some time::
 
-    cd ./workspace/amg2023-benchmark/Cts-6d48f81/workspace/
+    cd ./workspace/amg2023-benchmark/ruby-system/workspace/
     ramble --workspace-dir . --disable-progress-bar workspace setup
 
 Next, we run the AMG2023 experiments, which will launch jobs through the

--- a/docs/llnl-tutorial.rst
+++ b/docs/llnl-tutorial.rst
@@ -16,7 +16,7 @@ systems.
 
 To run Benchpark, you will need to install its requirements:
 
-1) Clone LLNL/Benchpark offical repo
+1) Clone LLNL/Benchpark official repo
 
 You need git and Python 3.8+::
     


### PR DESCRIPTION
## Description

This PR tends to introduce some minor changes for a more easier and smooth setup for Benchpark on LLNL systems.

Fixes #779 

Summary for the proposed changes:
1. Added repo cloning step for the "Default Path" in the docs
2. Added `. setup-env.sh` step execution for the "Default Path" flow in the docs.
3. Fixed a command that leads to "No such file or directory" error
4. Changed to use `python3` instead of `python` that does not work on Ruby cluster
5. Added steps for setting up virtual environment for the "Impatient Path" flow in the docs