### PR TITLE
Prevent Allocation of OS Reserved Cores

### DIFF
--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -43,6 +43,8 @@ class System(ExperimentSystemBase):
         self.external_resources = None
 
         self.sys_cores_per_node = None
+        self.sys_cores_os_reserved = None
+        self.sys_cores_os_reserved_list = None
         self.sys_gpus_per_node = None
         self.sys_mem_per_node = None
         self.scheduler = None
@@ -112,7 +114,13 @@ class System(ExperimentSystemBase):
                 raise ValueError(f"Missing required info: {attr}")
 
         optionals = {}
-        for opt in ["sys_gpus_per_node", "sys_mem_per_node", "queue"]:
+        for opt in [
+            "sys_cores_os_reserved",
+            "sys_cores_os_reserved_list",
+            "sys_gpus_per_node",
+            "sys_mem_per_node",
+            "queue",
+        ]:
             if getattr(self, opt, None):
                 optionals[opt] = getattr(self, opt)
 

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -95,14 +95,32 @@ class Caliper(BasicModifier):
 
     def _build_metadata(self, workspace, app_inst):
         """Write the caliper metadata to json"""
+
+        cali_metadata = {}
+
+        # system metadata
+        system_metadata = [
+            "sys_cores_per_node",  # required
+            "scheduler",  # required
+            "rocm_arch",
+            "cuda_arch",
+            "sys_cores_os_reserved",
+            "sys_cores_os_reserved_list",
+            "sys_gpus_per_node",
+            "sys_mem_per_node",
+            "system_site",
+        ]
+        for key in system_metadata:
+            # Certain keys not required or may not be present
+            if key in app_inst.variables.keys():
+                cali_metadata[key] = app_inst.variables[key]
+
         # Load the Caliper metadata variable from ramble.yaml
         experiment_metadata = app_inst.expander.expand_var_name(
             "caliper_metadata", typed=True, merge_used_stage=False
         )
         app_inst.expander.flush_used_variable_stage()
-
         # rebuild dictionary with expanded variables
-        cali_metadata = {}
         for key, val in experiment_metadata.items():
             cali_metadata[key] = app_inst.expander.expand_var(val)
 

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -104,8 +104,8 @@ class Caliper(BasicModifier):
             "scheduler",  # required
             "rocm_arch",
             "cuda_arch",
-            "sys_cores_os_reserved",
-            "sys_cores_os_reserved_list",
+            "sys_cores_os_reserved_per_node",
+            "sys_cores_os_reserved_per_node_list",
             "sys_gpus_per_node",
             "sys_mem_per_node",
             "system_site",

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -17,6 +17,8 @@ class LlnlCluster(System):
     id_to_resources = {
         "ruby": {
             "sys_cores_per_node": 56,
+            "sys_cores_os_reserved_per_node": 0,  # No core or thread reservation
+            "sys_cores_os_reserved_per_node_list": None,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/Supermicro-icelake-OmniPath/hardware_description.yaml",
@@ -29,6 +31,8 @@ class LlnlCluster(System):
         },
         "dane": {
             "sys_cores_per_node": 112,
+            "sys_cores_os_reserved_per_node": 0,  # No explicit core reservation, first thread on each core reserved (2 threads per core)
+            "sys_cores_os_reserved_per_node_list": None,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
             + "/DELL-sapphirerapids-OmniPath/hardware_description.yaml",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -18,7 +18,8 @@ class LlnlElcapitan(System):
     id_to_resources = {
         "tioga": {
             "rocm_arch": "gfx90a",
-            "sys_cores_per_node": 64,
+            "sys_cores_per_node": 56,
+            "sys_cores_os_reserved": 8,
             "sys_gpus_per_node": 8,
             "system_site": "llnl",
             "scheduler": "flux",
@@ -27,7 +28,8 @@ class LlnlElcapitan(System):
         },
         "elcapitan": {
             "rocm_arch": "gfx942",
-            "sys_cores_per_node": 96,
+            "sys_cores_per_node": 84,
+            "sys_cores_os_reserved": 12,
             "sys_gpus_per_node": 4,
             "system_site": "llnl",
             "scheduler": "flux",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -19,7 +19,8 @@ class LlnlElcapitan(System):
         "tioga": {
             "rocm_arch": "gfx90a",
             "sys_cores_per_node": 56,
-            "sys_cores_os_reserved": 8,
+            "sys_cores_os_reserved_per_node": 8,
+            "sys_cores_os_reserved_per_node_list": [0, 8, 16, 24, 32, 40, 48, 56],
             "sys_gpus_per_node": 8,
             "system_site": "llnl",
             "scheduler": "flux",
@@ -29,7 +30,21 @@ class LlnlElcapitan(System):
         "elcapitan": {
             "rocm_arch": "gfx942",
             "sys_cores_per_node": 84,
-            "sys_cores_os_reserved": 12,
+            "sys_cores_os_reserved_per_node": 12,
+            "sys_cores_os_reserved_per_node_list": [
+                0,
+                8,
+                16,
+                24,
+                32,
+                40,
+                48,
+                56,
+                64,
+                72,
+                80,
+                88,
+            ],  # 3 cores reserved per socket
             "sys_gpus_per_node": 4,
             "system_site": "llnl",
             "scheduler": "flux",

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -17,7 +17,8 @@ class LlnlSierra(System):
     id_to_resources = {
         "lassen": {
             "cuda_arch": 70,
-            "sys_cores_per_node": 44,
+            "sys_cores_per_node": 40,
+            "sys_cores_os_reserved": 4,
             "sys_gpus_per_node": 4,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -19,6 +19,7 @@ class LlnlSierra(System):
             "cuda_arch": 70,
             "sys_cores_per_node": 40,
             "sys_cores_os_reserved": 4,
+            "sys_cores_os_reserved_list": [0, 1],  # First two cores on each socket reserved.
             "sys_gpus_per_node": 4,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -18,8 +18,13 @@ class LlnlSierra(System):
         "lassen": {
             "cuda_arch": 70,
             "sys_cores_per_node": 40,
-            "sys_cores_os_reserved": 4,
-            "sys_cores_os_reserved_list": [0, 1],  # First two cores on each socket reserved.
+            "sys_cores_os_reserved_per_node": 4,
+            "sys_cores_os_reserved_per_node_list": [
+                0,
+                1,
+                22,
+                23,
+            ],  # First two cores on each socket reserved.
             "sys_gpus_per_node": 4,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)


### PR DESCRIPTION
## Description

- [x] Currently, we create job files that allocate all of the hardware cores on a node, which _may_ include OS reserved cores. These cores will not be available for the job, so it will oversubscribe _n_ cores (n OS reserved cores). This change subtracts that amount from `sys_cores_per_node` and provides a new variable for clarity (so user is not confused why there are less cores), `sys_cores_os_reserved_per_node`. Information was verified by checking affinity on each system.
- [x] Add system information to caliper metadata (if applicable)
```
            "sys_cores_per_node",
            "scheduler",
            "rocm_arch",
            "cuda_arch",
            "sys_cores_os_reserved_per_node",
            "sys_cores_os_reserved_per_node_list",
            "sys_gpus_per_node",
            "sys_mem_per_node",
            "system_site",
``` 

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `sys_cores_per_node` and add `sys_cores_os_reserved` in `systems/llnl-*/system.py`.