### PR TITLE
Add 512 and 1024 Block Sizes to RAJAPerf

### DIFF
--- a/repo/raja-perf/package.py
+++ b/repo/raja-perf/package.py
@@ -308,6 +308,9 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         else:
             entries.append(cmake_cache_option("ENABLE_HIP", False))
 
+        if "+cuda" in spec or "+rocm" in spec:
+            entries.append(cmake_cache_string("RAJA_PERFSUITE_GPU_BLOCKSIZES", "25,64,128,256,512,1024"))
+
         entries.append(cmake_cache_option("ENABLE_OPENMP_TARGET", "+openmp_target" in spec))
         if "+openmp_target" in spec:
             if ("%xl" in spec):


### PR DESCRIPTION
## Description

- [x] `RAJA_PERFSUITE_GPU_BLOCKSIZES` is required to build with for block sizes 512 and 1024. The defaults are 25, 64, 128, and 256

```
RAJA_HIP-block_25
RAJA_HIP-block_64
RAJA_HIP-block_128
RAJA_HIP-block_256
RAJA_HIP-block_512
RAJA_HIP-block_1024
```

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Update `repo/raja-perf/package.py`
