### PR TITLE
Print build log

### DIFF
--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -18,10 +18,12 @@
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
     - ramble --disable-logger --workspace-dir . workspace setup
     # Run Experiments and Print Log
-    - ramble --disable-logger --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
-    - find experiments/ -type f -name "*.out" -exec cat {} +
+    - |
+      ramble --disable-logger --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
+      find experiments/ -type f -name "*.out" -exec cat {} +
     # Analyze Experiments
-    - ramble --disable-logger --workspace-dir . workspace analyze --format json yaml text
+    - ramble --disable-logger --workspace-dir . workspace analyze --format json yaml
+      text
     - cd -
     # Benchpark Analyze experiments with "+strong"
     - |

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -14,17 +14,14 @@
     - ./bin/benchpark setup ${BENCHMARK}-benchmark ${HOST}-system workspace/
     # Setup Ramble & Spack
     - . workspace/setup.sh
-    # Setup Workspace and Print Log
+    # Setup Workspace
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
-    - |
-      setup_out=$(ramble --workspace-dir . workspace setup)
-      cat $(echo "$setup_out" | grep -o "log file: [^ ]*\.out" | head -n1 | sed 's/log file: //')
+    - ramble --disable-logger --workspace-dir . workspace setup
     # Run Experiments and Print Log
-    - |
-      ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
-      find experiments/ -type f -name "*.out" -exec cat {} +
+    - ramble --disable-logger --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
+    - find experiments/ -type f -name "*.out" -exec cat {} +
     # Analyze Experiments
-    - ramble --workspace-dir . workspace analyze --format json yaml text
+    - ramble --disable-logger --workspace-dir . workspace analyze --format json yaml text
     - cd -
     # Benchpark Analyze experiments with "+strong"
     - |

--- a/.gitlab/utils/run-experiment.yml
+++ b/.gitlab/utils/run-experiment.yml
@@ -14,14 +14,15 @@
     - ./bin/benchpark setup ${BENCHMARK}-benchmark ${HOST}-system workspace/
     # Setup Ramble & Spack
     - . workspace/setup.sh
-    # Setup Workspace
+    # Setup Workspace and Print Log
     - cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
-    - ramble --workspace-dir . workspace setup
-    # Run Experiments
-    - ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes}
-      == 1'
-    # Cat each output file
-    - find experiments/ -type f -name "*.out" -exec cat {} +
+    - |
+      setup_out=$(ramble --workspace-dir . workspace setup)
+      cat $(echo "$setup_out" | grep -o "log file: [^ ]*\.out" | head -n1 | sed 's/log file: //')
+    # Run Experiments and Print Log
+    - |
+      ramble --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
+      find experiments/ -type f -name "*.out" -exec cat {} +
     # Analyze Experiments
     - ramble --workspace-dir . workspace analyze --format json yaml text
     - cd -


### PR DESCRIPTION
## Description

- [x] https://github.com/LLNL/benchpark/pull/815 removed the `--disable-logger` from the `workspace setup`, accidentally hiding build errors in CI logs. Still need to cat the `ramble on` logs to print run output.
