### PR TITLE
Enable Parallel Pipeline Concurrency (Speed Up Multiple Pipelines)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ variables:
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
-  CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
+  CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/bd/$CI_PIPELINE_ID
   BUILDDIR: $CUSTOM_CI_BUILDS_DIR
   CI_BUILDS_DIR: $CUSTOM_CI_BUILDS_DIR/$CI_RUNNER_SHORT_TOKEN
   CI_PROJECT_DIR: $CI_BUILDS_DIR/gitlab/benchpark/benchpark

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,8 @@ variables:
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
-  CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PROJECT_NAME/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
-  #/g/g0/benchpark/.jacamar-ci/builds/yxrvGpCU/001
+  CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
+  SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   FLUX_ARGS: -N 1 --exclusive
   # Dane
-  DANE_SHARED_ALLOC: -N 1 -t 12:00:00 --exclusive --reservation=ci
+  DANE_SHARED_ALLOC: -N 1 -t 06:00:00 --exclusive --reservation=ci
   # Tuolumne (max 4hr policy)
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ variables:
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
-  CUSTOM_CI_BUILDS_DIR: ~/.jacamar-ci/builds/$CI_PROJECT_NAME/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
+  CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PROJECT_NAME/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
   #/g/g0/benchpark/.jacamar-ci/builds/yxrvGpCU/001
 default:
   id_tokens:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,11 @@ variables:
   ALWAYS_RUN_PATTERN: ^develop$|^master$|^v[0-9.]*$|^releases/$
   # Expand multi-line commands in logs
   FF_SCRIPT_SECTIONS: 1
+  # clean up the repository after the job finishes
+  FF_ENABLE_JOB_CLEANUP: "true"
+  GIT_STRATEGY: "fetch"
   # Debugging logs on gitlab
-  CI_DEBUG_TRACE: "true"
+  CI_DEBUG_TRACE: 'true'
   # Job variables
   # LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -t 00:30:00 --exclusive --reservation=ci"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
@@ -22,9 +25,10 @@ variables:
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
   CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
+  BUILDDIR: $CUSTOM_CI_BUILDS_DIR
   CI_BUILDS_DIR: $CUSTOM_CI_BUILDS_DIR/$CI_RUNNER_SHORT_TOKEN
   CI_PROJECT_DIR: $CI_BUILDS_DIR/gitlab/benchpark/benchpark
-  #SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
+  # SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,9 @@ variables:
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
   CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/builds/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
-  SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
+  CI_BUILDS_DIR: $CUSTOM_CI_BUILDS_DIR/$CI_RUNNER_SHORT_TOKEN
+  CI_PROJECT_DIR: $CI_BUILDS_DIR/gitlab/benchpark/benchpark
+  #SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,9 @@ variables:
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   FLUX_ARGS: -N 1 --exclusive
   # Dane
-  DANE_SHARED_ALLOC: -N 1 -t 06:00:00 --exclusive --reservation=ci
+  DANE_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive --reservation=ci
   # Tuolumne (max 4hr policy)
-  TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
+  TUOLUMNE_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,8 @@ variables:
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
   CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/bd/$CI_PIPELINE_ID
+  # Dir cleanup can take awhile
+  RUNNER_AFTER_SCRIPT_TIMEOUT: 20m
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,3 +50,13 @@ stages:
   - allocate-resources
   - test
   - release-resources
+  - cleanup-dir
+cleanup_pipeline_dir:
+  tags: [shell, oslic]
+  needs:
+    - release_resources_dane
+    - release_resources_flux_tioga
+    - release_resources_flux_tuolumne
+  extends: .on_host_template
+  stage: cleanup-dir
+  script: [rm -rf $CUSTOM_CI_BUILDS_DIR]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,12 +10,11 @@ variables:
   # Expand multi-line commands in logs
   FF_SCRIPT_SECTIONS: 1
   # clean up the repository after the job finishes
-  FF_ENABLE_JOB_CLEANUP: "true"
-  GIT_STRATEGY: "fetch"
+  FF_ENABLE_JOB_CLEANUP: 'true'
+  GIT_STRATEGY: fetch
   # Debugging logs on gitlab
