### PR TITLE
Analyzing RAJAPerf for gpumodes

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -50,8 +50,8 @@ class RajaPerf(
                 f"Only one type of scaling per experiment is allowed for application package {self.name}"
             )
 
-        n_resources = {"n_ranks": 4}
-        problem_sizes = {"size": 8388608}
+        n_resources = {"n_ranks": 1}
+        problem_sizes = {"size": 1048576}
 
         if self.spec.satisfies("+single_node"):
             for pk, pv in n_resources.items():

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -50,8 +50,8 @@ class RajaPerf(
                 f"Only one type of scaling per experiment is allowed for application package {self.name}"
             )
 
-        n_resources = {"n_ranks": 1}
-        problem_sizes = {"size": 1048576}
+        n_resources = {"n_ranks": 4}
+        problem_sizes = {"size": 8388608}
 
         if self.spec.satisfies("+single_node"):
             for pk, pv in n_resources.items():
@@ -90,21 +90,13 @@ class RajaPerf(
                 self.add_experiment_variable(nk, nv, True)
 
         if self.spec.satisfies("+cuda"):
-            self.add_experiment_variable("RAJAPerf_variant", "Base_CUDA", True)
-            self.add_experiment_variable("RAJAPerf_tuning", "block_256", True)
             self.add_experiment_variable("n_gpus", n_resources, True)
         elif self.spec.satisfies("+rocm"):
-            self.add_experiment_variable("RAJAPerf_variant", "Base_HIP", True)
-            self.add_experiment_variable("RAJAPerf_tuning", "block_256", True)
             self.add_experiment_variable("n_gpus", n_resources, True)
         elif self.spec.satisfies("+openmp"):
-            self.add_experiment_variable("RAJAPerf_variant", "Base_OpenMP", True)
-            self.add_experiment_variable("RAJAPerf_tuning", "default", True)
             self.add_experiment_variable("n_ranks", n_resources, True)
             self.add_experiment_variable("n_threads_per_proc", 1, True)
         else:
-            self.add_experiment_variable("RAJAPerf_variant", "Base_Seq", True)
-            self.add_experiment_variable("RAJAPerf_tuning", "default", True)
             self.add_experiment_variable("n_ranks", n_resources, True)
 
         self.set_required_variables(

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -153,6 +153,9 @@ def make_stacked_line_chart(**kwargs):
         figsize=kwargs["chart_figsize"] if kwargs["chart_figsize"] else (12, 7),
         ax=ax,
     )
+    y_axis_limits = kwargs.get("chart_yaxis_limits")
+    if y_axis_limits is not None:
+        ax.set_ylim(y_axis_limits[0], y_axis_limits[1])
 
     handles, labels = ax.get_legend_handles_labels()
     handles = list(reversed(handles))
@@ -428,6 +431,14 @@ def setup_parser(root_parser):
     )
     root_parser.add_argument(
         "--chart-fontsize", type=int, help="Font size of the output chart."
+    )
+    root_parser.add_argument(
+        "--chart-yaxis-limits",
+        type=float,
+        nargs=2,
+        metavar=('YMIN', 'YMAX'),
+        default=None,
+        help="Set both y-axis limits: --chart-yaxis-limits YMIN YMAX"
     )
 
 

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -196,7 +196,7 @@ def prepare_data(**kwargs):
     Processes .cali files from a Ramble workspace to generate performance charts.
     """
     workspace_dir = kwargs["workspace_dir"]
-    files = glob(os.path.join(workspace_dir, "**/*.cali"), recursive=True)
+    files = glob(os.path.join(workspace_dir, f"**/*{kwargs['file_name_match']}.cali"), recursive=True)
     logger.info(f"Found {len(files)} .cali files for analysis.")
 
     tk = th.Thicket.from_caliperreader(files, disable_tqdm=True)
@@ -439,6 +439,12 @@ def setup_parser(root_parser):
         metavar=('YMIN', 'YMAX'),
         default=None,
         help="Set both y-axis limits: --chart-yaxis-limits YMIN YMAX"
+    )
+    root_parser.add_argument(
+        "--file-name-match",
+        type=str,
+        default="",
+        help="Set optional cali file name to match. Useful if multiple caliper files are generated per experiment (e.g. RAJAPerf)"
     )
 
 

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -196,7 +196,10 @@ def prepare_data(**kwargs):
     Processes .cali files from a Ramble workspace to generate performance charts.
     """
     workspace_dir = kwargs["workspace_dir"]
