### PR TITLE
Make oneapi Compiler Default on llnl-cluster

### DIFF
--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -48,7 +48,7 @@ class LlnlCluster(System):
 
     variant(
         "compiler",
-        default="oneapi",
+        default="oneapi2023",
         values=("oneapi", "oneapi2023", "gcc", "intel"),
         description="Which compiler to use",
     )

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -48,8 +48,8 @@ class LlnlCluster(System):
 
     variant(
         "compiler",
-        default="gcc",
-        values=("gcc", "intel", "oneapi"),
+        default="oneapi",
+        values=("oneapi", "gcc", "intel"),
         description="Which compiler to use",
     )
 


### PR DESCRIPTION
## Description

- [x] Use the oneapi compiler in favor of using gcc as a default on llnl-cluster.
- [x] Depends on #770 

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `systems/llnl-cluster/system.py`