### PR TITLE
Refactor CDash Dashboard Names

### DIFF
--- a/.gitlab/tests/non_shared.yml
+++ b/.gitlab/tests/non_shared.yml
@@ -21,7 +21,7 @@ workflow:
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
         SCHEDULER_PARAMETERS: -nnodes 1 -W 40 -q pci
-        BENCHMARK: [amg2023, kripke, raja-perf]
+        BENCHMARK: [amg2023, kripke]
         VARIANT: [+cuda]
 run_tests_nonshared:
   resource_group: $HOST

--- a/.gitlab/tests/non_shared.yml
+++ b/.gitlab/tests/non_shared.yml
@@ -18,18 +18,11 @@ workflow:
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 00:30:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023, kripke, laghos]
-        VARIANT: ['']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Ruby Supermicro-icelake-OmniPath [benchpark system init --dest=ruby-system
-          llnl-cluster cluster=ruby]
       - HOST: lassen
         ARCHCONFIG: llnl-sierra
         SCHEDULER_PARAMETERS: -nnodes 1 -W 40 -q pci
         BENCHMARK: [amg2023, kripke, raja-perf]
         VARIANT: [+cuda]
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system
-          llnl-sierra]
 run_tests_nonshared:
   resource_group: $HOST
   stage: test

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -80,25 +80,16 @@ run_tests_flux_tuolumne:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [amg2023, kripke, laghos, raja-perf]
         VARIANT: [+rocm]
-        SYSTEM_ARGS: [gpumode=SPX]
-        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
-          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive
         BENCHMARK: [amg2023]
         VARIANT: [+rocm scaling=strong]
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
-          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
       # Test TPX, CPX
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [laghos]
         VARIANT: [+rocm]
         SYSTEM_ARGS: [gpumode=TPX, gpumode=CPX]
-        DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
-          --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
 run_tests_flux_tioga:
   resource_group: tioga
   extends: .run_tests_flux
@@ -110,6 +101,3 @@ run_tests_flux_tioga:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [amg2023, kripke, laghos]
         VARIANT: [+rocm]
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init
-          --dest=tioga-system llnl-elcapitan cluster=tioga]

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -55,7 +55,9 @@ release_resources_dane:
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke, amg2023]
-        VARIANT: ['scaling=strong caliper=mpi,time', 'scaling=weak caliper=mpi,time']
+        VARIANT:
+          - scaling=strong caliper=mpi,time
+          - scaling=weak caliper=mpi,time
       # Test old_scaling
       - HOST: dane
         ARCHCONFIG: llnl-cluster

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -44,47 +44,29 @@ release_resources_dane:
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [hpl, hpcg, amg2023, kripke]
         VARIANT: [+openmp, '']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [laghos, raja-perf, phloem]
-        VARIANT: ['']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       # Strong scaling runs for "benchpark analyze" test
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke]
         VARIANT: ['scaling=strong caliper=mpi,time']
-        SYSTEM_ARGS: ['']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       # Test affinity and hwloc with caliper on
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke]
         VARIANT: ['caliper=mpi,time hwloc=on affinity=on']
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [laghos]
         VARIANT: [caliper=mpi scaling=strong]
         SYSTEM_ARGS: [compiler=oneapi2023]
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023]
         VARIANT: [caliper=mpi scaling=strong, caliper=mpi scaling=weak]
         SYSTEM_ARGS: [compiler=oneapi]
-        DASHBOARD_NAME: Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system
-          llnl-cluster cluster=dane]
 run_tests_dane:
   tags: [shell, dane]
   needs: [allocate_resources_dane]

--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -30,10 +30,19 @@
       fi
     - |
       if [[ $RUN_CTEST == "true" ]]; then
+        # associative array (Bash 4+)
+        declare -A DASHBOARD_NAMES
+        # Map cluster names to their full dashboard names
+        DASHBOARD_NAMES["tuolumne"]="Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]"
+        DASHBOARD_NAMES["tioga"]="Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init --dest=tioga-system llnl-elcapitan cluster=tioga]"
+        DASHBOARD_NAMES["ruby"]="Ruby Supermicro-icelake-OmniPath [benchpark system init --dest=ruby-system llnl-cluster cluster=ruby]"
+        DASHBOARD_NAMES["lassen"]="Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system llnl-sierra]"
+        DASHBOARD_NAMES["dane"]="Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system llnl-cluster cluster=dane]"
+        # Run ctest
         module load cmake/3.23.1
         ctest -S CTestGitlab.cmake \
           -DHOST="${HOST}" \
-          -DDASHBOARD_NAME="${DASHBOARD_NAME}" \
+          -DDASHBOARD_NAME="${DASHBOARD_NAMES[$HOST]}" \
           -DBUILD_NAME="${HOST}/${BENCHMARK}${VARIANT} ${SYSTEM_ARGS}" \
           -DSITE="$(hostname)" \
           -DTEST_TYPE="${TEST_TYPE}"


### PR DESCRIPTION
## Description

- [x] CDash Dashboard names and empty arguments in matrix make gitlab tests hard to read and the dashboard names are redundant to have in the matrix, since they map 1:1 to the hostname. This change selects the correct dashboard name based on the hostname right before uploading to cdash.
- [x] Succinct naming also helps avoid an error where Gitlab refuses names greater than 255 characters
```
release_resources_flux_tuolumne job: need `run_tests_flux_tuolumne: [tuolumne, llnl-elcapitan, -N 1 -t 30m --queue=pci --exclusive, amg2023, +rocm caliper=mpi scaling=strong scaling-iterations=2, , Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]]` name is too long (maximum is 255 characters)
```

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab` files related to dashboards
