### PR TITLE
Change intel oneapi optimization flags for mfem

### DIFF
--- a/repo/mfem/package.py
+++ b/repo/mfem/package.py
@@ -22,6 +22,13 @@ class Mfem(BuiltinMfem):
 
     requires("+caliper", when="^hypre+caliper")
 
+    def configure(self, spec, prefix):
+        if spec.satisfies('%oneapi'):
+            spec.compiler_flags["cxxflags"] = [flag for flag in spec.compiler_flags["cxxflags"] if not flag.startswith('-O')]
+            spec.compiler_flags["cxxflags"].append("-O2")
+            spec.compiler_flags["cxxflags"].append("-fp-speculation=safe")
+        super().configure(spec, prefix)
+
     def setup_build_environment(self, env):
         if "+cuda" in self.spec:
             env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")


### PR DESCRIPTION
## Description
This PR changes the intel oneapi compiler flags for mfem to use `-O2 -fp-speculation=safe`
This change circumvents default non-safe optimizations that break things in MFEM (https://github.com/mfem/mfem/issues/4768)
Fixes issue #856

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))
- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.