-  CI_DEBUG_TRACE: 'true'
+  # CI_DEBUG_TRACE: 'true'
   # Job variables
-  # LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -t 00:30:00 --exclusive --reservation=ci"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   FLUX_ARGS: -N 1 --exclusive
   # Dane
@@ -25,10 +24,6 @@ variables:
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
   CUSTOM_CI_BUILDS_DIR: /g/g0/benchpark/.jacamar-ci/bd/$CI_PIPELINE_ID
-  BUILDDIR: $CUSTOM_CI_BUILDS_DIR
-  CI_BUILDS_DIR: $CUSTOM_CI_BUILDS_DIR/$CI_RUNNER_SHORT_TOKEN
-  CI_PROJECT_DIR: $CI_BUILDS_DIR/gitlab/benchpark/benchpark
-  # SPACK_INSTALL_TREE: $CUSTOM_CI_BUILDS_DIR/spack/opt/spack
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,4 +59,6 @@ cleanup_pipeline_dir:
     - release_resources_flux_tuolumne
   extends: .on_host_template
   stage: cleanup-dir
-  script: [rm -rf $CUSTOM_CI_BUILDS_DIR]
+  script:
+    - echo "Removing $CUSTOM_CI_BUILDS_DIR"
+    - rm -rf $CUSTOM_CI_BUILDS_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   # Expand multi-line commands in logs
   FF_SCRIPT_SECTIONS: 1
   # Debugging logs on gitlab
-  # CI_DEBUG_TRACE: "true"
+  CI_DEBUG_TRACE: "true"
   # Job variables
   # LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -t 00:30:00 --exclusive --reservation=ci"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
@@ -21,6 +21,8 @@ variables:
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive
+  CUSTOM_CI_BUILDS_DIR: ~/.jacamar-ci/builds/$CI_PROJECT_NAME/$CI_PIPELINE_ID/$CI_CONCURRENT_ID
+  #/g/g0/benchpark/.jacamar-ci/builds/yxrvGpCU/001
 default:
   id_tokens:
     SITE_ID_TOKEN:

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -41,7 +41,8 @@ allocate_resources_tioga:
 .release_resources_flux:
   extends: .on_host_template
   stage: release-resources
-  script: [. .gitlab/utils/cancel-flux.sh]
+  # Do not cleanup dir yet
+  script: [. .gitlab/utils/cancel-flux.sh --no-clean]
 release_resources_flux_tuolumne:
   extends: .release_resources_flux
   needs: [allocate_resources_tuolumne, run_tests_flux_tuolumne]

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -70,7 +70,6 @@ release_resources_flux_tioga:
   after_script:
     - !reference [.report_status, after_script]
 run_tests_flux_tuolumne:
-  resource_group: tuolumne
   extends: .run_tests_flux
   tags: [shell, tuolumne]
   needs: [allocate_resources_tuolumne]
@@ -100,7 +99,6 @@ run_tests_flux_tuolumne:
         DASHBOARD_NAME: Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init
           --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]
 run_tests_flux_tioga:
-  resource_group: tioga
   extends: .run_tests_flux
   tags: [shell, tioga]
   needs: [allocate_resources_tioga]

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -98,7 +98,7 @@ run_tests_flux_tuolumne:
         GPUMODE: TPX
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke, laghos, raja-perf]
+        BENCHMARK: [kripke, laghos]
         VARIANT: [+rocm scaling=strong scaling-iterations=2]
         SYSTEM_ARGS: [gpumode=CPX]
         GPUMODE: CPX

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -98,7 +98,7 @@ run_tests_flux_tuolumne:
         GPUMODE: TPX
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke, laghos]
+        BENCHMARK: [kripke, laghos, raja-perf]
         VARIANT: [+rocm scaling=strong scaling-iterations=2]
         SYSTEM_ARGS: [gpumode=CPX]
         GPUMODE: CPX

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -42,8 +42,6 @@ allocate_resources_tioga:
   extends: .on_host_template
   stage: release-resources
   script: [. .gitlab/utils/cancel-flux.sh]
