### PR TITLE
Post Nightly Tests to Correct Dashboard

### DIFF
--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -38,11 +38,13 @@
         DASHBOARD_NAMES["ruby"]="Ruby Supermicro-icelake-OmniPath [benchpark system init --dest=ruby-system llnl-cluster cluster=ruby]"
         DASHBOARD_NAMES["lassen"]="Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system llnl-sierra]"
         DASHBOARD_NAMES["dane"]="Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system llnl-cluster cluster=dane]"
+        # Set DASHBOARD_NAME to env var if set, otherwise from array
+        DASHBOARD_NAME="${DASHBOARD_NAME:-${DASHBOARD_NAMES[$HOST]}}"
         # Run ctest
         module load cmake/3.23.1
         ctest -S CTestGitlab.cmake \
           -DHOST="${HOST}" \
-          -DDASHBOARD_NAME="${DASHBOARD_NAMES[$HOST]}" \
+          -DDASHBOARD_NAME="${DASHBOARD_NAME}" \
           -DBUILD_NAME="${HOST}/${BENCHMARK} ${VARIANT} ${SYSTEM_ARGS}" \
           -DSITE="$(hostname)" \
           -DTEST_TYPE="${TEST_TYPE}"


### PR DESCRIPTION
## Description

- [x] https://github.com/LLNL/benchpark/pull/882 made a change that cause the nightly tests to post to the daily dashboards instead of the `Nightly [develop]` dashbaord

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/utils/status.yml`
