### PR TITLE
Make oneapi Compiler Default on llnl-cluster

### DIFF
--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -48,8 +48,8 @@ class LlnlCluster(System):
 
     variant(
         "compiler",
-        default="gcc",
-        values=("gcc", "intel", "oneapi"),
+        default="oneapi",
+        values=("oneapi", "gcc", "intel"),
         description="Which compiler to use",
     )
 


### PR DESCRIPTION
## Description

- [x] Use the oneapi compiler in favor of using gcc as a default on llnl-cluster.

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `systems/llnl-cluster/system.py`

