### PR TITLE
Improve Logs on Gitlab CI for Debugging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ variables:
 # test".  Add protected branches here. See default value in
 # preliminary-ignore-draft-pr.yml.
   ALWAYS_RUN_PATTERN: ^develop$|^master$|^v[0-9.]*$|^releases/$
+  # Expand multi-line commands in logs
+  FF_SCRIPT_SECTIONS: 1
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -1,7 +1,5 @@
 .run_experiment:
   script:
-    # Expand multi-line commands
-    - export FF_SCRIPT_SECTIONS=true
     # Activate Virtual Environment
     - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     - |

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -1,9 +1,10 @@
 .run_experiment:
   script:
+    - set -xv
     # Activate Virtual Environment
     - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     # Initialize System
-    - >
+    - |
       EXTRA_ARGS=""
       if [  "$HOST" != "lassen" ]; then
           EXTRA_ARGS="cluster=$HOST"  # llnl-sierra has no 'cluster'

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -1,6 +1,7 @@
 .run_experiment:
   script:
-    - set -xv
+    # Expand multi-line commands
+    - export FF_SCRIPT_SECTIONS=true
     # Activate Virtual Environment
     - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     - |

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -18,12 +18,12 @@
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
     - ramble --workspace-dir . workspace setup
     # Run Experiments
-    - ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
+    - ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes}
+      == 1'
     # Cat each output file
     - find experiments/ -type f -name "*.out" -exec cat {} +
     # Analyze Experiments
-    - ramble --workspace-dir . workspace analyze --format json
-      yaml text
+    - ramble --workspace-dir . workspace analyze --format json yaml text
     - cd -
     # Benchpark Analyze experiments with "+strong"
     - |

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -22,6 +22,7 @@
     # Run Experiments
     - ramble --workspace-dir . --disable-progress-bar on --executor '{execute_experiment}'
       --where '{n_nodes} == 1'
+    - cat '{experiment_name}.out'
     # Analyze Experiments
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json
       yaml text

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -3,7 +3,7 @@
     # Activate Virtual Environment
     - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     # Initialize System
-    - |
+    - >
       EXTRA_ARGS=""
       if [  "$HOST" != "lassen" ]; then
           EXTRA_ARGS="cluster=$HOST"  # llnl-sierra has no 'cluster'

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -16,14 +16,13 @@
     - . workspace/setup.sh
     # Setup Workspace
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
-    - ramble --workspace-dir . --disable-progress-bar workspace setup
+    - ramble --workspace-dir . workspace setup
     # Run Experiments
-    - |
-      output=$(ramble --workspace-dir . --disable-progress-bar on --executor '{execute_experiment}' --where '{n_nodes} == 1')
-      log_path=$(echo "$output" | grep -oP '^==>\s+\K/.+execute\..+\.out')
-      cat $log_path
+    - ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
+    # Cat each output file
+    - find experiments/ -type f -name "*.out" -exec cat {} +
     # Analyze Experiments
-    - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json
+    - ramble --workspace-dir . workspace analyze --format json
       yaml text
     - cd -
     # Benchpark Analyze experiments with "+strong"

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -18,9 +18,10 @@
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
     - ramble --workspace-dir . --disable-progress-bar workspace setup
     # Run Experiments
-    - ramble --workspace-dir . --disable-progress-bar on --executor '{execute_experiment}'
-      --where '{n_nodes} == 1'
-    - cat '{experiment_name}.out'
+    - |
+      output=$(ramble --workspace-dir . --disable-progress-bar on --executor '{execute_experiment}' --where '{n_nodes} == 1')
+      log_path=$(echo "$output" | grep -oP '^==>\s+\K/.+execute\..+\.out')
+      cat $log_path
     # Analyze Experiments
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json
       yaml text

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -22,9 +22,9 @@
     - . workspace/setup.sh
     # Setup Workspace
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
-    - ramble --workspace-dir . --disable-progress-bar --disable-logger workspace setup
+    - ramble --workspace-dir . --disable-progress-bar workspace setup
     # Run Experiments
-    - ramble --workspace-dir . --disable-progress-bar --disable-logger on --executor
+    - ramble --workspace-dir . --disable-progress-bar on --executor
       '{execute_experiment}' --where '{n_nodes} == 1'
     # Analyze Experiments
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -24,8 +24,8 @@
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
     - ramble --workspace-dir . --disable-progress-bar workspace setup
     # Run Experiments
-    - ramble --workspace-dir . --disable-progress-bar on --executor
-      '{execute_experiment}' --where '{n_nodes} == 1'
+    - ramble --workspace-dir . --disable-progress-bar on --executor '{execute_experiment}'
+      --where '{n_nodes} == 1'
     # Analyze Experiments
     - ramble --workspace-dir . --disable-progress-bar workspace analyze --format json
       yaml text


### PR DESCRIPTION
## Description

- [x] Often it is hard to parse runtime errors from the gitlab logs, so we have to manually run the benchmark to check the error. This PR aims to address this by printing the runtime stdout to the logs.
- [x] Multiline commands are concatenated, which makes issues like https://github.com/LLNL/benchpark/pull/824 hard to debug. Theres an env variable `FF_SCRIPT_SECTIONS`, which enables a dropdown to see the entire block command.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/utils/run-experiment.yml`
