### PR TITLE
Fixes for Flux Allocation Modifier

### DIFF
--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -372,16 +372,16 @@ class Allocation(BasicModifier):
     def flux_instructions(self, v):
         batch_opts, cmd_opts = Allocation._init_batch_and_cmd_opts(v)
 
+        # Always run exclusive for mpibind + flux.
+        # Otherwise, binding may oversubscribe cores before all cores are allocated.
+        cmd_opts.append("--exclusive")
+
         if v.n_ranks:
             cmd_ranks = f"-n {v.n_ranks}"
             if v.gpu_factor:
-                req = int(math.ceil(v.n_ranks / v.gpu_factor))
-                batch_ranks = f"-n {req}"
-            else:
-                batch_ranks = cmd_ranks
+                cmd_ranks = f"-n {v.n_ranks * v.gpu_factor}"
         if v.n_nodes:
             cmd_opts.append(f"-N {v.n_nodes}")
-            cmd_opts.append("--exclusive")
         if v.n_gpus:
             gpus_per_rank = 1  # self.gpus_as_gpus_per_rank(v)
             cmd_opts.append(f"-g={gpus_per_rank}")
@@ -389,9 +389,7 @@ class Allocation(BasicModifier):
         if v.timeout:
             batch_opts.append(f"-t {v.timeout}m")
 
-        batch_directives = list(
-            f"# flux: {x}" for x in ([batch_ranks] + cmd_opts + batch_opts)
-        )
+        batch_directives = list(f"# flux: {x}" for x in (cmd_opts + batch_opts))
 
         v.mpi_command = f"flux run {' '.join([cmd_ranks] + cmd_opts)}"
         v.batch_submit = "flux batch {execute_experiment}"

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -376,13 +376,13 @@ class Allocation(BasicModifier):
         # Always run exclusive for mpibind + flux.
         # Otherwise, binding may oversubscribe cores before all cores are allocated.
         cmd_opts.append("--exclusive")
+        # Required for '--exclusive'. Will be computed, if not defined, from initialization
+        cmd_opts.append(f"-N {v.n_nodes}")
 
         if v.n_ranks:
             cmd_ranks = f"-n {v.n_ranks}"
             if v.gpu_factor:
                 cmd_ranks = f"-n {v.n_ranks * v.gpu_factor}"
-        if v.n_nodes:
-            cmd_opts.append(f"-N {v.n_nodes}")
         if v.n_gpus:
             gpus_per_rank = 1  # self.gpus_as_gpus_per_rank(v)
             cmd_opts.append(f"-g={gpus_per_rank}")

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -37,6 +37,7 @@ class AllocOpt(Enum):
     POST_EXEC_CMDS = 302
     PRE_EXEC_CMDS = 303
     GPU_FACTOR = 304
+    MPIBIND_BINDINGS = 305
 
     @staticmethod
     def as_type(enumval, input):
@@ -388,6 +389,9 @@ class Allocation(BasicModifier):
 
         if v.timeout:
             batch_opts.append(f"-t {v.timeout}m")
+
+        if v.mpibind_bindings:
+            cmd_opts.append("--setopt=mpibind=verbose:1")
 
         batch_directives = list(f"# flux: {x}" for x in (cmd_opts + batch_opts))
 

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -285,6 +285,8 @@ class Allocation(BasicModifier):
             gpus_node_request = None
             if v.n_gpus:
                 if v.sys_gpus_per_node:
