### PR TITLE
Remove _BENCHPARK_INITIALIZED

### DIFF
--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -149,18 +149,12 @@ def mirror_create(args):
         with open(setup_dest, "w", encoding="utf-8") as f:
             f.write(
                 """\
-if [ -n "${_BENCHPARK_INITIALIZED:-}" ]; then
-    return 0
-fi
-
 this_script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 . $this_script_dir/spack/share/spack/setup-env.sh
 . $this_script_dir/ramble/share/ramble/setup-env.sh
 
 export SPACK_DISABLE_LOCAL_CONFIG=1
-
-export _BENCHPARK_INITIALIZED=true
 """
             )
 

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -181,14 +181,8 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
         with open(initializer_script, "w") as f:
             f.write(
                 f"""\
-if [ -n "${{_BENCHPARK_INITIALIZED:-}}" ]; then
-    return 0
-fi
-
 {pkg_str}
 . {per_workspace_setup.ramble_location}/share/ramble/setup-env.sh
-
-export _BENCHPARK_INITIALIZED=true
 """
             )
 

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -202,4 +202,4 @@ Further steps are needed to build the experiments ({ramble_setup}) and run them 
 
     # Generate shell script to setup and run latest experiment
     with open(run_script, "w") as f:
-        f.write(f"{ramble_setup}\n{ramble_run}\n")
+        f.write(f"{ramble_setup} && {ramble_run}\n")


### PR DESCRIPTION
## Description

- [x] Remove _BENCHPARK_INITIALIZED for the following reasons:
1. If the user does the following on develop:
```
$ benchpark setup expr sys workspace
$ . workspace/setup.sh
$ ramble --workspace-dir workspace workspace setup
$ benchpark setup expr2 sys2 workspace2
$ . workspace2/setup.sh
$ ramble --workspace-dir workspace2 workspace setup
```
The last line will use `workspace/ramble` and `workspace/spack` instead of the intended `workspace2/ramble` and `workspace2/spack`, because `_BENCHPARK_INITIALIZED=true` and the `. workspace2/setup.sh` will exit early. This can lead to silent issues, since the user should be under the impression they are using `workspace2/spack` to build.
2. Also, removing the first workspace `rm workspace` will result in ramble/spack not being found error, since the `. workspace2/setup.sh` would have no effect, which is confusing.

It would be possible to keep the functionality for `_BENCHPARK_INITIALIZED` if we set this value equal to the workspace path, and checked if the path differed, e.g.:
```
SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
# exit early if _SCRIPT_DIR not defined or SCRIPT_DIR == _SCRIPT_DIR

# initialize

_SCRIPT_DIR = SCRIPT_DIR
```
But this check would only work for bash in this example, would need to check differently for different shells.

- [x] Update `.latest-experiment.sh` to fail if first command fails

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `lib/benchpark/cmd/setup.py` and `lib/benchpark/cmd/mirror.py`