-  variables:
-    GIT_STRATEGY: none
 release_resources_flux_tuolumne:
   extends: .release_resources_flux
   needs: [allocate_resources_tuolumne, run_tests_flux_tuolumne]

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -12,8 +12,6 @@ workflow:
 allocate_resources_dane:
   tags: [shell, dane]
   needs: [dane-up-check]
-  variables:
-    GIT_STRATEGY: none
   extends: .on_host_template
   stage: allocate-resources
   script:
@@ -30,8 +28,6 @@ allocate_resources_dane:
 release_resources_dane:
   tags: [shell, dane]
   needs: [allocate_resources_dane, run_tests_slurm_dane]
-  variables:
-    GIT_STRATEGY: none
   extends: .on_host_template
   stage: release-resources
   script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -36,7 +36,6 @@ release_resources_dane:
 # Test Run Section
 ##################
 .test_clusters_dane: &test_clusters_dane
-  resource_group: dane
   extends: .on_host_template
   parallel:
     matrix:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -30,8 +30,9 @@ release_resources_dane:
   needs: [allocate_resources_dane, run_tests_slurm_dane]
   extends: .on_host_template
   stage: release-resources
+  # Do not cleanup dir yet
   script:
-    - . .gitlab/utils/cancel-slurm.sh
+    - . .gitlab/utils/cancel-slurm.sh --no-clean
 ##################
 # Test Run Section
 ##################

--- a/.gitlab/utils/cancel-flux.sh
+++ b/.gitlab/utils/cancel-flux.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -x
+
+NO_CLEAN=false
+if [[ "$1" == "--no-clean" ]]; then
+    NO_CLEAN=true
+fi
+
 export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME}${GPUMODE} | awk '{print $1}')
 ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
-echo "Removing $CUSTOM_CI_BUILDS_DIR"
-rm -rf $CUSTOM_CI_BUILDS_DIR
+
+if ! $NO_CLEAN; then
+    rm -rf $CUSTOM_CI_BUILDS_DIR
+fi

--- a/.gitlab/utils/cancel-flux.sh
+++ b/.gitlab/utils/cancel-flux.sh
@@ -2,3 +2,5 @@
 set -x
 export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME}${GPUMODE} | awk '{print $1}')
 ([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
+echo "Removing $CUSTOM_CI_BUILDS_DIR"
+rm -rf $CUSTOM_CI_BUILDS_DIR

--- a/.gitlab/utils/cancel-slurm.sh
+++ b/.gitlab/utils/cancel-slurm.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+set -x
 export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
 ([[ -n "${JOBID}" ]] && scancel ${JOBID} || exit 0)
+echo "Removing $CUSTOM_CI_BUILDS_DIR"
+rm -rf $CUSTOM_CI_BUILDS_DIR

--- a/.gitlab/utils/cancel-slurm.sh
+++ b/.gitlab/utils/cancel-slurm.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -x
+
+NO_CLEAN=false
+if [[ "$1" == "--no-clean" ]]; then
+    NO_CLEAN=true
+fi
+
 export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
 ([[ -n "${JOBID}" ]] && scancel ${JOBID} || exit 0)
-echo "Removing $CUSTOM_CI_BUILDS_DIR"
-rm -rf $CUSTOM_CI_BUILDS_DIR
+
+if ! $NO_CLEAN; then
+    rm -rf $CUSTOM_CI_BUILDS_DIR
+fi

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -3,7 +3,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_JOB_NAME =~ /release_resources/ && $CI_PIPELINE_SOURCE != "schedule"
+    - if: $CI_JOB_NAME =~ /release_resources|cleanup_pipeline_dir/ && $CI_PIPELINE_SOURCE
+        != "schedule"
       when: always
     - when: on_success
     - changes:

--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -15,13 +15,13 @@ fi
 ./bin/benchpark experiment init --dest=${BENCHMARK} ${BENCHMARK} ${VARIANT}
 
 # Build Workspace
-./bin/benchpark setup ${BENCHMARK} ${HOST} workspace/
+./bin/benchpark setup ${BENCHMARK} ${HOST} wkp/
 
 # Setup Ramble & Spack
-. workspace/setup.sh
+. wkp/setup.sh
 
 # Setup Workspace
-cd ./workspace/${BENCHMARK}/${HOST}/workspace/
+cd ./wkp/${BENCHMARK}/${HOST}/workspace/
 
 ramble --disable-logger --workspace-dir . workspace setup
 
@@ -43,8 +43,8 @@ cd -
 
 # Benchpark Analyze experiments with "+strong"
 if [[ "$VARIANT" == *"scaling=strong caliper=mpi,time"* ]] || [[ "$VARIANT" == *"+strong~single_node caliper=mpi,time"* ]]; then
-    ./bin/benchpark analyze --workspace-dir ./workspace/${BENCHMARK}/${HOST}/workspace/
+    ./bin/benchpark analyze --workspace-dir ./wkp/${BENCHMARK}/${HOST}/workspace/
 fi
 
 # Check Experiment Exit Codes
-python ./.gitlab/bin/exit-codes ./workspace/${BENCHMARK}/${HOST}/workspace/results.latest.json
+python ./.gitlab/bin/exit-codes ./wkp/${BENCHMARK}/${HOST}/workspace/results.latest.json

--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -6,22 +6,22 @@ set -e
 
 # Initialize System
 if [ "$HOST" == "lassen" ]; then
-    ./bin/benchpark system init --dest=${HOST}-system ${ARCHCONFIG} $SYSTEM_ARGS
+    ./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} $SYSTEM_ARGS
 else
-    ./bin/benchpark system init --dest=${HOST}-system ${ARCHCONFIG} cluster=$HOST $SYSTEM_ARGS
+    ./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} cluster=$HOST $SYSTEM_ARGS
 fi
 
 # Initialize Experiment
