### PR TITLE
Clone From Local Bootstrap to Speedup `benchpark setup`

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -895,4 +895,4 @@ jobs:
           pip install -r ./requirements.txt
       - name: Run
         run: |-
-          python -m pytest
+          ./bin/benchpark unit-test

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -13,7 +13,8 @@ import benchpark.repo
 
 from benchpark.runtime import RuntimeResources
 
-RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper.bootstrap()  # noqa
 
 import ramble.config as cfg  # noqa
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -8,13 +8,7 @@ import pathlib
 import re
 import sys
 
-import benchpark.paths
 import benchpark.repo
-
-from benchpark.runtime import RuntimeResources
-
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
 
 import ramble.config as cfg  # noqa
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -13,7 +13,7 @@ import benchpark.repo
 
 from benchpark.runtime import RuntimeResources
 
-benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+RuntimeResources(benchpark.paths.benchpark_home)
 
 import ramble.config as cfg  # noqa
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -13,8 +13,7 @@ import benchpark.repo
 
 from benchpark.runtime import RuntimeResources
 
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
+benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 
 import ramble.config as cfg  # noqa
 

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -142,7 +142,9 @@ def command(args):
     initializer_script = experiments_root / "setup.sh"
     run_script = experiments_root / ".latest-experiment.sh"
 
-    per_workspace_setup = RuntimeResources(experiments_root)
+    per_workspace_setup = RuntimeResources(
+        experiments_root, upstream=RuntimeResources(benchpark.paths.benchpark_home)
+    )
 
     # Parse experiment YAML for package_manager
     def find(d, tag):

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -15,7 +15,6 @@ import ruamel.yaml as yaml
 import benchpark.paths
 from benchpark.debug import debug_print
 from benchpark.runtime import RuntimeResources
-import benchpark.system
 
 
 # Note: it would be nice to vendor spack.llnl.util.link_tree, but that

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -16,7 +16,8 @@ import benchpark.repo
 import benchpark.runtime
 import benchpark.variant
 
-benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper.bootstrap()
 
 import ramble.language.language_base  # noqa
 import ramble.language.language_helpers  # noqa

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -11,13 +11,7 @@ from benchpark.error import BenchparkError
 from benchpark.directives import ExperimentSystemBase
 from benchpark.directives import variant
 import benchpark.spec
-import benchpark.paths
-import benchpark.repo
-import benchpark.runtime
 import benchpark.variant
-
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
-bootstrapper.bootstrap()
 
 import ramble.language.language_base  # noqa
 import ramble.language.language_helpers  # noqa

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -16,8 +16,7 @@ import benchpark.repo
 import benchpark.runtime
 import benchpark.variant
 
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
-bootstrapper.bootstrap()
+benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 
 import ramble.language.language_base  # noqa
 import ramble.language.language_helpers  # noqa

--- a/lib/benchpark/paths.py
+++ b/lib/benchpark/paths.py
@@ -20,3 +20,5 @@ benchpark_home = pathlib.Path(os.path.expanduser("~/.benchpark"))
 global_ramble_path = benchpark_home / "ramble"
 global_spack_path = benchpark_home / "spack"
 hardware_descriptions = benchpark_root / "systems" / "all_hardware_descriptions"
+checkout_versions = benchpark_root / "checkout-versions.yaml"
+remote_urls = benchpark_root / "remote-urls.yaml"

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -14,10 +14,7 @@ import benchpark.runtime
 
 # isort: off
 
-bootstrapper = benchpark.runtime.RuntimeResources(
-    benchpark.paths.benchpark_home
-)  # noqa
-bootstrapper.bootstrap()  # noqa
+benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 
 import llnl.util.lang  # noqa
 import ramble.language.language_base  # noqa

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -10,14 +10,8 @@ import sys
 from enum import Enum
 
 import benchpark.paths
-import benchpark.runtime
 
 # isort: off
-
-bootstrapper = benchpark.runtime.RuntimeResources(
-    benchpark.paths.benchpark_home
-)  # noqa
-bootstrapper.bootstrap()  # noqa
 
 import llnl.util.lang  # noqa
 import ramble.language.language_base  # noqa

--- a/lib/benchpark/repo.py
+++ b/lib/benchpark/repo.py
@@ -14,7 +14,10 @@ import benchpark.runtime
 
 # isort: off
 
-benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = benchpark.runtime.RuntimeResources(
+    benchpark.paths.benchpark_home
+)  # noqa
+bootstrapper.bootstrap()  # noqa
 
 import llnl.util.lang  # noqa
 import ramble.language.language_base  # noqa

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -64,9 +64,13 @@ class Command:
 
 
 class RuntimeResources:
-    def __init__(self, dest):
+    def __init__(self, dest, upstream=None):
         self.root = benchpark.paths.benchpark_root
         self.dest = pathlib.Path(dest)
+        self.upstream = upstream
+
+        self.ramble_location = self.dest / "ramble"
+        self.spack_location = self.dest / "spack"
 
         checkout_versions_location = self.root / "checkout-versions.yaml"
         with open(checkout_versions_location, "r") as yaml_file:
@@ -74,8 +78,9 @@ class RuntimeResources:
             self.ramble_commit = data["versions"]["ramble"]
             self.spack_commit = data["versions"]["spack"]
 
-        self.ramble_location = self.dest / "ramble"
-        self.spack_location = self.dest / "spack"
+        # If instance does not have an upstream, it is the upstream
+        if not self.upstream:
+            self.bootstrap()
 
     def update_old_bootstrap(self, desired_commit, location):
         # Store first 7 of hash in checkout-versions.yaml

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -83,7 +83,7 @@ class RuntimeResources:
             remote_ramble_url = data["urls"]["ramble"]
             remote_spack_url = data["urls"]["spack"]
 
-        # If instance does not have an upstream, it is the upstream
+        # If this does not have an upstream, then we will be cloning from the URLs indicated in remote-urls.yaml
         if self.upstream is None:
             self.ramble_url = remote_ramble_url
             self.spack_url = remote_spack_url

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -84,7 +84,7 @@ class RuntimeResources:
             self.spack_url = data["urls"]["spack"]
 
         # If instance does not have an upstream, it is the upstream
-        if not self.upstream:
+        if self.upstream is None:
             self.bootstrap()
 
     def _check_and_update_bootstrap(self, desired_commit, location):
