### PR TITLE
Replace oneapi 2022 with 2023

### DIFF
--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -72,17 +72,9 @@ release_resources_dane:
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
-        BENCHMARK: [laghos]
-        VARIANT: [caliper=mpi scaling=strong]
-        SYSTEM_ARGS: [compiler=oneapi2023]
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023]
         VARIANT: [caliper=mpi scaling=strong, caliper=mpi scaling=weak]
-        SYSTEM_ARGS: [compiler=oneapi]
+        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
           llnl-cluster cluster=dane]
 run_tests_dane:

--- a/repo/hypre/package.py
+++ b/repo/hypre/package.py
@@ -30,6 +30,18 @@ class Hypre(BuiltinHypre):
         return configure_args
 
     def setup_build_environment(self, env):
+        if self.spec.satisfies('%oneapi'):
+            compiler_version = self.spec.compiler.version
+
+            # Convert to integer for comparison (e.g., 2023.1.0 -> 2023)
+            major_version = int(str(compiler_version).split('.')[0])
+
+            if major_version < 2023:
+                raise RuntimeError(
+                    "This package requires Intel oneAPI compiler version 2023 or newer. "
+                    "Detected version: {0}".format(compiler_version)
+                )
+
         super().setup_build_environment(env)
 
         spec = self.spec

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -48,8 +48,8 @@ class LlnlCluster(System):
 
     variant(
         "compiler",
-        default="oneapi2023",
-        values=("oneapi", "oneapi2023", "gcc", "intel"),
+        default="oneapi",
+        values=("oneapi", "oneapi", "gcc", "intel"),
         description="Which compiler to use",
     )
 
@@ -204,24 +204,6 @@ class LlnlCluster(System):
                         "buildable": False,
                         "externals": [
                             {
-                                "spec": "mvapich2@2.3.7-intel202210",
-                                "prefix": "/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0",
-                                "extra_attributes": {
-                                    "ldflags": "-L/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0/lib -lmpi"
-                                },
-                            }
-                        ],
-                    }
-                }
-            }
-        elif self.spec.satisfies("compiler=oneapi2023"):
-            selections |= {
-                "packages": selections["packages"]
-                | {
-                    "mpi": {
-                        "buildable": False,
-                        "externals": [
-                            {
                                 "spec": "mvapich2@2.3.7-intel202321",
                                 "prefix": "/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2023.2.1",
                                 "extra_attributes": {
@@ -238,11 +220,7 @@ class LlnlCluster(System):
         return selections
 
     def compiler_weighting_cfg(self):
-        compiler = self.spec.variants["compiler"][0]
-
-        if compiler == "oneapi":
-            return {"packages": {"all": {"require": [{"one_of": ["%oneapi", "%gcc"]}]}}}
-        elif compiler == "oneapi2023":
+        if self.spec.satisfies("compiler=oneapi"):
             return {"packages": {"all": {"require": [{"one_of": ["%oneapi", "%gcc"]}]}}}
         else:
             return {"packages": {}}
@@ -315,45 +293,6 @@ class LlnlCluster(System):
                     },
                     {
                         "compiler": {
-                            "spec": "oneapi@2022.1.0",
-                            "paths": {
-                                "cc": "/usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icx",
-                                "cxx": "/usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/icpx",
-                                "f77": "/usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx",
-                                "fc": "/usr/tce/packages/intel/intel-2022.1.0/compiler/2022.1.0/linux/bin/ifx",
-                            },
-                            "flags": {},
-                            "operating_system": "rhel8",
-                            "target": "x86_64",
-                            "modules": [],
-                            "environment": {},
-                            "extra_rpaths": [],
-                        }
-                    },
-                ]
-            }
-        elif self.spec.satisfies("compiler=oneapi2023"):
-            selections = {
-                "compilers": [
-                    {
-                        "compiler": {
-                            "spec": "gcc@12.1.1",
-                            "paths": {
-                                "cc": "/usr/tce/packages/gcc/gcc-12.1.1/bin/gcc",
-                                "cxx": "/usr/tce/packages/gcc/gcc-12.1.1/bin/g++",
-                                "f77": "/usr/tce/packages/gcc/gcc-12.1.1/bin/gfortran",
-                                "fc": "/usr/tce/packages/gcc/gcc-12.1.1/bin/gfortran",
-                            },
-                            "flags": {},
-                            "operating_system": "rhel8",
-                            "target": "x86_64",
-                            "modules": [],
-                            "environment": {},
-                            "extra_rpaths": [],
-                        }
-                    },
-                    {
-                        "compiler": {
                             "spec": "oneapi@2023.2.1",
                             "paths": {
                                 "cc": "/usr/tce/packages/intel/intel-2023.2.1/compiler/2023.2.1/linux/bin/icx",
@@ -378,13 +317,7 @@ class LlnlCluster(System):
         return {
             "software": {
                 "packages": {
-                    "default-compiler": {
-                        "pkg_spec": (
-                            "oneapi"
-                            if self.spec.satisfies("compiler=oneapi2023")
-                            else self.spec.variants["compiler"][0]
-                        )
-                    },
+                    "default-compiler": {"pkg_spec": self.spec.variants["compiler"][0]},
                     "default-mpi": {"pkg_spec": "mvapich2"},
                     "compiler-gcc": {"pkg_spec": "gcc"},
                     "compiler-intel": {"pkg_spec": "intel"},

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -49,7 +49,7 @@ class LlnlCluster(System):
     variant(
         "compiler",
         default="oneapi",
-        values=("oneapi", "oneapi", "gcc", "intel"),
+        values=("oneapi", "gcc", "intel"),
         description="Which compiler to use",
     )
 


### PR DESCRIPTION
## Description

- [x] There is a hypre build issue (https://lc.llnl.gov/gitlab/benchpark/benchpark/-/jobs/2730071) for oneapi2022, which prevents building amg2023. Using oneapi2023 works for all benchmarks, so changing to this version by default.
- [x] Disallow `oneapi@<=2022` by manual check in package.py to avoid hypre build error

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `systems/llnl-cluster/system.py`