-./bin/benchpark experiment init --dest=${BENCHMARK}-benchmark ${BENCHMARK} ${VARIANT}
+./bin/benchpark experiment init --dest=${BENCHMARK} ${BENCHMARK} ${VARIANT}
 
 # Build Workspace
-./bin/benchpark setup ${BENCHMARK}-benchmark ${HOST}-system workspace/
+./bin/benchpark setup ${BENCHMARK} ${HOST} workspace/
 
 # Setup Ramble & Spack
 . workspace/setup.sh
 
 # Setup Workspace
-cd ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
+cd ./workspace/${BENCHMARK}/${HOST}/workspace/
 
 ramble --disable-logger --workspace-dir . workspace setup
 
@@ -43,8 +43,8 @@ cd -
 
 # Benchpark Analyze experiments with "+strong"
 if [[ "$VARIANT" == *"scaling=strong caliper=mpi,time"* ]] || [[ "$VARIANT" == *"+strong~single_node caliper=mpi,time"* ]]; then
-    ./bin/benchpark analyze --workspace-dir ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/
+    ./bin/benchpark analyze --workspace-dir ./workspace/${BENCHMARK}/${HOST}/workspace/
 fi
 
 # Check Experiment Exit Codes
-python ./.gitlab/bin/exit-codes ./workspace/${BENCHMARK}-benchmark/${HOST}-system/workspace/results.latest.json
+python ./.gitlab/bin/exit-codes ./workspace/${BENCHMARK}/${HOST}/workspace/results.latest.json


### PR DESCRIPTION
## Description

- [x] Remove resource groups limitations for shared allocations only to enable parallel pipelines (for multiple PRs). Using the pipeline ID in the job path enables this, as runner ID and runner concurrency ID already exist in path. Should expect speedup of P for P concurrent pipelines, over develop strategy.
- [x] Resolves #862 
- [x] Requires #881 to add `rm -rf $CUSTOM_CI_BUILDS_DIR` as step under `cancel-flux.sh` and `cancel-slurm.sh` to ensure job cleanup (does not happen automatically when setting CUSTOM_CI_BUILDS_DIR)

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab`