### PR TITLE
Kripke in mpi-only mode should use 'Sequential' arch

### DIFF
--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -137,6 +137,8 @@ class Kripke(
             self.add_experiment_variable("arch", "CUDA")
         elif self.spec.satisfies("+rocm"):
             self.add_experiment_variable("arch", "HIP")
+        else:
+            self.add_experiment_variable("arch", "Sequential")
 
         self.set_required_variables(
             n_resources="{npx}*{npy}*{npz}",


### PR DESCRIPTION
## Description
This PR adds the 'Sequential' arch value for kripke's mpi-only mode

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define a single node and multi-node experiments