+                    if v.gpu_factor:
+                        v.n_gpus *= v.gpu_factor
                     gpus_node_request = math.ceil(v.n_gpus / float(v.sys_gpus_per_node))
                 else:
                     raise ValueError(

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -380,11 +380,6 @@ class Allocation(BasicModifier):
 
         if v.n_ranks:
             cmd_ranks = f"-n {v.n_ranks}"
-            if v.gpu_factor:
-                req = int(math.ceil(v.n_ranks / v.gpu_factor))
-                batch_ranks = f"-n {req}"
-            else:
-                batch_ranks = cmd_ranks
         if v.n_gpus:
             gpus_per_rank = 1  # self.gpus_as_gpus_per_rank(v)
             cmd_opts.append(f"-g={gpus_per_rank}")
@@ -392,9 +387,7 @@ class Allocation(BasicModifier):
         if v.timeout:
             batch_opts.append(f"-t {v.timeout}m")
 
-        batch_directives = list(
-            f"# flux: {x}" for x in ([batch_ranks] + cmd_opts + batch_opts)
-        )
+        batch_directives = list(f"# flux: {x}" for x in (cmd_opts + batch_opts))
 
         v.mpi_command = f"flux run {' '.join([cmd_ranks] + cmd_opts)}"
         v.batch_submit = "flux batch {execute_experiment}"

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -37,7 +37,6 @@ class AllocOpt(Enum):
     POST_EXEC_CMDS = 302
     PRE_EXEC_CMDS = 303
     GPU_FACTOR = 304
-    MPIBIND_BINDINGS = 305
 
     @staticmethod
     def as_type(enumval, input):
@@ -285,8 +284,6 @@ class Allocation(BasicModifier):
             gpus_node_request = None
             if v.n_gpus:
                 if v.sys_gpus_per_node:
-                    if v.gpu_factor:
-                        v.n_gpus *= v.gpu_factor
                     gpus_node_request = math.ceil(v.n_gpus / float(v.sys_gpus_per_node))
                 else:
                     raise ValueError(
@@ -384,7 +381,10 @@ class Allocation(BasicModifier):
         if v.n_ranks:
             cmd_ranks = f"-n {v.n_ranks}"
             if v.gpu_factor:
-                cmd_ranks = f"-n {v.n_ranks * v.gpu_factor}"
+                req = int(math.ceil(v.n_ranks / v.gpu_factor))
+                batch_ranks = f"-n {req}"
+            else:
+                batch_ranks = cmd_ranks
         if v.n_gpus:
             gpus_per_rank = 1  # self.gpus_as_gpus_per_rank(v)
             cmd_opts.append(f"-g={gpus_per_rank}")
@@ -392,10 +392,9 @@ class Allocation(BasicModifier):
         if v.timeout:
             batch_opts.append(f"-t {v.timeout}m")
 
-        if v.mpibind_bindings:
-            cmd_opts.append("--setopt=mpibind=verbose:1")
-
-        batch_directives = list(f"# flux: {x}" for x in (cmd_opts + batch_opts))
+        batch_directives = list(
+            f"# flux: {x}" for x in ([batch_ranks] + cmd_opts + batch_opts)
+        )
 
         v.mpi_command = f"flux run {' '.join([cmd_ranks] + cmd_opts)}"
         v.batch_submit = "flux batch {execute_experiment}"


### PR DESCRIPTION
- [x] Remove `-n` e.g. nslots from batch arguments. This was intended to set ntasks, but `flux batch -n` does is not the same as setting ntasks. Removing this is fine, since we use `--exclusive` and set `flux run -n` which is ntasks.
- [x] Refactor to make it clear we are always running with `flux run --exclusive` (`if v.n_nodes` was always computed so always true).
With `-x` on Tuolumne: `flux submit -N 1 -x -n 84 --setopt=mpibind=verbose:1 --output="myfile.out" sleep 10`
```
flux-shell[0]: (null): mpibind: 
mpibind: task   0 nths  1 gpus 0 cpus 1
mpibind: task   1 nths  1 gpus 0 cpus 2
mpibind: task   2 nths  1 gpus 0 cpus 3
mpibind: task   3 nths  1 gpus 0 cpus 4
mpibind: task   4 nths  1 gpus 0 cpus 5
mpibind: task   5 nths  1 gpus 0 cpus 6
mpibind: task   6 nths  1 gpus 0 cpus 7
mpibind: task   7 nths  1 gpus 0 cpus 9
mpibind: task   8 nths  1 gpus 0 cpus 10
mpibind: task   9 nths  1 gpus 0 cpus 11
mpibind: task  10 nths  1 gpus 0 cpus 12
mpibind: task  11 nths  1 gpus 0 cpus 13
mpibind: task  12 nths  1 gpus 0 cpus 14
mpibind: task  13 nths  1 gpus 0 cpus 15
mpibind: task  14 nths  1 gpus 0 cpus 17
mpibind: task  15 nths  1 gpus 0 cpus 18
mpibind: task  16 nths  1 gpus 0 cpus 19
mpibind: task  17 nths  1 gpus 0 cpus 20
mpibind: task  18 nths  1 gpus 0 cpus 21
mpibind: task  19 nths  1 gpus 0 cpus 22
mpibind: task  20 nths  1 gpus 0 cpus 23
mpibind: task  21 nths  1 gpus 1 cpus 25
mpibind: task  22 nths  1 gpus 1 cpus 26
mpibind: task  23 nths  1 gpus 1 cpus 27
mpibind: task  24 nths  1 gpus 1 cpus 28
mpibind: task  25 nths  1 gpus 1 cpus 29
mpibind: task  26 nths  1 gpus 1 cpus 30
mpibind: task  27 nths  1 gpus 1 cpus 31
mpibind: task  28 nths  1 gpus 1 cpus 33
mpibind: task  29 nths  1 gpus 1 cpus 34
mpibind: task  30 nths  1 gpus 1 cpus 35
mpibind: task  31 nths  1 gpus 1 cpus 36
mpibind: task  32 nths  1 gpus 1 cpus 37
mpibind: task  33 nths  1 gpus 1 cpus 38
mpibind: task  34 nths  1 gpus 1 cpus 39
mpibind: task  35 nths  1 gpus 1 cpus 41
mpibind: task  36 nths  1 gpus 1 cpus 42
mpibind: task  37 nths  1 gpus 1 cpus 43
mpibind: task  38 nths  1 gpus 1 cpus 44
mpibind: task  39 nths  1 gpus 1 cpus 45
mpibind: task  40 nths  1 gpus 1 cpus 46
mpibind: task  41 nths  1 gpus 1 cpus 47
mpibind: task  42 nths  1 gpus 2 cpus 49
mpibind: task  43 nths  1 gpus 2 cpus 50
mpibind: task  44 nths  1 gpus 2 cpus 51
mpibind: task  45 nths  1 gpus 2 cpus 52
mpibind: task  46 nths  1 gpus 2 cpus 53
mpibind: task  47 nths  1 gpus 2 cpus 54
mpibind: task  48 nths  1 gpus 2 cpus 55
mpibind: task  49 nths  1 gpus 2 cpus 57
mpibind: task  50 nths  1 gpus 2 cpus 58
mpibind: task  51 nths  1 gpus 2 cpus 59
mpibind: task  52 nths  1 gpus 2 cpus 60
mpibind: task  53 nths  1 gpus 2 cpus 61
mpibind: task  54 nths  1 gpus 2 cpus 62
mpibind: task  55 nths  1 gpus 2 cpus 63
mpibind: task  56 nths  1 gpus 2 cpus 65
mpibind: task  57 nths  1 gpus 2 cpus 66
mpibind: task  58 nths  1 gpus 2 cpus 67
mpibind: task  59 nths  1 gpus 2 cpus 68
mpibind: task  60 nths  1 gpus 2 cpus 69
mpibind: task  61 nths  1 gpus 2 cpus 70
mpibind: task  62 nths  1 gpus 2 cpus 71
mpibind: task  63 nths  1 gpus 3 cpus 73
mpibind: task  64 nths  1 gpus 3 cpus 74
mpibind: task  65 nths  1 gpus 3 cpus 75
mpibind: task  66 nths  1 gpus 3 cpus 76
mpibind: task  67 nths  1 gpus 3 cpus 77
mpibind: task  68 nths  1 gpus 3 cpus 78
mpibind: task  69 nths  1 gpus 3 cpus 79
mpibind: task  70 nths  1 gpus 3 cpus 81
mpibind: task  71 nths  1 gpus 3 cpus 82
mpibind: task  72 nths  1 gpus 3 cpus 83
mpibind: task  73 nths  1 gpus 3 cpus 84
mpibind: task  74 nths  1 gpus 3 cpus 85
mpibind: task  75 nths  1 gpus 3 cpus 86
mpibind: task  76 nths  1 gpus 3 cpus 87
mpibind: task  77 nths  1 gpus 3 cpus 89
mpibind: task  78 nths  1 gpus 3 cpus 90
mpibind: task  79 nths  1 gpus 3 cpus 91
mpibind: task  80 nths  1 gpus 3 cpus 92
mpibind: task  81 nths  1 gpus 3 cpus 93
mpibind: task  82 nths  1 gpus 3 cpus 94
mpibind: task  83 nths  1 gpus 3 cpus 95
``` 
Without `-x`: `flux submit -N 1 -n 84 --setopt=mpibind=verbose:1 --output="myfile.out" sleep 10`
```
flux-shell[0]: (null): mpibind: 
mpibind: task   0 nths  1 gpus 0 cpus 12
mpibind: task   1 nths  1 gpus 0 cpus 108
mpibind: task   2 nths  1 gpus 0 cpus 13
mpibind: task   3 nths  1 gpus 0 cpus 109
mpibind: task   4 nths  1 gpus 0 cpus 14
mpibind: task   5 nths  1 gpus 0 cpus 110
mpibind: task   6 nths  1 gpus 0 cpus 15
mpibind: task   7 nths  1 gpus 0 cpus 111
mpibind: task   8 nths  1 gpus 0 cpus 17
mpibind: task   9 nths  1 gpus 0 cpus 113
mpibind: task  10 nths  1 gpus 0 cpus 18
mpibind: task  11 nths  1 gpus 0 cpus 114
mpibind: task  12 nths  1 gpus 0 cpus 19
mpibind: task  13 nths  1 gpus 0 cpus 115
mpibind: task  14 nths  1 gpus 0 cpus 20
mpibind: task  15 nths  1 gpus 0 cpus 116
mpibind: task  16 nths  1 gpus 0 cpus 21
mpibind: task  17 nths  1 gpus 0 cpus 117
mpibind: task  18 nths  1 gpus 0 cpus 22
mpibind: task  19 nths  1 gpus 0 cpus 118
mpibind: task  20 nths  1 gpus 0 cpus 23,119
mpibind: task  21 nths  1 gpus 1 cpus 25
mpibind: task  22 nths  1 gpus 1 cpus 26
mpibind: task  23 nths  1 gpus 1 cpus 27
mpibind: task  24 nths  1 gpus 1 cpus 28
mpibind: task  25 nths  1 gpus 1 cpus 29
mpibind: task  26 nths  1 gpus 1 cpus 30
mpibind: task  27 nths  1 gpus 1 cpus 31
mpibind: task  28 nths  1 gpus 1 cpus 33
mpibind: task  29 nths  1 gpus 1 cpus 34
mpibind: task  30 nths  1 gpus 1 cpus 35
mpibind: task  31 nths  1 gpus 1 cpus 36
mpibind: task  32 nths  1 gpus 1 cpus 37
mpibind: task  33 nths  1 gpus 1 cpus 38
mpibind: task  34 nths  1 gpus 1 cpus 39
mpibind: task  35 nths  1 gpus 1 cpus 41
mpibind: task  36 nths  1 gpus 1 cpus 42
mpibind: task  37 nths  1 gpus 1 cpus 43
mpibind: task  38 nths  1 gpus 1 cpus 44
mpibind: task  39 nths  1 gpus 1 cpus 45
mpibind: task  40 nths  1 gpus 1 cpus 46
mpibind: task  41 nths  1 gpus 1 cpus 47
mpibind: task  42 nths  1 gpus 2 cpus 49
mpibind: task  43 nths  1 gpus 2 cpus 50
mpibind: task  44 nths  1 gpus 2 cpus 51
mpibind: task  45 nths  1 gpus 2 cpus 52
mpibind: task  46 nths  1 gpus 2 cpus 53
mpibind: task  47 nths  1 gpus 2 cpus 54
mpibind: task  48 nths  1 gpus 2 cpus 55
mpibind: task  49 nths  1 gpus 2 cpus 57
mpibind: task  50 nths  1 gpus 2 cpus 58
mpibind: task  51 nths  1 gpus 2 cpus 59
mpibind: task  52 nths  1 gpus 2 cpus 60
mpibind: task  53 nths  1 gpus 2 cpus 61
mpibind: task  54 nths  1 gpus 2 cpus 62
mpibind: task  55 nths  1 gpus 2 cpus 63
mpibind: task  56 nths  1 gpus 2 cpus 65
mpibind: task  57 nths  1 gpus 2 cpus 66
mpibind: task  58 nths  1 gpus 2 cpus 67
mpibind: task  59 nths  1 gpus 2 cpus 68
mpibind: task  60 nths  1 gpus 2 cpus 69
mpibind: task  61 nths  1 gpus 2 cpus 70
mpibind: task  62 nths  1 gpus 2 cpus 71
mpibind: task  63 nths  1 gpus 3 cpus 73
mpibind: task  64 nths  1 gpus 3 cpus 74
mpibind: task  65 nths  1 gpus 3 cpus 75
mpibind: task  66 nths  1 gpus 3 cpus 76
mpibind: task  67 nths  1 gpus 3 cpus 77
mpibind: task  68 nths  1 gpus 3 cpus 78
mpibind: task  69 nths  1 gpus 3 cpus 79
mpibind: task  70 nths  1 gpus 3 cpus 81
mpibind: task  71 nths  1 gpus 3 cpus 82
mpibind: task  72 nths  1 gpus 3 cpus 83
mpibind: task  73 nths  1 gpus 3 cpus 84
mpibind: task  74 nths  1 gpus 3 cpus 85
mpibind: task  75 nths  1 gpus 3 cpus 86
mpibind: task  76 nths  1 gpus 3 cpus 87
mpibind: task  77 nths  1 gpus 3 cpus 89
mpibind: task  78 nths  1 gpus 3 cpus 90
mpibind: task  79 nths  1 gpus 3 cpus 91
mpibind: task  80 nths  1 gpus 3 cpus 92
mpibind: task  81 nths  1 gpus 3 cpus 93
mpibind: task  82 nths  1 gpus 3 cpus 94
mpibind: task  83 nths  1 gpus 3 cpus 95 
```

