### PR TITLE
Adds file and line number info to debug statements

### DIFF
--- a/lib/benchpark/debug.py
+++ b/lib/benchpark/debug.py
@@ -3,9 +3,26 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+from inspect import currentframe, getframeinfo
+
 DEBUG = False
+
+
+def get_linenumber():
+    cf = currentframe()
+    return cf.f_back.f_back.f_lineno
+
+
+def get_filename():
+    cf = currentframe()
+    return os.path.basename(getframeinfo(cf.f_back).filename)
 
 
 def debug_print(message):
     if DEBUG:
-        print("(debug) " + str(message))
+        print(
+            "(debug) " + get_filename() + "::" + str(get_linenumber()) + " " + message,
+            file=sys.stderr,
+        )

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -13,13 +13,7 @@ import sys
 import yaml
 
 import benchpark.paths
-
-DEBUG = False
-
-
-def debug_print(message):
-    if DEBUG:
-        print("(debug) " + str(message))
+from benchpark.debug import debug_print
 
 
 @contextmanager


### PR DESCRIPTION
## Description

e.g.,

(debug) benchpark::72 Hello, world!

Fixes https://github.com/LLNL/benchpark/issues/232

```
$ benchpark setup kripke lassen wkp
(debug) debug.py::78 source_dir = /Users/mckinsey1/Documents/repos/benchpark
(debug) debug.py::79 specified experiment = kripke
(debug) debug.py::80 specified system = lassen
Setting up configs for Ramble workspace /Users/mckinsey1/Documents/repos/benchpark/wkp/kripke/lassen/workspace/configs
Cloning Spack to /Users/mckinsey1/Documents/repos/benchpark/wkp/spack
(debug) debug.py::145 Done cloning Spack (/Users/mckinsey1/Documents/repos/benchpark/wkp/spack)
Cloning Ramble to /Users/mckinsey1/Documents/repos/benchpark/wkp/ramble
(debug) debug.py::132 Done cloning Ramble (/Users/mckinsey1/Documents/repos/benchpark/wkp/ramble)
To complete the benchpark setup, do the following:

    . /Users/mckinsey1/Documents/repos/benchpark/wkp/setup.sh

Further steps are needed to build the experiments (ramble --disable-progress-bar --workspace-dir /Users/mckinsey1/Documents/repos/benchpark/wkp/kripke/lassen/workspace workspace setup) and run them (ramble --disable-progress-bar --workspace-dir /Users/mckinsey1/Documents/repos/benchpark/wkp/kripke/lassen/workspace on)
```