### PR TITLE
Adds a 'benchpark bootstrap' command to manually trigger bootstrapping

### DIFF
--- a/docs/benchpark-commands.rst
+++ b/docs/benchpark-commands.rst
@@ -49,6 +49,9 @@ Search for available system and experiment specifications in Benchpark.
    * - benchpark info experiment <experiment>
      - Lists all information about a given experiment
      -
+   * - benchpark bootstrap
+     - Manually trigger bootstrapping or update the bootstrap
+     -
 
 Benchpark also has a help menu::
 

--- a/lib/benchpark/cmd/bootstrap.py
+++ b/lib/benchpark/cmd/bootstrap.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import benchpark.paths
+from benchpark.runtime import RuntimeResources
+
+
+def setup_parser(subparser):
+    pass
+
+
+def command(args):
+    bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)
+    bootstrapper.bootstrap()

--- a/lib/main.py
+++ b/lib/main.py
@@ -34,6 +34,7 @@ Subcommands:
     audit               Look for problems in System/Experiment repos
     info                Get information about Systems and Experiments
     list                List experiments, systems, benchmarks, and modifiers
+    bootstrap           Bootstrap benchpark or update an existing bootstrap
     analyze             Perform canned analysis on the performance data (caliper files) after 'ramble on'"""
 if "-h" == sys.argv[1] or "--help" == sys.argv[1]:
     print(helpstr)
@@ -54,6 +55,7 @@ import benchpark.cmd.unit_test  # noqa: E402
 import benchpark.cmd.mirror  # noqa: E402
 import benchpark.cmd.info  # noqa: E402
 import benchpark.cmd.list  # noqa: E402
+import benchpark.cmd.bootstrap  # noqa: E402
 from benchpark.accounting import benchpark_benchmarks  # noqa: E402
 
 try:
@@ -209,6 +211,11 @@ def init_commands(subparsers, actions_dict):
         "list", help="List experiments, systems, benchmarks, and modifiers"
     )
     benchpark.cmd.list.setup_parser(list_parser)
+    
+    bootstrap_parser = subparsers.add_parser(
+        "bootstrap", help="Bootstrap benchpark or update an existing bootstrap"
+    )
+    benchpark.cmd.bootstrap.setup_parser(bootstrap_parser)
 
     analyze_parser = subparsers.add_parser(
         "analyze",
@@ -224,6 +231,7 @@ def init_commands(subparsers, actions_dict):
     actions_dict["info"] = benchpark.cmd.info.command
     actions_dict["show-build"] = benchpark.cmd.show_build.command
     actions_dict["list"] = benchpark.cmd.list.command
+    actions_dict["bootstrap"] = benchpark.cmd.bootstrap.command
     if analyze_installed:
         benchpark.cmd.analyze.setup_parser(analyze_parser)
         actions_dict["analyze"] = benchpark.cmd.analyze.command

--- a/lib/main.py
+++ b/lib/main.py
@@ -211,7 +211,7 @@ def init_commands(subparsers, actions_dict):
         "list", help="List experiments, systems, benchmarks, and modifiers"
     )
     benchpark.cmd.list.setup_parser(list_parser)
-    
+
     bootstrap_parser = subparsers.add_parser(
         "bootstrap", help="Bootstrap benchpark or update an existing bootstrap"
     )


### PR DESCRIPTION
## Description

This PR adds a new `benchpark bootstrap` command that will manually trigger the bootstrapping process for Benchpark. This command can come in handy in certain situations where you do not want the user to have to wait on bootstrapping themselves (e.g., in a Docker container).

## Adding/modifying core functionality, CI, or documentation:

- [x] Update docs
- [ ] Update `.github/workflows` and `.gitlab/tests` unit tests (if needed)