@@ -124,7 +124,7 @@ class RuntimeResources:
         git_clone_commit(
             (
                 self.ramble_url
-                if not self.upstream
+                if self.upstream is None
                 else self.upstream.ramble_location  # Clone from local "upstream" repository
             ),
             self.ramble_commit,
@@ -137,7 +137,7 @@ class RuntimeResources:
         git_clone_commit(
             (
                 self.spack_url
-                if not self.upstream
+                if self.upstream is None
                 else self.upstream.spack_location  # Clone from local "upstream" repository
             ),
             self.spack_commit,

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -86,7 +86,6 @@ class RuntimeResources:
         # If this does not have an upstream, then we will be cloning from the URLs indicated in remote-urls.yaml
         if self.upstream is None:
             self.ramble_url, self.spack_url = remote_ramble_url, remote_spack_url
-            self.bootstrap()
         else:
             # Clone from local "upstream" repository
             self.ramble_url, self.spack_url = (

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -46,7 +46,7 @@ def run_command(command_str, env=None, stdout=None, stderr=None):
     out, err = proc.communicate()
     if proc.returncode != 0:
         raise RuntimeError(
-            f"Failed command: {command_str}\nOutput: {stdout}\nError: {stderr}"
+            f"Failed command: {command_str}\nOutput: {out}\nError: {err}"
         )
 
     return (out, err)

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -68,30 +68,31 @@ class RuntimeResources:
         self.dest = pathlib.Path(dest)
         self.upstream = upstream
 
-        self.ramble_location = self.dest / "ramble"
-        self.spack_location = self.dest / "spack"
+        self.ramble_location, self.spack_location = (
+            self.dest / "ramble",
+            self.dest / "spack",
+        )
 
         # Read pinned versions of ramble and spack
         with open(benchpark.paths.checkout_versions, "r") as yaml_file:
-            data = yaml.safe_load(yaml_file)
-            self.ramble_commit = data["versions"]["ramble"]
-            self.spack_commit = data["versions"]["spack"]
+            data = yaml.safe_load(yaml_file)["versions"]
+            self.ramble_commit, self.spack_commit = data["ramble"], data["spack"]
 
         # Read remote urls for ramble and spack
         with open(benchpark.paths.remote_urls, "r") as yaml_file:
-            data = yaml.safe_load(yaml_file)
-            remote_ramble_url = data["urls"]["ramble"]
-            remote_spack_url = data["urls"]["spack"]
+            data = yaml.safe_load(yaml_file)["urls"]
+            remote_ramble_url, remote_spack_url = data["ramble"], data["spack"]
 
         # If this does not have an upstream, then we will be cloning from the URLs indicated in remote-urls.yaml
         if self.upstream is None:
-            self.ramble_url = remote_ramble_url
-            self.spack_url = remote_spack_url
+            self.ramble_url, self.spack_url = remote_ramble_url, remote_spack_url
             self.bootstrap()
         else:
             # Clone from local "upstream" repository
-            self.ramble_url = self.upstream.ramble_location
-            self.spack_url = self.upstream.spack_location
+            self.ramble_url, self.spack_url = (
+                self.upstream.ramble_location,
+                self.upstream.spack_location,
+            )
 
     def _check_and_update_bootstrap(self, desired_commit, location):
         with working_dir(location):

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -88,8 +88,8 @@ class RuntimeResources:
             self.bootstrap()
 
     def _check_and_update_bootstrap(self, desired_commit, location):
-        # Store first 7 of hash in checkout-versions.yaml
         with working_dir(location):
+            # length of hash is 7 in checkout-versions.yaml
             current_commit = run_command("git rev-parse HEAD")[0].strip()[:7]
             if current_commit != desired_commit:
                 run_command("git fetch --all")

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -65,24 +65,29 @@ class Command:
 
 class RuntimeResources:
     def __init__(self, dest, upstream=None):
-        self.root = benchpark.paths.benchpark_root
         self.dest = pathlib.Path(dest)
         self.upstream = upstream
 
         self.ramble_location = self.dest / "ramble"
         self.spack_location = self.dest / "spack"
 
-        checkout_versions_location = self.root / "checkout-versions.yaml"
-        with open(checkout_versions_location, "r") as yaml_file:
+        # Read pinned versions of ramble and spack
+        with open(benchpark.paths.checkout_versions, "r") as yaml_file:
             data = yaml.safe_load(yaml_file)
             self.ramble_commit = data["versions"]["ramble"]
             self.spack_commit = data["versions"]["spack"]
+
+        # Read remote urls for ramble and spack
+        with open(benchpark.paths.remote_urls, "r") as yaml_file:
+            data = yaml.safe_load(yaml_file)
+            self.ramble_url = data["urls"]["ramble"]
+            self.spack_url = data["urls"]["spack"]
 
         # If instance does not have an upstream, it is the upstream
         if not self.upstream:
             self.bootstrap()
 
-    def update_old_bootstrap(self, desired_commit, location):
+    def _check_and_update_bootstrap(self, desired_commit, location):
         # Store first 7 of hash in checkout-versions.yaml
         with working_dir(location):
             current_commit = run_command("git rev-parse HEAD")[0].strip()[:7]
@@ -95,9 +100,9 @@ class RuntimeResources:
 
     def bootstrap(self):
         if not self.ramble_location.exists():
-            self._install_ramble(bootstrap=True)
+            self._install_ramble()
         else:
-            self.update_old_bootstrap(self.ramble_commit, self.ramble_location)
+            self._check_and_update_bootstrap(self.ramble_commit, self.ramble_location)
         ramble_lib_path = self.ramble_location / "lib" / "ramble"
         externals = str(ramble_lib_path / "external")
         if externals not in sys.path:
@@ -110,30 +115,30 @@ class RuntimeResources:
         # The reason for this oddity is that spack modules will compete with the internal
         # spack modules from ramble
         if not self.spack_location.exists():
-            self._install_spack(bootstrap=True)
+            self._install_spack()
         else:
-            self.update_old_bootstrap(self.spack_commit, self.spack_location)
+            self._check_and_update_bootstrap(self.spack_commit, self.spack_location)
 
-    def _install_ramble(self, bootstrap=False):
+    def _install_ramble(self):
         print(f"Cloning Ramble to {self.ramble_location}")
         git_clone_commit(
             (
-                "https://github.com/GoogleCloudPlatform/ramble.git"
-                if bootstrap
-                else benchpark.paths.benchpark_home / "ramble"
+                self.ramble_url
+                if not self.upstream
+                else self.upstream.ramble_location  # Clone from local "upstream" repository
             ),
             self.ramble_commit,
             self.ramble_location,
         )
         debug_print(f"Done cloning Ramble ({self.ramble_location})")
 
-    def _install_spack(self, bootstrap=False):
+    def _install_spack(self):
         print(f"Cloning Spack to {self.spack_location}")
         git_clone_commit(
             (
-                "https://github.com/spack/spack.git"
-                if bootstrap
-                else benchpark.paths.benchpark_home / "spack"
+                self.spack_url
+                if not self.upstream
+                else self.upstream.spack_location  # Clone from local "upstream" repository
             ),
             self.spack_commit,
             self.spack_location,

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -90,7 +90,7 @@ class RuntimeResources:
 
     def bootstrap(self):
         if not self.ramble_location.exists():
-            self._install_ramble()
+            self._install_ramble(bootstrap=True)
         else:
             self.update_old_bootstrap(self.ramble_commit, self.ramble_location)
         ramble_lib_path = self.ramble_location / "lib" / "ramble"
@@ -105,23 +105,33 @@ class RuntimeResources:
         # The reason for this oddity is that spack modules will compete with the internal
         # spack modules from ramble
         if not self.spack_location.exists():
-            self._install_spack()
+            self._install_spack(bootstrap=True)
         else:
             self.update_old_bootstrap(self.spack_commit, self.spack_location)
 
-    def _install_ramble(self):
+    def _install_ramble(self, bootstrap=False):
         print(f"Cloning Ramble to {self.ramble_location}")
         git_clone_commit(
-            "https://github.com/GoogleCloudPlatform/ramble.git",
+            (
+                "https://github.com/GoogleCloudPlatform/ramble.git"
+                if bootstrap
+                else benchpark.paths.benchpark_home / "ramble"
+            ),
             self.ramble_commit,
             self.ramble_location,
         )
         debug_print(f"Done cloning Ramble ({self.ramble_location})")
 
-    def _install_spack(self):
+    def _install_spack(self, bootstrap=False):
         print(f"Cloning Spack to {self.spack_location}")
         git_clone_commit(
-            "https://github.com/spack/spack.git", self.spack_commit, self.spack_location
+            (
+                "https://github.com/spack/spack.git"
+                if bootstrap
+                else benchpark.paths.benchpark_home / "spack"
+            ),
+            self.spack_commit,
+            self.spack_location,
         )
         debug_print(f"Done cloning Spack ({self.spack_location})")
 

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -80,12 +80,18 @@ class RuntimeResources:
         # Read remote urls for ramble and spack
         with open(benchpark.paths.remote_urls, "r") as yaml_file:
             data = yaml.safe_load(yaml_file)
-            self.ramble_url = data["urls"]["ramble"]
-            self.spack_url = data["urls"]["spack"]
+            remote_ramble_url = data["urls"]["ramble"]
+            remote_spack_url = data["urls"]["spack"]
 
         # If instance does not have an upstream, it is the upstream
         if self.upstream is None:
+            self.ramble_url = remote_ramble_url
+            self.spack_url = remote_spack_url
             self.bootstrap()
+        else:
+            # Clone from local "upstream" repository
+            self.ramble_url = self.upstream.ramble_location
+            self.spack_url = self.upstream.spack_location
 
     def _check_and_update_bootstrap(self, desired_commit, location):
         with working_dir(location):
@@ -122,11 +128,7 @@ class RuntimeResources:
     def _install_ramble(self):
         print(f"Cloning Ramble to {self.ramble_location}")
         git_clone_commit(
-            (
-                self.ramble_url
-                if self.upstream is None
-                else self.upstream.ramble_location  # Clone from local "upstream" repository
-            ),
+            self.ramble_url,
             self.ramble_commit,
             self.ramble_location,
         )
@@ -135,11 +137,7 @@ class RuntimeResources:
     def _install_spack(self):
         print(f"Cloning Spack to {self.spack_location}")
         git_clone_commit(
-            (
-                self.spack_url
-                if self.upstream is None
-                else self.upstream.spack_location  # Clone from local "upstream" repository
-            ),
+            self.spack_url,
             self.spack_commit,
             self.spack_location,
         )

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -17,7 +17,8 @@ import benchpark.paths
 import benchpark.repo
 import benchpark.runtime
 
-benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper.bootstrap()
 
 import llnl.util.lang  # noqa
 

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -13,12 +13,7 @@ import re
 from typing import Iterable, Iterator, List, Match, Optional, Union
 
 from benchpark.error import BenchparkError
-import benchpark.paths
 import benchpark.repo
-import benchpark.runtime
-
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
-bootstrapper.bootstrap()
 
 import llnl.util.lang  # noqa
 

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -17,8 +17,7 @@ import benchpark.paths
 import benchpark.repo
 import benchpark.runtime
 
-bootstrapper = benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
-bootstrapper.bootstrap()
+benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 
 import llnl.util.lang  # noqa
 

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -7,20 +7,11 @@ import hashlib
 import os
 import packaging.version
 import yaml
-
-import benchpark.paths
-from benchpark.directives import ExperimentSystemBase
-import benchpark.repo
-from benchpark.runtime import RuntimeResources
-
 from typing import Dict, Tuple
+
+from benchpark.directives import ExperimentSystemBase
 import benchpark.spec
 import benchpark.variant
-
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
-
-_repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 
 
 def _hash_id(content_list):

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -17,7 +17,7 @@ from typing import Dict, Tuple
 import benchpark.spec
 import benchpark.variant
 
-benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
+RuntimeResources(benchpark.paths.benchpark_home)
 
 _repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -17,7 +17,8 @@ from typing import Dict, Tuple
 import benchpark.spec
 import benchpark.variant
 
-RuntimeResources(benchpark.paths.benchpark_home)
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper.bootstrap()  # noqa
 
 _repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -17,8 +17,7 @@ from typing import Dict, Tuple
 import benchpark.spec
 import benchpark.variant
 
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
+benchpark.runtime.RuntimeResources(benchpark.paths.benchpark_home)
 
 _repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -40,7 +40,7 @@ if "-h" == sys.argv[1] or "--help" == sys.argv[1]:
     exit()
 
 import benchpark.paths  # noqa: E402
-from benchpark.runtime import RuntimeResources
+from benchpark.runtime import RuntimeResources  # noqa: E402
 
 bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
 bootstrapper.bootstrap()  # noqa

--- a/lib/main.py
+++ b/lib/main.py
@@ -39,6 +39,12 @@ if "-h" == sys.argv[1] or "--help" == sys.argv[1]:
     print(helpstr)
     exit()
 
+import benchpark.paths  # noqa: E402
+from benchpark.runtime import RuntimeResources
+
+bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
+bootstrapper.bootstrap()  # noqa
+
 import benchpark.cmd.audit  # noqa: E402
 import benchpark.cmd.system  # noqa: E402
 import benchpark.cmd.experiment  # noqa: E402
@@ -48,7 +54,6 @@ import benchpark.cmd.unit_test  # noqa: E402
 import benchpark.cmd.mirror  # noqa: E402
 import benchpark.cmd.info  # noqa: E402
 import benchpark.cmd.list  # noqa: E402
-import benchpark.paths  # noqa: E402
 from benchpark.accounting import benchpark_benchmarks  # noqa: E402
 
 try:

--- a/remote-urls.yaml
+++ b/remote-urls.yaml
@@ -1,0 +1,7 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+urls:
+  ramble: "https://github.com/GoogleCloudPlatform/ramble.git"
+  spack: "https://github.com/spack/spack.git"

--- a/remote-urls.yaml
+++ b/remote-urls.yaml
@@ -3,5 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 urls:
-  ramble: "https://github.com/GoogleCloudPlatform/ramble.git"
-  spack: "https://github.com/spack/spack.git"
+  ramble: https://github.com/GoogleCloudPlatform/ramble.git
+  spack: https://github.com/spack/spack.git


### PR DESCRIPTION
## Description

- [x] Instead of cloning from the internet, clone from local bootstrap for benchpark workspaces.
- [x] Enable setting an upstream in `RuntimeResources`, explicitly connecting the bootstrapped spack/ramble and workspace spack/ramble.
   - [x] Upstream set in `benchpark setup ...` (`setup.py`, when benchpark workspace is created, so bootstrap created by previous command no longer required, as it will be created here if it does not exist.
   - [x] Use upstream to bootstrap (if instance does not have an upstream bootstrapping will occur).
   - [x] Upstream uses remote url for clone, "origin" uses local upstream repository to clone.
- [x] Refactor remote urls logically similar to hash versions. 

## Cloning Performance improvement

local performance ~8x
```
develop - benchpark setup ...
real    0m55.378s
user    0m25.981s
sys     0m20.266s

#784 - benchpark setup ...
real    0m7.611s
user    0m4.146s
sys     0m5.958s
```

dane performance ~2x
```
develop - benchpark setup ...
real    4m33.224s
user    0m50.784s
sys     0m23.990s

#784 - benchpark setup ...
real    2m14.887s
user    0m4.101s
sys     0m9.247s
```

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `lib/benchpark/runtime.py`
