### PR TITLE
ci: add concurrency groups to cancel obsolete CI runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,11 @@ on:
     secrets:
       BENCHPARK_CODECOV_TOKEN:
         required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_unit_tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/diffpackages.yml
+++ b/.github/workflows/diffpackages.yml
@@ -4,6 +4,11 @@ on:
       modified_repo_dirs:
         required: true
         type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   diffPackages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,11 @@
 name: Build & Deploy docs site to GitHub Pages
 on:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,6 +1,11 @@
 name: License Checks
 on:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-license:
     runs-on: ubuntu-24.04

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,6 +1,11 @@
 name: Run Benchpark and Simple Benchmark Suite
 on:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   saxpy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,11 @@
 name: Linting & Style Checks
 on:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**Pull Request Update:** Enhance CI Efficiency by Adding Concurrency Controls in **benchpark** 🚀

---

## What’s Changed

* **Unmodified**

  * `ci.yml` already includes `concurrency`—no change needed.
  * `label.yml` is event-driven; left untouched.
  * `nightly.yml` remains as-is (optional to add, but not critical).

* **Added `concurrency`** to:

  * `coverage.yml`
  * `diffpackages.yml`
  * `docs.yml`
  * `license.yml`
  * `run.yml`
  * `style.yml`

Each of these workflows now starts with:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

---

## Example of the Issue

1. **Without concurrency groups:**

   * Developer A pushes **commit `abc123`** → CI run **15** is queued.
   * Before 15 starts, Dev A pushes **commit `def456`** → CI run **16** is queued behind 15.
   * CI run 15 starts and completes, then 16 runs.
   * **Wasted effort:** Runner time spent on 15, even though its results are now obsolete.

2. **With concurrency groups (this PR):**

   * Dev A pushes **commit `abc123`** → CI run **15** queued.
   * Dev A pushes **commit `def456`** → CI run **16** queued **and immediately cancels** 15.
   * Only 16 runs.
   * **Result:** No redundant builds; feedback for the latest code arrives sooner.

---

## Why This Matters

1. **Eliminate Redundant Runs**
   Older queued or in-flight jobs are auto-cancelled as soon as a new commit lands on the same branch, so we never waste runner time on obsolete builds.

2. **Faster Feedback**
   Developers see results for their latest changes immediately, instead of waiting behind outdated jobs in the queue.

3. **Reduced CI Costs**
   By cancelling stale jobs, we free up minutes and capacity for truly necessary work.

4. **Clean Build History**
   Only the most relevant runs are kept, making it easier to spot and debug failures.

---

## How to Verify

1. Push a commit to any branch in **benchpark** (e.g. `feature/foo`).
2. Immediately push another commit to that same branch.
3. In the GitHub Actions UI, confirm that the first run is cancelled the moment the second is queued—only the latest run proceeds.

---

Please review the file changes. If you’d like to include `nightly.yml` as well or adjust the grouping key, let me know!
