### PR TITLE
Add More Tuolumne Unit Tests

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -20,9 +20,15 @@ include:
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
         SCHEDULER_PARAMETERS: -N 1 -t 60m --queue=pci --exclusive
-        BENCHMARK: [amg2023, kripke, laghos]
+        BENCHMARK:
+          - amg2023
+          - babelstream
+          - kripke
+          - laghos
+          - lammps
+          - osu-micro-benchmarks
         VARIANT: [+rocm]
-        SYSTEM_ARGS: ['']
+        SYSTEM_ARGS: [gpumode=SPX, gpumode=TPX, gpumode=CPX]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster

--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -34,7 +34,7 @@
         ctest -S CTestGitlab.cmake \
           -DHOST="${HOST}" \
           -DDASHBOARD_NAME="${DASHBOARD_NAME}" \
-          -DBUILD_NAME="${HOST}/${BENCHMARK}${VARIANT}" \
+          -DBUILD_NAME="${HOST}/${BENCHMARK}${VARIANT} ${SYSTEM_ARGS}" \
           -DSITE="$(hostname)" \
           -DTEST_TYPE="${TEST_TYPE}"
       else


### PR DESCRIPTION
## Description

- [x] Add more nightly Tuolumne unit tests and correctly fill `SYSTEM_ARGS` in CDash table so different gpumode runs do not appear the same.
