### PR TITLE
Increase CI Time Limits and Switch Ruby Tests to Dane

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -6,7 +6,7 @@ include:
     matrix:
       - HOST: tioga
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
+        SCHEDULER_PARAMETERS: -N 1 -t 60m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
         BENCHMARK:
           - amg2023
           - babelstream
@@ -18,19 +18,19 @@ include:
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive
+        SCHEDULER_PARAMETERS: -N 1 -t 60m --queue=pci --exclusive
         BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: [+rocm]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023, babelstream, kripke, lammps]
         VARIANT: [+openmp]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK:
           - amg2023
           - gpcnet
@@ -47,7 +47,7 @@ include:
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
-        SCHEDULER_PARAMETERS: -nnodes 1 -W 40 -q pci
+        SCHEDULER_PARAMETERS: -nnodes 1 -W 60 -q pci
         BENCHMARK:
           - amg2023
           - babelstream

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -28,7 +28,7 @@ include:
         BENCHMARK: [amg2023, babelstream, kripke, lammps]
         VARIANT: [+openmp]
         DASHBOARD_NAME: Nightly [benchpark-develop]
-      - HOST: ruby
+      - HOST: dane
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK:

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -6,7 +6,7 @@ include:
     matrix:
       - HOST: tioga
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 20m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
+        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
         BENCHMARK:
           - amg2023
           - babelstream
@@ -18,19 +18,19 @@ include:
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 20m --queue=pci --exclusive
+        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive
         BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: [+rocm]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:20:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023, babelstream, kripke, lammps]
         VARIANT: [+openmp]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: ruby
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:20:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK:
           - amg2023
           - gpcnet
@@ -47,7 +47,7 @@ include:
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
-        SCHEDULER_PARAMETERS: -nnodes 1 -W 20 -q pci
+        SCHEDULER_PARAMETERS: -nnodes 1 -W 40 -q pci
         BENCHMARK:
           - amg2023
           - babelstream

--- a/.gitlab/tests/test.yml
+++ b/.gitlab/tests/test.yml
@@ -9,42 +9,42 @@ workflow:
     matrix:
       - HOST: tioga
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 20m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
+        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive  # ref: https://github.com/LLNL/radiuss-shared-ci/blob/main/customization/custom-jobs-and-variables.yml
         BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: [+rocm]
         DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init
           --dest=tioga-system llnl-elcapitan cluster=tioga]
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 20m --queue=pci --exclusive
+        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive
         BENCHMARK: [kripke]
         VARIANT: [+rocm]
         DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
           --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:20:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK: [hpl, hpcg, amg2023, kripke]
         VARIANT: [+openmp]
         DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
           llnl-cluster cluster=dane]
-      - HOST: ruby
+      - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:20:00 --exclusive --reservation=ci
-        BENCHMARK: [laghos]
+        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
+        BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: ['']  # MPI-only test
         DASHBOARD_NAME: Ruby Supermicro-icelake-OmniPath [benchpark system init --dest=ruby-system
           llnl-cluster cluster=ruby]
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
-        SCHEDULER_PARAMETERS: -nnodes 1 -W 20 -q pci
+        SCHEDULER_PARAMETERS: -nnodes 1 -W 40 -q pci
         BENCHMARK: [amg2023, kripke]
         VARIANT: [+cuda]
         DASHBOARD_NAME: Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system
           llnl-sierra]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 00:20:00 --exclusive --reservation=ci
+        SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK: [kripke]
         VARIANT: ['+strong~single_node caliper=mpi,time']
         DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system


### PR DESCRIPTION
## Description

- [x] Increase nightly tests to 1hr (more likely to get allocated over night) and increase PR tests to at least 30 minutes. Also, move ruby tests to Dane.


## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/tests/nightly.yml` and `.gitlab/tests/tests.yml`
