### PR TITLE
Add "Machine Up" Checks and Decouple Cluster Workflows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,10 +33,16 @@ include:
     file:
       - utilities/preliminary-ignore-draft-pr.yml
       - utilities/skip-branch-not-a-pr.yml
+  # Machine checks
+  - local: .gitlab/utils/machine_checks.yml
   # Daily tests (from PRs)
   - local: .gitlab/tests/shared_flux_clusters.yml
-  - local: .gitlab/tests/shared_slurm_clusters.yml
-  - local: .gitlab/tests/non_shared.yml
+  #- local: .gitlab/tests/shared_slurm_clusters.yml
+  #- local: .gitlab/tests/non_shared.yml
   # Nightly tests
-  - local: .gitlab/tests/nightly.yml
-stages: [allocate-resources, test, release-resources]
+  #- local: .gitlab/tests/nightly.yml
+stages:
+  - machine-checks
+  - allocate-resources
+  - test
+  - release-resources

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,10 +35,10 @@ include:
       - utilities/skip-branch-not-a-pr.yml
   # Daily tests (from PRs)
   - local: .gitlab/tests/shared_flux_clusters.yml
-  #- local: .gitlab/tests/shared_slurm_clusters.yml
-  #- local: .gitlab/tests/non_shared.yml
+  - local: .gitlab/tests/shared_slurm_clusters.yml
+  - local: .gitlab/tests/non_shared.yml
   # Nightly tests
-  #- local: .gitlab/tests/nightly.yml
+  - local: .gitlab/tests/nightly.yml
 stages:
   - machine-checks
   - allocate-resources

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,8 +33,6 @@ include:
     file:
       - utilities/preliminary-ignore-draft-pr.yml
       - utilities/skip-branch-not-a-pr.yml
-  # Machine checks
-  - local: .gitlab/utils/machine_checks.yml
   # Daily tests (from PRs)
   - local: .gitlab/tests/shared_flux_clusters.yml
   #- local: .gitlab/tests/shared_slurm_clusters.yml

--- a/.gitlab/tests/non_shared.yml
+++ b/.gitlab/tests/non_shared.yml
@@ -4,10 +4,13 @@
 # For these clusters we run separate allocations, which is significantly slower overall.
 include:
   - local: .gitlab/utils/status.yml
+  - local: .gitlab/utils/machine_checks.yml
+  - local: .gitlab/utils/rules.yml
 workflow:
   auto_cancel:
     on_new_commit: conservative
 .test_clusters: &test_clusters
+  extends: .on_host_template
   parallel:
     matrix:
       - HOST: ruby
