### PR TITLE
Enable Multiple Trials with Caliper

### DIFF
--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -31,9 +31,6 @@ class Caliper(BasicModifier):
 
     maintainers("pearce8")
 
-    # The filename for Caliper output data
-    _cali_datafile = "{experiment_run_dir}/{experiment_name}.cali"
-
     # The filename for metadata forwarded from Benchpark to Caliper
     _caliper_metadata_file = "{experiment_run_dir}/{experiment_name}_metadata.json"
 
@@ -50,8 +47,8 @@ class Caliper(BasicModifier):
 
     env_var_modification(
         "CALI_CONFIG",
-        'spot(output={}{}),metadata(file={}),metadata(file=/etc/node_info.json,keys="host.name,host.cluster,host.os")'.format(
-            _cali_datafile, "${CALI_CONFIG_MODE}", _caliper_metadata_file
+        'spot({}),metadata(file={}),metadata(file=/etc/node_info.json,keys="host.name,host.cluster,host.os")'.format(
+            "${CALI_CONFIG_MODE}", _caliper_metadata_file
         ),
         method="set",
         modes=[_default_mode],
@@ -128,8 +125,6 @@ class Caliper(BasicModifier):
         cali_metadata_file = self.expander.expand_var(self._caliper_metadata_file)
         with open(cali_metadata_file, "w") as f:
             f.write(json.dumps(cali_metadata))
-
-    archive_pattern(_cali_datafile)
 
     software_spec("caliper", pkg_spec="caliper")
 


### PR DESCRIPTION
## Description

- [x] Currently, running `ramble on` will overwrite the caliper file, since the name of the caliper file is the experiment name. If we take out the hardcoded name, the caliper file names will be unique, enabling running `ramble on` multiple times.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `modifiers/caliper/modifier.py`
