### PR TITLE
add developer docs

### DIFF
--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -1,0 +1,84 @@
+.. Copyright 2023 Lawrence Livermore National Security, LLC and other
+   Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: Apache-2.0
+
+===============
+Developer Guide
+===============
+
+This guide is intended for people who want to work on Benchpark itself.
+
+--------
+Overview
+--------
+
+Benchpark is designed with several roles in mind:
+
+#. **Users**, who want to install, run, and analyze performance of HPC benchmarks
+#. **Application Developers**, who want to share their benchmarks.
+#. **Procurement Teams**, who curate workload representation, evaluate and
+   monitor system progress at HPC centers.
+#. **HPC Vendors**, who understand the curated workload of HPC centers, propose
+   systems.
+#. **Benchpark Developers**, who work on Benchpark, add new features, and try
+   to make the jobs of benchmark developers and users easier.
+
+This gets us to the key concepts in Benchpark's software design:
+
+- Specs: expressions for describing experiments and compute systems
+- Packages: Python modules that build benchmarks according to a spec.
+
+-------------------
+Directory Structure
+-------------------
+
+So that you can familiarize yourself with the project, we will start with a
+high-level view of Benchpark's directory structure:
+
+.. code-block:: none
+
+   benchpark/
+      bin/
+         benchpark              <- main benchpark executable
+
+      common-resources/
+         execute_experiment.tpl
+
+      docs/                     <- source for this documentation
+
+      experiments/              <- experiment specs are defined here
+
+      lib/
+         benchpark/             <- benchpark module
+         scripts/               <- developer scripts
+
+      modifiers/                <- modifier definitions
+
+      repo/                     <- benchmarks are defined here
+
+      systems/                  <- system specs are defined here
+
+      var/
+         exp_repo/
+         sys_repo/
+
+----------------------
+Updating Documentation
+----------------------
+
+To update and build the documentation, we need to install the Sphinx package.
+
+.. code-block:: bash
+
+   pip install sphinx
+
+After updating the documentation, render the pages with the following:
+
+.. code-block:: bash
+
+   cd docs
+   make html
+
+Then, open ``_build/html/index.html`` in a browser to view the rendered
+documentation.

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -43,9 +43,6 @@ high-level view of Benchpark's directory structure:
          benchpark              <- main benchpark executable
          benchpark-python       <- execute python scripts using benchpark library
 
-      common-resources/
-         execute_experiment.tpl
-
       docs/                     <- source for this documentation
 
       experiments/              <- experiment specs
@@ -61,10 +58,6 @@ high-level view of Benchpark's directory structure:
          **/package.py          <- spack package spec
 
       systems/                  <- system specs
-
-      var/
-         exp_repo/
-         sys_repo/
 
 ----------------------
 Updating Documentation

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -76,7 +76,7 @@ To build the documentation, requirements can be easily installed from ``.github/
 
    pip install -r .github/workflows/requirements/docs.txt
 
-After updating the documentation, render the pages with the following:
+This requires ``python>=3.11`` (or try an earlier version of sphinx). After updating the documentation, render the pages with the following:
 
 .. code-block:: bash
 

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -41,23 +41,26 @@ high-level view of Benchpark's directory structure:
    benchpark/
       bin/
          benchpark              <- main benchpark executable
+         benchpark-python       <- execute python scripts using benchpark library
 
       common-resources/
          execute_experiment.tpl
 
       docs/                     <- source for this documentation
 
-      experiments/              <- experiment specs are defined here
+      experiments/              <- experiment specs
 
       lib/
-         benchpark/             <- benchpark module
-         scripts/               <- developer scripts
+         benchpark/             <- benchpark library
+         scripts/               <- scripts for common benchpark use cases
 
       modifiers/                <- modifier definitions
 
       repo/                     <- benchmarks are defined here
+         **/application.py      <- ramble application spec
+         **/package.py          <- spack package spec
 
-      systems/                  <- system specs are defined here
+      systems/                  <- system specs
 
       var/
          exp_repo/
@@ -67,11 +70,11 @@ high-level view of Benchpark's directory structure:
 Updating Documentation
 ----------------------
 
-To update and build the documentation, we need to install the Sphinx package.
+To build the documentation, requirements can be easily installed from ``.github/workflows/requirements/docs.txt``, using:
 
 .. code-block:: bash
 
-   pip install sphinx
+   pip install -r .github/workflows/requirements/docs.txt
 
 After updating the documentation, render the pages with the following:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@
    add-an-experiment
    add-a-dryrun
    update-a-system-config
+   developer-guide
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,11 @@
    add-an-experiment
    add-a-dryrun
    update-a-system-config
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Developer Docs
+
    developer-guide
 
 .. toctree::


### PR DESCRIPTION
## Description

Start section for developer docs with the following subsections:
- how to build documentation
- directory structure
- types of users

#786 will build extend details for the developer docs