### PR TITLE
Change oneapi2023 -> oneapi in nightly tests

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -16,7 +16,6 @@ include:
           - raja-perf
           - remhos
         VARIANT: [+rocm]
-        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
@@ -46,14 +45,12 @@ include:
         SCHEDULER_PARAMETERS: -N 1 -t 30m --queue=pci --exclusive
         BENCHMARK: [amg2023, kripke, laghos, remhos]
         VARIANT: [+rocm caliper=mpi scaling=strong scaling-iterations=2]
-        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [amg2023, babelstream, kripke, lammps]
         VARIANT: [+openmp]
-        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
@@ -70,15 +67,12 @@ include:
           - phloem
           - smb
           - stream
-        VARIANT: ['']  # MPI-only
-        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
         SCHEDULER_PARAMETERS: -N 1 -t 01:00:00 --exclusive --reservation=ci
         BENCHMARK: [laghos, remhos]
         VARIANT: [caliper=mpi scaling=strong scaling-iterations=2]
-        SYSTEM_ARGS: [compiler=oneapi2023]
         DASHBOARD_NAME: Nightly [benchpark-develop]
       - HOST: dane
         ARCHCONFIG: llnl-cluster
@@ -99,7 +93,6 @@ include:
           - lammps
           - osu-micro-benchmarks
         VARIANT: [+cuda]
-        SYSTEM_ARGS: ['']
         DASHBOARD_NAME: Nightly [benchpark-develop]
 nightly_test_run:
   resource_group: $HOST

--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -34,7 +34,7 @@
         ctest -S CTestGitlab.cmake \
           -DHOST="${HOST}" \
           -DDASHBOARD_NAME="${DASHBOARD_NAME}" \
-          -DBUILD_NAME="${HOST}/${BENCHMARK}${VARIANT} ${SYSTEM_ARGS}" \
+          -DBUILD_NAME="${HOST}/${BENCHMARK} ${VARIANT} ${SYSTEM_ARGS}" \
           -DSITE="$(hostname)" \
           -DTEST_TYPE="${TEST_TYPE}"
       else


### PR DESCRIPTION
## Description

- [x] #878 made oneapi2023 the default `oneapi`, but the change was missed in the nightlies. Additionally, we cleanup parameters with single empty arguments `['']` since this is implied. Currently, this could have only been caught if the nightly tests were manually triggered on #878 before it was merged.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/tests/nightly.yml`