-    files = glob(os.path.join(workspace_dir, f"**/*{kwargs['file_name_match']}.cali"), recursive=True)
+    files = glob(
+        os.path.join(workspace_dir, f"**/*{kwargs['file_name_match']}.cali"),
+        recursive=True,
+    )
     logger.info(f"Found {len(files)} .cali files for analysis.")
 
     tk = th.Thicket.from_caliperreader(files, disable_tqdm=True)
@@ -436,15 +439,15 @@ def setup_parser(root_parser):
         "--chart-yaxis-limits",
         type=float,
         nargs=2,
-        metavar=('YMIN', 'YMAX'),
+        metavar=("YMIN", "YMAX"),
         default=None,
-        help="Set both y-axis limits: --chart-yaxis-limits YMIN YMAX"
+        help="Set both y-axis limits: --chart-yaxis-limits YMIN YMAX",
     )
     root_parser.add_argument(
         "--file-name-match",
         type=str,
         default="",
-        help="Set optional cali file name to match. Useful if multiple caliper files are generated per experiment (e.g. RAJAPerf)"
+        help="Set optional cali file name to match. Useful if multiple caliper files are generated per experiment (e.g. RAJAPerf)",
     )
 
 

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -7,20 +7,11 @@ import hashlib
 import os
 import packaging.version
 import yaml
-
-import benchpark.paths
-from benchpark.directives import ExperimentSystemBase
-import benchpark.repo
-from benchpark.runtime import RuntimeResources
-
 from typing import Dict, Tuple
+
+from benchpark.directives import ExperimentSystemBase
 import benchpark.spec
 import benchpark.variant
-
-bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
-bootstrapper.bootstrap()  # noqa
-
-_repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 
 
 def _hash_id(content_list):
@@ -43,8 +34,8 @@ class System(ExperimentSystemBase):
         self.external_resources = None
 
         self.sys_cores_per_node = None
-        self.sys_cores_os_reserved_per_node = None
-        self.sys_cores_os_reserved_per_node_list = None
+        self.sys_cores_os_reserved = None
+        self.sys_cores_os_reserved_list = None
         self.sys_gpus_per_node = None
         self.sys_mem_per_node = None
         self.scheduler = None
