### PR TITLE
Revert "Make oneapi Compiler Default on llnl-cluster"

### DIFF
--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -48,8 +48,8 @@ class LlnlCluster(System):
 
     variant(
         "compiler",
-        default="oneapi",
-        values=("oneapi", "gcc", "intel"),
+        default="gcc",
+        values=("gcc", "intel", "oneapi"),
         description="Which compiler to use",
     )
 


### PR DESCRIPTION
Reverts LLNL/benchpark#817