@@ -31,20 +34,6 @@ run_tests_nonshared:
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**
-        - experiments/**
-        - systems/$ARCHCONFIG/**
-        - repo/$BENCHMARK/**
-        - modifiers/**
-        - var/**
-        - lib/**
   before_script:
     - !reference [.report_status, before_script]
   script: [./.gitlab/utils/run-experiment.sh]

--- a/.gitlab/tests/non_shared.yml
+++ b/.gitlab/tests/non_shared.yml
@@ -11,7 +11,7 @@ workflow:
     on_new_commit: conservative
 .test_clusters: &test_clusters
   extends: .on_host_template
-  needs: ["ruby-up-check", "lassen-up-check"]
+  needs: [ruby-up-check, lassen-up-check]
   parallel:
     matrix:
       - HOST: ruby

--- a/.gitlab/tests/non_shared.yml
+++ b/.gitlab/tests/non_shared.yml
@@ -11,6 +11,7 @@ workflow:
     on_new_commit: conservative
 .test_clusters: &test_clusters
   extends: .on_host_template
+  needs: ["ruby-up-check", "lassen-up-check"]
   parallel:
     matrix:
       - HOST: ruby

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -70,6 +70,7 @@ release_resources_flux_tioga:
   after_script:
     - !reference [.report_status, after_script]
 run_tests_flux_tuolumne:
+  resource_group: tuolumne
   extends: .run_tests_flux
   tags: [shell, tuolumne]
   needs: [allocate_resources_tuolumne]
@@ -91,6 +92,7 @@ run_tests_flux_tuolumne:
         DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
           --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
 run_tests_flux_tioga:
+  resource_group: tioga
   extends: .run_tests_flux
   tags: [shell, tioga]
   needs: [allocate_resources_tioga]

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -76,9 +76,17 @@ run_tests_flux_tuolumne:
     matrix:
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke]
+        BENCHMARK: [amg2023, kripke, laghos, raja-perf]
         VARIANT: [+rocm]
         SYSTEM_ARGS: [gpumode=SPX]
+        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
+          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
+      # Test TPX, CPX
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [laghos]
+        VARIANT: [+rocm]
+        SYSTEM_ARGS: [gpumode=TPX, gpumode=CPX]
         DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
           --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
 run_tests_flux_tioga:
@@ -89,7 +97,7 @@ run_tests_flux_tioga:
     matrix:
       - HOST: tioga
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke]
+        BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: [+rocm]
         SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -31,7 +31,7 @@ workflow:
     - set -x
     - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
 allocate_resources_tuolumne:
-  resource_group: tuolumne
+  #resource_group: tuolumne
   extends: .allocate_resources_flux
   variables:
     HOST: tuolumne
@@ -39,7 +39,7 @@ allocate_resources_tuolumne:
   tags: [shell, tuolumne]
   needs: ["tuolumne-up-check"]
 allocate_resources_tioga:
-  resource_group: tioga
+  #resource_group: tioga
   extends: .allocate_resources_flux
   variables:
     HOST: tioga
@@ -58,14 +58,14 @@ allocate_resources_tioga:
   variables:
     GIT_STRATEGY: none
 release_resources_flux_tuolumne:
-  resource_group: tuolumne
+  #resource_group: tuolumne
   extends: .release_resources_flux
   needs: ["allocate_resources_tuolumne"]
   variables:
     HOST: tuolumne
   tags: [shell, tuolumne]
 release_resources_flux_tioga:
-  resource_group: tioga
+  #resource_group: tioga
   extends: .release_resources_flux
   needs: ["allocate_resources_tioga"]
   variables:

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -1,37 +1,20 @@
 include:
   - local: .gitlab/utils/status.yml
   - local: .gitlab/utils/machine_checks.yml
+  - local: .gitlab/utils/rules.yml
 workflow:
   auto_cancel:
     on_new_commit: conservative
-# Common template for rules
-.on_host_template:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
-      when: never
-    - if: $CI_JOB_NAME =~ /release_resources/ && $CI_PIPELINE_SOURCE != "schedule"
-      when: on_success
-    - when: on_success
-    - changes:
-      - .gitlab-ci.yml
-      - .gitlab/**
-      - bin/**
-      - experiments/$BENCHMARK/**
-      - systems/$ARCHCONFIG/**
-      - repo/$BENCHMARK/**
-      - modifiers/**
-      - var/**
-      - lib/**
 #############################
 # Resource Allocation Section
 #############################
 .allocate_resources_flux:
+  extends: .on_host_template
   stage: allocate-resources
   script:
     - set -x
     - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
 allocate_resources_tuolumne:
-  #resource_group: tuolumne
   extends: .allocate_resources_flux
   variables:
     HOST: tuolumne
@@ -39,7 +22,6 @@ allocate_resources_tuolumne:
   tags: [shell, tuolumne]
   needs: ["tuolumne-up-check"]
 allocate_resources_tioga:
-  #resource_group: tioga
   extends: .allocate_resources_flux
   variables:
     HOST: tioga
@@ -50,6 +32,7 @@ allocate_resources_tioga:
 # Resource Release Section
 ##########################
 .release_resources_flux:
+  extends: .on_host_template
   stage: release-resources
   script:
     - set -x
@@ -58,14 +41,12 @@ allocate_resources_tioga:
   variables:
     GIT_STRATEGY: none
 release_resources_flux_tuolumne:
-  #resource_group: tuolumne
   extends: .release_resources_flux
   needs: ["allocate_resources_tuolumne", "run_tests_flux_tuolumne"]
   variables:
     HOST: tuolumne
   tags: [shell, tuolumne]
 release_resources_flux_tioga:
-  #resource_group: tioga
   extends: .release_resources_flux
   needs: ["allocate_resources_tioga", "run_tests_flux_tioga"]
   variables:
@@ -100,7 +81,6 @@ run_tests_flux_tuolumne:
         SYSTEM_ARGS: [gpumode=SPX]
         DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
           --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
-  #resource_group: tuolumne
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]
@@ -114,4 +94,3 @@ run_tests_flux_tioga:
         SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init
           --dest=tioga-system llnl-elcapitan cluster=tioga]
-  #resource_group: tioga

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -60,64 +60,58 @@ allocate_resources_tioga:
 release_resources_flux_tuolumne:
   #resource_group: tuolumne
   extends: .release_resources_flux
-  needs: ["allocate_resources_tuolumne"]
+  needs: ["allocate_resources_tuolumne", "run_tests_flux_tuolumne"]
   variables:
     HOST: tuolumne
   tags: [shell, tuolumne]
 release_resources_flux_tioga:
   #resource_group: tioga
   extends: .release_resources_flux
-  needs: ["allocate_resources_tioga"]
+  needs: ["allocate_resources_tioga", "run_tests_flux_tioga"]
   variables:
     HOST: tioga
   tags: [shell, tioga]
-
+##################
+# Test Run Section
+##################
+.run_tests_flux:
+  stage: test
+  extends: .on_host_template
+  before_script:
+    - !reference [.report_status, before_script]
+  script:
+    - |
+      ALLOC_ID=$(flux jobs --name="${ALLOC_NAME}" -n -o "{id}")
+      echo -e "[Information]: Shared allocation ID = ${ALLOC_ID}"
+      PROXY="$( [[ -n "${ALLOC_ID}" ]] && echo "flux proxy ${ALLOC_ID}" || echo "" )"
+    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS} .gitlab/utils/run-experiment.sh )
+  after_script:
+    - !reference [.report_status, after_script]
 run_tests_flux_tuolumne:
-  stage: test
+  extends: .run_tests_flux
   tags: [shell, tuolumne]
-  extends: .on_host_template
-  #resource_group: tuolumne
   needs: ["allocate_resources_tuolumne"]
-  variables:
-    HOST: tuolumne
-    ARCHCONFIG: llnl-elcapitan
-    BENCHMARK: amg2023
-    VARIANT: +rocm
-    SYSTEM_ARGS: gpumode=SPX
-    DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
-  before_script:
-    - !reference [.report_status, before_script]
-  script:
-    - |
-      ALLOC_ID=$(flux jobs --name="${ALLOC_NAME}" -n -o "{id}")
-      echo -e "[Information]: Shared allocation ID = ${ALLOC_ID}"
-      PROXY="$( [[ -n "${ALLOC_ID}" ]] && echo "flux proxy ${ALLOC_ID}" || echo "" )"
-    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS}
-      .gitlab/utils/run-experiment.sh )
-  after_script:
-    - !reference [.report_status, after_script]
-
+  parallel:
+    matrix:
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [amg2023, kripke]
+        VARIANT: [+rocm]
+        SYSTEM_ARGS: [gpumode=SPX]
+        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
+          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
+  #resource_group: tuolumne
 run_tests_flux_tioga:
-  stage: test
+  extends: .run_tests_flux
   tags: [shell, tioga]
-  extends: .on_host_template
-  #resource_group: tioga
   needs: ["allocate_resources_tioga"]
-  variables:
-    HOST: tioga
-    ARCHCONFIG: llnl-elcapitan
-    BENCHMARK: amg2023
-    VARIANT: +rocm
-    SYSTEM_ARGS: ""
-    DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init --dest=tioga-system llnl-elcapitan cluster=tioga]
-  before_script:
-    - !reference [.report_status, before_script]
-  script:
-    - |
-      ALLOC_ID=$(flux jobs --name="${ALLOC_NAME}" -n -o "{id}")
-      echo -e "[Information]: Shared allocation ID = ${ALLOC_ID}"
-      PROXY="$( [[ -n "${ALLOC_ID}" ]] && echo "flux proxy ${ALLOC_ID}" || echo "" )"
-    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS}
-      .gitlab/utils/run-experiment.sh )
-  after_script:
-    - !reference [.report_status, after_script]
+  parallel:
+    matrix:
+      - HOST: tioga
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [amg2023, kripke]
+        VARIANT: [+rocm]
+        SYSTEM_ARGS: ['']
+        DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init
+          --dest=tioga-system llnl-elcapitan cluster=tioga]
+  #resource_group: tioga

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -1,11 +1,10 @@
 include:
   - local: .gitlab/utils/status.yml
   - local: .gitlab/utils/machine_checks.yml
-
 workflow:
   auto_cancel:
     on_new_commit: conservative
-
+# Common template for rules
 .on_host_template:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
@@ -23,70 +22,62 @@ workflow:
       - modifiers/**
       - var/**
       - lib/**
-
-allocate_resources_flux_tuolumne:
-  #resource_group: tuolumne
-  needs: ["tuolumne-up-check"]
+#############################
+# Resource Allocation Section
+#############################
+.allocate_resources_flux:
+  stage: allocate-resources
+  script:
+    - set -x
+    - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
+allocate_resources_tuolumne:
+  resource_group: tuolumne
+  extends: .allocate_resources_flux
   variables:
-    GIT_STRATEGY: none
     HOST: tuolumne
     SHARED_ALLOC: $TUOLUMNE_SHARED_ALLOC
-  stage: allocate-resources
   tags: [shell, tuolumne]
-  extends: .on_host_template
-  script:
-    - set -x
-    - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
-
-allocate_resources_flux_tioga:
-  allow_failure: false
-  #resource_group: tioga
-  needs: ["tioga-up-check"]
+  needs: ["tuolumne-up-check"]
+allocate_resources_tioga:
+  resource_group: tioga
+  extends: .allocate_resources_flux
   variables:
-    GIT_STRATEGY: none
     HOST: tioga
     SHARED_ALLOC: $TIOGA_SHARED_ALLOC
-  stage: allocate-resources
   tags: [shell, tioga]
-  extends: .on_host_template
+  needs: ["tioga-up-check"]
+##########################
+# Resource Release Section
+##########################
+.release_resources_flux:
+  stage: release-resources
   script:
     - set -x
-    - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
-
+    - export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+    - ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
+  variables:
+    GIT_STRATEGY: none
 release_resources_flux_tuolumne:
-  #resource_group: tuolumne
-  needs: ["allocate_resources_flux_tuolumne"]
+  resource_group: tuolumne
+  extends: .release_resources_flux
+  needs: ["allocate_resources_tuolumne"]
   variables:
-    GIT_STRATEGY: none
     HOST: tuolumne
-  stage: release-resources
   tags: [shell, tuolumne]
-  extends: .on_host_template
-  script:
-    - set -x
-    - export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
-    - ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
-
 release_resources_flux_tioga:
-  #resource_group: tioga
-  needs: ["allocate_resources_flux_tioga"]
+  resource_group: tioga
+  extends: .release_resources_flux
+  needs: ["allocate_resources_tioga"]
   variables:
-    GIT_STRATEGY: none
     HOST: tioga
-  stage: release-resources
   tags: [shell, tioga]
-  extends: .on_host_template
-  script:
-    - set -x
-    - export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
-    - ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
 
 run_tests_flux_tuolumne:
   stage: test
   tags: [shell, tuolumne]
   extends: .on_host_template
   #resource_group: tuolumne
-  needs: ["allocate_resources_flux_tuolumne"]
+  needs: ["allocate_resources_tuolumne"]
   variables:
     HOST: tuolumne
     ARCHCONFIG: llnl-elcapitan
@@ -111,7 +102,7 @@ run_tests_flux_tioga:
   tags: [shell, tioga]
   extends: .on_host_template
   #resource_group: tioga
-  needs: ["allocate_resources_flux_tioga"]
+  needs: ["allocate_resources_tioga"]
   variables:
     HOST: tioga
     ARCHCONFIG: llnl-elcapitan

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -20,14 +20,14 @@ allocate_resources_tuolumne:
     HOST: tuolumne
     SHARED_ALLOC: $TUOLUMNE_SHARED_ALLOC
   tags: [shell, tuolumne]
-  needs: ["tuolumne-up-check"]
+  needs: [tuolumne-up-check]
 allocate_resources_tioga:
   extends: .allocate_resources_flux
   variables:
     HOST: tioga
     SHARED_ALLOC: $TIOGA_SHARED_ALLOC
   tags: [shell, tioga]
-  needs: ["tioga-up-check"]
+  needs: [tioga-up-check]
 ##########################
 # Resource Release Section
 ##########################
@@ -42,13 +42,13 @@ allocate_resources_tioga:
     GIT_STRATEGY: none
 release_resources_flux_tuolumne:
   extends: .release_resources_flux
-  needs: ["allocate_resources_tuolumne", "run_tests_flux_tuolumne"]
+  needs: [allocate_resources_tuolumne, run_tests_flux_tuolumne]
   variables:
     HOST: tuolumne
   tags: [shell, tuolumne]
 release_resources_flux_tioga:
   extends: .release_resources_flux
-  needs: ["allocate_resources_tioga", "run_tests_flux_tioga"]
+  needs: [allocate_resources_tioga, run_tests_flux_tioga]
   variables:
     HOST: tioga
   tags: [shell, tioga]
@@ -65,13 +65,14 @@ release_resources_flux_tioga:
       ALLOC_ID=$(flux jobs --name="${ALLOC_NAME}" -n -o "{id}")
       echo -e "[Information]: Shared allocation ID = ${ALLOC_ID}"
       PROXY="$( [[ -n "${ALLOC_ID}" ]] && echo "flux proxy ${ALLOC_ID}" || echo "" )"
-    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS} .gitlab/utils/run-experiment.sh )
+    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS}
+      .gitlab/utils/run-experiment.sh )
   after_script:
     - !reference [.report_status, after_script]
 run_tests_flux_tuolumne:
   extends: .run_tests_flux
   tags: [shell, tuolumne]
-  needs: ["allocate_resources_tuolumne"]
+  needs: [allocate_resources_tuolumne]
   parallel:
     matrix:
       - HOST: tuolumne
@@ -92,7 +93,7 @@ run_tests_flux_tuolumne:
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]
-  needs: ["allocate_resources_tioga"]
+  needs: [allocate_resources_tioga]
   parallel:
     matrix:
       - HOST: tioga

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -1,105 +1,124 @@
 include:
   - local: .gitlab/utils/status.yml
+  - local: .gitlab/utils/machine_checks.yml
+
 workflow:
   auto_cancel:
     on_new_commit: conservative
-# Common host template
+
 .on_host_template:
   rules:
-    - if: $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH
-        != "develop" && $ALL_TARGETS != "ON"
+    - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_JOB_NAME =~ /release_resources/
-      when: always
+    - if: $CI_JOB_NAME =~ /release_resources/ && $CI_PIPELINE_SOURCE != "schedule"
+      when: on_success
     - when: on_success
-allocate_resources_flux:
-  resource_group: $HOST
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
-  variables:
-    GIT_STRATEGY: none
-  stage: allocate-resources
-  parallel:
-    matrix:
-      - HOST: tuolumne
-        SHARED_ALLOC: $TUOLUMNE_SHARED_ALLOC
-      - HOST: tioga
-        SHARED_ALLOC: $TIOGA_SHARED_ALLOC
-  tags: [shell, $HOST]
-  extends: .on_host_template
-  script:
-    - |
-      set -x
-      flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
-release_resources_flux:
-  resource_group: $HOST
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
-  variables:
-    GIT_STRATEGY: none
-  stage: release-resources
-  parallel:
-    matrix:
-      - HOST: tuolumne
-      - HOST: tioga
-  tags: [shell, $HOST]
-  extends: .on_host_template
-  script:
-    - |
-      set -x
-      export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
-      ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
-.test_clusters_template: &test_clusters_template
-  parallel:
-    matrix:
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke, laghos, raja-perf]
-        VARIANT: [+rocm]
-        SYSTEM_ARGS: [gpumode=SPX]
-        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
-          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
-      # Test TPX, CPX
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [laghos]
-        VARIANT: [+rocm]
-        SYSTEM_ARGS: [gpumode=TPX, gpumode=CPX]
-        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
-          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
-      - HOST: tioga
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke, laghos]
-        VARIANT: [+rocm]
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init
-          --dest=tioga-system llnl-elcapitan cluster=tioga]
-run_tests_flux:
-  stage: test
-  tags: [shell, $HOST]
-  extends: .on_host_template
-  <<: *test_clusters_template
-  resource_group: $HOST
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
     - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**
-        - experiments/**
-        - systems/$ARCHCONFIG/**
-        - repo/$BENCHMARK/**
-        - modifiers/**
-        - var/**
-        - lib/**
+      - .gitlab-ci.yml
+      - .gitlab/**
+      - bin/**
+      - experiments/$BENCHMARK/**
+      - systems/$ARCHCONFIG/**
+      - repo/$BENCHMARK/**
+      - modifiers/**
+      - var/**
+      - lib/**
+
+allocate_resources_flux_tuolumne:
+  #resource_group: tuolumne
+  needs: ["tuolumne-up-check"]
+  variables:
+    GIT_STRATEGY: none
+    HOST: tuolumne
+    SHARED_ALLOC: $TUOLUMNE_SHARED_ALLOC
+  stage: allocate-resources
+  tags: [shell, tuolumne]
+  extends: .on_host_template
+  script:
+    - set -x
+    - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
+
+allocate_resources_flux_tioga:
+  allow_failure: false
+  #resource_group: tioga
+  needs: ["tioga-up-check"]
+  variables:
+    GIT_STRATEGY: none
+    HOST: tioga
+    SHARED_ALLOC: $TIOGA_SHARED_ALLOC
+  stage: allocate-resources
+  tags: [shell, tioga]
+  extends: .on_host_template
+  script:
+    - set -x
+    - flux --parent alloc ${SHARED_ALLOC} --job-name=${ALLOC_NAME} --bg
+
+release_resources_flux_tuolumne:
+  #resource_group: tuolumne
+  needs: ["allocate_resources_flux_tuolumne"]
+  variables:
+    GIT_STRATEGY: none
+    HOST: tuolumne
+  stage: release-resources
+  tags: [shell, tuolumne]
+  extends: .on_host_template
+  script:
+    - set -x
+    - export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+    - ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
+
+release_resources_flux_tioga:
+  #resource_group: tioga
+  needs: ["allocate_resources_flux_tioga"]
+  variables:
+    GIT_STRATEGY: none
+    HOST: tioga
+  stage: release-resources
+  tags: [shell, tioga]
+  extends: .on_host_template
+  script:
+    - set -x
+    - export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+    - ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
+
+run_tests_flux_tuolumne:
+  stage: test
+  tags: [shell, tuolumne]
+  extends: .on_host_template
+  #resource_group: tuolumne
+  needs: ["allocate_resources_flux_tuolumne"]
+  variables:
+    HOST: tuolumne
+    ARCHCONFIG: llnl-elcapitan
+    BENCHMARK: amg2023
+    VARIANT: +rocm
+    SYSTEM_ARGS: gpumode=SPX
+    DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
+  before_script:
+    - !reference [.report_status, before_script]
+  script:
+    - |
+      ALLOC_ID=$(flux jobs --name="${ALLOC_NAME}" -n -o "{id}")
+      echo -e "[Information]: Shared allocation ID = ${ALLOC_ID}"
+      PROXY="$( [[ -n "${ALLOC_ID}" ]] && echo "flux proxy ${ALLOC_ID}" || echo "" )"
+    - ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS}
+      .gitlab/utils/run-experiment.sh )
+  after_script:
+    - !reference [.report_status, after_script]
+
+run_tests_flux_tioga:
+  stage: test
+  tags: [shell, tioga]
+  extends: .on_host_template
+  #resource_group: tioga
+  needs: ["allocate_resources_flux_tioga"]
+  variables:
+    HOST: tioga
+    ARCHCONFIG: llnl-elcapitan
+    BENCHMARK: amg2023
+    VARIANT: +rocm
+    SYSTEM_ARGS: ""
+    DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init --dest=tioga-system llnl-elcapitan cluster=tioga]
   before_script:
     - !reference [.report_status, before_script]
   script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -36,6 +36,7 @@ release_resources_dane:
 # Test Run Section
 ##################
 .test_clusters_dane: &test_clusters_dane
+  resource_group: dane
   extends: .on_host_template
   parallel:
     matrix:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -11,7 +11,7 @@ workflow:
 #############################
 allocate_resources_dane:
   tags: [shell, dane]
-  needs: ["dane-up-check"]
+  needs: [dane-up-check]
   variables:
     GIT_STRATEGY: none
   extends: .on_host_template
@@ -24,7 +24,7 @@ allocate_resources_dane:
 ##########################
 release_resources_dane:
   tags: [shell, dane]
-  needs: ["allocate_resources_dane", "run_tests_dane"]
+  needs: [allocate_resources_dane, run_tests_dane]
   variables:
     GIT_STRATEGY: none
   extends: .on_host_template
@@ -70,7 +70,7 @@ release_resources_dane:
           llnl-cluster cluster=dane]
 run_tests_dane:
   tags: [shell, dane]
-  needs: ["allocate_resources_dane"]
+  needs: [allocate_resources_dane]
   stage: test
   <<: *test_clusters_dane
   before_script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -1,60 +1,44 @@
 # Clusters listed here are native slurm clusters that we test using flux. See "non_shared.yaml"
 include:
   - local: .gitlab/utils/status.yml
+  - local: .gitlab/utils/machine_checks.yml
+  - local: .gitlab/utils/rules.yml
 workflow:
   auto_cancel:
     on_new_commit: conservative
-.on_host_dane:
+#############################
+# Resource Allocation Section
+#############################
+allocate_resources_dane:
   tags: [shell, dane]
-  rules:
-    # Advanced jobs can only run on master, develop or if ALL_TARGETS is ON.
-    # Set ADVANCED_JOB to ON in the job definition to make it an advanced job.
-    - if: $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH
-        != "develop" && $ALL_TARGETS != "ON"
-      when: never
-    # We should always release resources allocated in the pipeline.
-    - if: $CI_JOB_NAME =~ /release_resources/
-      when: always
-    # A true statement is expected to allow jobs to run. Here is the default.
-    - when: on_success
-allocate_resources_slurm:
-  resource_group: dane
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
+  needs: ["dane-up-check"]
   variables:
     GIT_STRATEGY: none
-  extends: .on_host_dane
+  extends: .on_host_template
   stage: allocate-resources
   script:
     - sbatch ${DANE_SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME} --wrap="srun
       -N 1 -n 1 flux start sleep inf"
-release_resources_slurm:
-  resource_group: dane
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
+##########################
+# Resource Release Section
+##########################
+release_resources_dane:
+  tags: [shell, dane]
+  needs: ["allocate_resources_dane", "run_tests_dane"]
   variables:
     GIT_STRATEGY: none
-  extends: .on_host_dane
+  extends: .on_host_template
   stage: release-resources
   script:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID} || exit 0)
+##################
+# Test Run Section
+##################
 .test_clusters_dane: &test_clusters_dane
+  extends: .on_host_template
   parallel:
     matrix:
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        BENCHMARK: [hpl, hpcg, amg2023, kripke]
-        VARIANT: [+openmp, '']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [laghos, raja-perf]
@@ -62,40 +46,11 @@ release_resources_slurm:
         SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
           llnl-cluster cluster=dane]
-      # Strong scaling runs for "benchpark analyze" test
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        BENCHMARK: [kripke]
-        VARIANT: ['+strong~single_node caliper=mpi,time']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
-      # Test affinity and hwloc with caliper on
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        BENCHMARK: [kripke]
-        VARIANT: ['+single_node caliper=mpi,time hwloc=on affinity=on']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
-run_tests_slurm:
-  extends: .on_host_dane
-  resource_group: $HOST
+run_tests_dane:
+  tags: [shell, dane]
+  needs: ["allocate_resources_dane"]
   stage: test
   <<: *test_clusters_dane
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - if: $CI_PIPELINE_SOURCE != "schedule"
-      when: always
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**
-        - experiments/**
-        - systems/$ARCHCONFIG/**
-        - repo/$BENCHMARK/**
-        - modifiers/**
-        - var/**
-        - lib/**
   before_script:
     - !reference [.report_status, before_script]
   script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -41,9 +41,31 @@ release_resources_dane:
     matrix:
       - HOST: dane
         ARCHCONFIG: llnl-cluster
+        BENCHMARK: [hpl, hpcg, amg2023, kripke]
+        VARIANT: [+openmp, '']
+        SYSTEM_ARGS: ['']
+        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
+          llnl-cluster cluster=dane]
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
         BENCHMARK: [laghos, raja-perf]
         VARIANT: ['']
         SYSTEM_ARGS: ['']
+        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
+          llnl-cluster cluster=dane]
+      # Strong scaling runs for "benchpark analyze" test
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        BENCHMARK: [kripke]
+        VARIANT: ['+strong~single_node caliper=mpi,time']
+        SYSTEM_ARGS: ['']
+        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
+          llnl-cluster cluster=dane]
+      # Test affinity and hwloc with caliper on
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        BENCHMARK: [kripke]
+        VARIANT: ['+single_node caliper=mpi,time hwloc=on affinity=on']
         DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
           llnl-cluster cluster=dane]
 run_tests_dane:

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -13,27 +13,29 @@
              --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab ${CI_MACHINE} down\", \"context\": \"ci/gitlab/${CI_MACHINE}\" }"
         exit 1
       fi
-  allow_failure: false
-# machine-up-check:
-#   extends: .machine-check
-#   stage: machine-checks
-#   parallel:
-#     matrix:
-#       - CI_MACHINE: [tuolumne, tioga, dane, lassen, ruby]
-#   rules:
-#     - when: on_success
 
 tioga-up-check:
   stage: machine-checks
   variables:
     CI_MACHINE: "tioga"
   extends: [.machine-check]
-  script:
-    - echo "Forcing failure for tioga for testing"
-    - exit 1
-
 tuolumne-up-check:
   stage: machine-checks
   variables:
     CI_MACHINE: "tuolumne"
+  extends: [.machine-check]
+dane-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: "dane"
+  extends: [.machine-check]
+ruby-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: "ruby"
+  extends: [.machine-check]
+lassen-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: "lassen"
   extends: [.machine-check]

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -13,29 +13,28 @@
              --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab ${CI_MACHINE} down\", \"context\": \"ci/gitlab/${CI_MACHINE}\" }"
         exit 1
       fi
-
 tioga-up-check:
   stage: machine-checks
   variables:
-    CI_MACHINE: "tioga"
+    CI_MACHINE: tioga
   extends: [.machine-check]
 tuolumne-up-check:
   stage: machine-checks
   variables:
-    CI_MACHINE: "tuolumne"
+    CI_MACHINE: tuolumne
   extends: [.machine-check]
 dane-up-check:
   stage: machine-checks
   variables:
-    CI_MACHINE: "dane"
+    CI_MACHINE: dane
   extends: [.machine-check]
 ruby-up-check:
   stage: machine-checks
   variables:
-    CI_MACHINE: "ruby"
+    CI_MACHINE: ruby
   extends: [.machine-check]
 lassen-up-check:
   stage: machine-checks
   variables:
-    CI_MACHINE: "lassen"
+    CI_MACHINE: lassen
   extends: [.machine-check]

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -1,0 +1,39 @@
+.machine-check:
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      if [[ $(jq '.[env.CI_MACHINE].total_nodes_up' /usr/global/tools/lorenz/data/loginnodeStatus) == 0 ]]
+      then
+        echo -e "\e[31mNo node available on ${CI_MACHINE}\e[0m"
+        curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab ${CI_MACHINE} down\", \"context\": \"ci/gitlab/${CI_MACHINE}\" }"
+        exit 1
+      fi
+  allow_failure: false
+# machine-up-check:
+#   extends: .machine-check
+#   stage: machine-checks
+#   parallel:
+#     matrix:
+#       - CI_MACHINE: [tuolumne, tioga, dane, lassen, ruby]
+#   rules:
+#     - when: on_success
+
+tioga-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: "tioga"
+  extends: [.machine-check]
+  script:
+    - echo "Forcing failure for tioga for testing"
+    - exit 1
+
+tuolumne-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: "tuolumne"
+  extends: [.machine-check]

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -1,17 +1,18 @@
 .on_host_template:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
+    - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
+        != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
     - if: $CI_JOB_NAME =~ /release_resources/ && $CI_PIPELINE_SOURCE != "schedule"
       when: on_success
     - when: on_success
     - changes:
-      - .gitlab-ci.yml
-      - .gitlab/**
-      - bin/**
-      - experiments/$BENCHMARK/**
-      - systems/$ARCHCONFIG/**
-      - repo/$BENCHMARK/**
-      - modifiers/**
-      - var/**
-      - lib/**
+        - .gitlab-ci.yml
+        - .gitlab/**
+        - bin/**
+        - experiments/$BENCHMARK/**
+        - systems/$ARCHCONFIG/**
+        - repo/$BENCHMARK/**
+        - modifiers/**
+        - var/**
+        - lib/**

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -1,0 +1,17 @@
+.on_host_template:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
+      when: never
+    - if: $CI_JOB_NAME =~ /release_resources/ && $CI_PIPELINE_SOURCE != "schedule"
+      when: on_success
+    - when: on_success
+    - changes:
+      - .gitlab-ci.yml
+      - .gitlab/**
+      - bin/**
+      - experiments/$BENCHMARK/**
+      - systems/$ARCHCONFIG/**
+      - repo/$BENCHMARK/**
+      - modifiers/**
+      - var/**
+      - lib/**

--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -25,8 +25,10 @@ cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
 
 ramble --disable-logger --workspace-dir . workspace setup
 
-if [ "$HOST" == "dane" ]; then
-    # Using flux on dane (srun called in "ramble on")
+# Using flux on dane (srun called in "ramble on")
+if [ "$HOST" == "dane" ] && \
+    # Nightly testing still using slurm
+    [ $CI_PIPELINE_SOURCE != "schedule" ]; then
     find . -type f -name execute_experiment -exec sed -i 's/\bsrun\b/flux run --exclusive/g' {} +
 fi
 


### PR DESCRIPTION
## Description

- [x] Add stage dependencies using the `needs` clause, update rules, and refactor gitlab yaml syntax such that jobs complete independently for each cluster. Before these changes, one cluster being down could block the other clusters.
- [x] ~These changes also allow disabling the `resource_group` parameter, which limited jobs to a single runner at a time. Since all we are requesting is non-interactive shell runners that are mainly for submitting the shell script to the allocated node and watch for stdout, they do not use much resources and we can submit jobs in parallel.~ Removing this for now and tracking bug for this feature in #862 
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/04d908ae-4d2c-4194-b4e2-cef022de36fe" />

~each of the `run_test*` runners are running in parallel, but are non-interactive shell runners on the login node **not** individual batch requests.~

- [x] Fix Dane nightly tests which use slurm (dailys use flux)

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/**` for rework
