### PR TITLE
Set cuda 12.6 as the default on matrix

### DIFF
--- a/systems/llnl-matrix/system.py
+++ b/systems/llnl-matrix/system.py
@@ -28,8 +28,8 @@ class LlnlMatrix(System):
 
     variant(
         "cuda",
-        default="12.2.2",
-        values=("12.2.2", "11.8.0"),
+        default="12.6.0",
+        values=("12.6.0", "12.2.2", "11.8.0"),
         description="CUDA version",
     )
 


### PR DESCRIPTION
## Description
This PR sets cuda 12.6.0 as the default compiler on matrix.
12.6.0 fixes the runtime error in laghos/mfem #770 #855

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))
- [x] Add/modify `systems/system_name/system.py` file