### PR TITLE
Set Sequential Default in Kripke application.py

### DIFF
--- a/repo/kripke/application.py
+++ b/repo/kripke/application.py
@@ -72,7 +72,7 @@ class Kripke(ExecutableApplication):
     workload_variable('sigs2', default='0.05',
                       description='Total material cross-sections',
                       workloads=['kripke'])
-    workload_variable('arch', default='OpenMP',
+    workload_variable('arch', default='Sequential',
                       description='Architecture selection. Selects the back-end used for computation, available are Sequential, OpenMP, CUDA and HIP. The default depends on capabilities selected by the build system and is selected from list of increasing precedence: Sequential, OpenMP, CUDA and HIP.',
                       workloads=['kripke'])
     workload_variable('layout', default='DGZ',


### PR DESCRIPTION
## Description

- [x] The `arch` is now being set correctly as of #820 in `experiment.py`, but since the default variant in the `package.py` is mpi-only, the default here should also be `Sequential` instead of openmp 