### PR TITLE
isolate bootstrap cache to workspace spack instance

### DIFF
--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -169,7 +169,7 @@ class RuntimeResources:
                 "config",
                 "--scope=site",
                 "add",
-                f"bootstrap:root:{bootstrap_cache_location}"
+                f"bootstrap:root:{bootstrap_cache_location}",
             )
         return spack, first_time
 

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -154,6 +154,7 @@ class RuntimeResources:
         env = {"SPACK_DISABLE_LOCAL_CONFIG": "1"}
         spack = Command(self.spack_location / "bin" / "spack", env)
         spack_cache_location = self.spack_location / "misc-cache"
+        bootstrap_cache_location = self.spack_location / "bootstrap-cache"
         first_time = False
         if not self.spack_location.exists():
             first_time = True
@@ -163,6 +164,12 @@ class RuntimeResources:
                 "--scope=site",
                 "add",
                 f"config:misc_cache:{spack_cache_location}",
+            )
+            spack(
+                "config",
+                "--scope=site",
+                "add",
+                f"bootstrap:root:{bootstrap_cache_location}"
             )
         return spack, first_time
 


### PR DESCRIPTION
Updates the workspace created by `benchpark setup`: the Spack instance associated with the workspace now has its own instance of the bootstrap cache (which keeps it from interacting with other spack instances).