@@ -115,8 +106,8 @@ class System(ExperimentSystemBase):
 
         optionals = {}
         for opt in [
-            "sys_cores_os_reserved_per_node",
-            "sys_cores_os_reserved_per_node_list",
+            "sys_cores_os_reserved",
+            "sys_cores_os_reserved_list",
             "sys_gpus_per_node",
             "sys_mem_per_node",
             "queue",
@@ -151,12 +142,19 @@ class System(ExperimentSystemBase):
 
     def compute_dict(self):
         # This can be overridden by any subclass that needs more flexibility
+        compilers = self.compute_compilers_section()
         return {
             "system_id": self.compute_system_id(),
             "variables": self.compute_variables_section(),
             "software": self.compute_software_section(),
             "auxiliary_software_files": {
-                "compilers": self.compute_compilers_section(),
+                "compilers": (
+                    # "'compilers:':" syntax is required to enforce spack to use benchpark-defined
+                    # compilers instead of external compilers defined by spack compiler search (from ramble).
+                    {"compilers:": compilers["compilers"]}
+                    if compilers
+                    else None
+                ),
                 "packages": self.compute_packages_section(),
             },
         }

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -43,8 +43,8 @@ class System(ExperimentSystemBase):
         self.external_resources = None
 
         self.sys_cores_per_node = None
-        self.sys_cores_os_reserved = None
-        self.sys_cores_os_reserved_list = None
+        self.sys_cores_os_reserved_per_node = None
+        self.sys_cores_os_reserved_per_node_list = None
         self.sys_gpus_per_node = None
         self.sys_mem_per_node = None
         self.scheduler = None
@@ -115,8 +115,8 @@ class System(ExperimentSystemBase):
 
         optionals = {}
         for opt in [
-            "sys_cores_os_reserved",
-            "sys_cores_os_reserved_list",
+            "sys_cores_os_reserved_per_node",
+            "sys_cores_os_reserved_per_node_list",
             "sys_gpus_per_node",
             "sys_mem_per_node",
             "queue",

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -20,7 +20,12 @@ class RajaPerf(ExecutableApplication):
 
     executable('run', 'raja-perf.exe --size {size}', use_mpi=True)
 
-    workload('suite', executables=['run'])
+    executable(
+        "modules",
+        "export LD_LIBRARY_PATH=/opt/cray/pe/cce/18.0.1/cce/x86_64/lib:$LD_LIBRARY_PATH",
+    )
+
+    workload('suite', executables=['modules', 'run'])
 
     figure_of_merit('All tests pass', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'(?P<tpass>DONE)!!!...', group_name='tpass', units='')
 

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -18,7 +18,7 @@ class RajaPerf(ExecutableApplication):
             'mpi','network-point-to-point','network-latency-bound',
             'c++','raja','sycl']
 
-    executable('run', 'raja-perf.exe --size {size} --variants {RAJAPerf_variant} --tunings {RAJAPerf_tuning} --outfile {experiment_name}', use_mpi=True)
+    executable('run', 'raja-perf.exe --size {size}', use_mpi=True)
 
     workload('suite', executables=['run'])
 

--- a/repo/raja-perf/application.py
+++ b/repo/raja-perf/application.py
@@ -20,12 +20,7 @@ class RajaPerf(ExecutableApplication):
 
     executable('run', 'raja-perf.exe --size {size}', use_mpi=True)
 
-    executable(
-        "modules",
-        "export LD_LIBRARY_PATH=/opt/cray/pe/cce/18.0.1/cce/x86_64/lib:$LD_LIBRARY_PATH",
-    )
-
-    workload('suite', executables=['modules', 'run'])
+    workload('suite', executables=['run'])
 
     figure_of_merit('All tests pass', log_file='{experiment_run_dir}/{experiment_name}.out', fom_regex=r'(?P<tpass>DONE)!!!...', group_name='tpass', units='')
 

--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -361,3 +361,10 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         options = [f"-DMPI_CXX_LINK_FLAGS='{self.spec['mpi'].libs.ld_flags}'"]
         return options
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+
+        if self.compiler.extra_rpaths:
+            for rpath in self.compiler.extra_rpaths:
+                env.prepend_path("LD_LIBRARY_PATH", rpath)


### PR DESCRIPTION
## Description

These are fixes related to studying gpumodes performance using RAJAPerf in Benchpark:
- [x] Enable generating all applicable `variant`-`tuning` caliper files instead of pinning single file. Benchpark metadata will be applied to each caliper file (parsed by the internal caliper config in RAJAPerf app).
- [x] Update `benchpark analyze` to support analyzing multiple caliper files per run, and setting y-axis limits for analyzing multiple charts.
- [x] Fix modulepath error by adding rpaths in RAJAPerf `package.py`, related to #754 

## Experiments

- [x] Update `experiments/raja-perf/experiment.py`

## Applications

- [x] Update `repo/raja-perf/application.py`, `repo/raja-perf/package.py`

## Library

- [x] Update `lib/benchpark/cmd/analyze.py`