### PR TITLE
Strong Test Needs to be in Root

### DIFF
--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -29,11 +29,11 @@
     # Analyze Experiments
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json
       yaml text
+    - cd -
     # Benchpark Analyze experiments with "+strong"
     - |
       if [[ "$VARIANT" == *"+strong"* ]]; then
         ./bin/benchpark analyze --workspace-dir .
       fi
     # Check Experiment Exit Codes
-    - cd -
     - python ./.gitlab/bin/exit-codes ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/results.latest.json


### PR DESCRIPTION
## Description

- [x] `.bin/benchpark` doesnt work from ramble workspace, so `cd` back to root
