### PR TITLE
Print Usage When No Command Provided

### DIFF
--- a/lib/benchpark/cmd/experiment.py
+++ b/lib/benchpark/cmd/experiment.py
@@ -39,7 +39,9 @@ def experiment_init(args):
 
 
 def setup_parser(root_parser):
-    system_subparser = root_parser.add_subparsers(dest="experiment_subcommand")
+    system_subparser = root_parser.add_subparsers(
+        dest="experiment_subcommand", required=True
+    )
 
     init_parser = system_subparser.add_parser("init")
     init_parser.add_argument("--dest", help="Place all system files here directly")
@@ -56,7 +58,3 @@ def command(args):
     }
     if args.experiment_subcommand in actions:
         actions[args.experiment_subcommand](args)
-    else:
-        raise ValueError(
-            f"Unknown subcommand for 'experiment': {args.experiment_subcommand}"
-        )

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -188,7 +188,7 @@ def info_experiment(args):
 
 
 def setup_parser(root_parser):
-    info_subparser = root_parser.add_subparsers(dest="info_subcommand")
+    info_subparser = root_parser.add_subparsers(dest="info_subcommand", required=True)
 
     system_parser = info_subparser.add_parser("system")
     system_parser.add_argument(
@@ -227,5 +227,3 @@ def command(args):
     }
     if args.info_subcommand in actions:
         actions[args.info_subcommand](args)
-    else:
-        raise ValueError(f"Unknown subcommand for 'info': {args.info_subcommand}")

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -81,6 +81,7 @@ def setup_parser(root_parser):
     list_subparser = root_parser.add_subparsers(
         dest="list_subcommand",
         help="List available experiments, systems, and modifiers",
+        required=True,
     )
 
     # Add subcommands
@@ -131,5 +132,3 @@ def command(args):
     }
     if args.list_subcommand in actions:
         actions[args.list_subcommand](args)
-    else:
-        raise ValueError(f"Unknown subcommand for 'list': {args.list_subcommand}")

--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -224,7 +224,9 @@ ramble config --scope=site add \"config:spack:global:args:'-d'\"
 
 
 def setup_parser(root_parser):
-    mirror_subparser = root_parser.add_subparsers(dest="system_subcommand")
+    mirror_subparser = root_parser.add_subparsers(
+        dest="system_subcommand", required=True
+    )
 
     create_parser = mirror_subparser.add_parser("create")
     create_parser.add_argument(
@@ -242,5 +244,3 @@ def command(args):
     }
     if args.system_subcommand in actions:
         actions[args.system_subcommand](args)
-    else:
-        raise ValueError(f"Unknown subcommand for 'system': {args.system_subcommand}")

--- a/lib/benchpark/cmd/show_build.py
+++ b/lib/benchpark/cmd/show_build.py
@@ -65,7 +65,9 @@ def show_build_dump(args):
 
 
 def setup_parser(root_parser):
-    show_build_subparser = root_parser.add_subparsers(dest="show_build_subcommand")
+    show_build_subparser = root_parser.add_subparsers(
+        dest="show_build_subcommand", required=True
+    )
 
     dump_parser = show_build_subparser.add_parser("dump")
     dump_parser.add_argument(
@@ -81,7 +83,3 @@ def command(args):
     }
     if args.show_build_subcommand in actions:
         actions[args.show_build_subcommand](args)
-    else:
-        raise ValueError(
-            f"Unknown subcommand for 'show-build': {args.show_build_subcommand}"
-        )

--- a/lib/benchpark/cmd/system.py
+++ b/lib/benchpark/cmd/system.py
@@ -110,7 +110,9 @@ def system_external(args):
 
 
 def setup_parser(root_parser):
-    system_subparser = root_parser.add_subparsers(dest="system_subcommand")
+    system_subparser = root_parser.add_subparsers(
+        dest="system_subcommand", required=True
+    )
 
     init_parser = system_subparser.add_parser("init")
     init_parser.add_argument("--dest", help="Place all system files here directly")
@@ -143,5 +145,3 @@ def command(args):
     }
     if args.system_subcommand in actions:
         actions[args.system_subcommand](args)
-    else:
-        raise ValueError(f"Unknown subcommand for 'system': {args.system_subcommand}")

--- a/lib/main.py
+++ b/lib/main.py
@@ -16,7 +16,7 @@ __version__ = "0.1.0"
 if "-V" in sys.argv or "--version" in sys.argv:
     print(__version__)
     exit()
-helpstr = """usage: benchpark [-h] [-V] {tags,system,experiment,setup,unit-test,audit,info,list} ...
+helpstr = """usage: main.py [-h] [-V] {tags,system,experiment,setup,unit-test,audit,mirror,info,show-build,list,bootstrap,analyze} ...
 
 Benchpark
 
@@ -25,14 +25,16 @@ options:
   -V, --version         show version number and exit
 
 Subcommands:
-  {tags,system,experiment,setup,unit-test,audit,info,list}
+  {tags,system,experiment,setup,unit-test,audit,mirror,info,show-build,list,bootstrap,analyze}
     tags                Tags in Benchpark experiments
     system              Initialize a system config
     experiment          Interact with experiments
     setup               Set up an experiment and prepare it to build/run
     unit-test           Run benchpark unit tests
     audit               Look for problems in System/Experiment repos
+    mirror              Copy a benchpark workspace
     info                Get information about Systems and Experiments
+    show-build          Show how spack built a benchmark
     list                List experiments, systems, benchmarks, and modifiers
     bootstrap           Bootstrap benchpark or update an existing bootstrap
     analyze             Perform pre-defined analysis on the performance data (caliper files) after 'ramble on'"""

--- a/lib/main.py
+++ b/lib/main.py
@@ -16,7 +16,7 @@ __version__ = "0.1.0"
 if "-V" in sys.argv or "--version" in sys.argv:
     print(__version__)
     exit()
-helpstr = """usage: main.py [-h] [-V] {tags,system,experiment,setup,unit-test,audit,info,list} ...
+helpstr = """usage: benchpark [-h] [-V] {tags,system,experiment,setup,unit-test,audit,info,list} ...
 
 Benchpark
 
@@ -36,7 +36,7 @@ Subcommands:
     list                List experiments, systems, benchmarks, and modifiers
     bootstrap           Bootstrap benchpark or update an existing bootstrap
     analyze             Perform pre-defined analysis on the performance data (caliper files) after 'ramble on'"""
-if "-h" == sys.argv[1] or "--help" == sys.argv[1]:
+if len(sys.argv) == 1 or "-h" == sys.argv[1] or "--help" == sys.argv[1]:
     print(helpstr)
     exit()
 


### PR DESCRIPTION
## Description

- [x] Currently we are missing the check if the user runs `benchpark` with no arguments.
- [x] Subcommands check for required arguments manually, when this can be done automatically with clearer error messages.

## Examples

### Develop
```
$ benchpark
Traceback (most recent call last):
  File "/Users/mckinsey1/Documents/repos/benchpark/lib/main.py", line 39, in <module>
    if "-h" == sys.argv[1] or "--help" == sys.argv[1]:
               ~~~~~~~~^^^
IndexError: list index out of range
Traceback (most recent call last):
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 23, in <module>
    main()
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 19, in main
    subprocess.run([sys.executable, main_py] + sys.argv[1:], check=True)
  File "/opt/anaconda3/envs/bp-3.11.11/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/opt/anaconda3/envs/bp-3.11.11/bin/python3', PosixPath('/Users/mckinsey1/Documents/repos/benchpark/lib/main.py')]' returned non-zero exit status 1.
```
### #895
```
$ benchpark
usage: main.py [-h] [-V] {tags,system,experiment,setup,unit-test,audit,mirror,info,show-build,list,bootstrap,analyze} ...

Benchpark

options:
  -h, --help            show this help message and exit
  -V, --version         show version number and exit

Subcommands:
  {tags,system,experiment,setup,unit-test,audit,mirror,info,show-build,list,bootstrap,analyze}
    tags                Tags in Benchpark experiments
    system              Initialize a system config
    experiment          Interact with experiments
    setup               Set up an experiment and prepare it to build/run
    unit-test           Run benchpark unit tests
    audit               Look for problems in System/Experiment repos
    mirror              Copy a benchpark workspace
    info                Get information about Systems and Experiments
    show-build          Show how spack built a benchmark
    list                List experiments, systems, benchmarks, and modifiers
    bootstrap           Bootstrap benchpark or update an existing bootstrap
    analyze             Perform pre-defined analysis on the performance data (caliper files) after 'ramble on'
```
and subcommands
### Develop
```
$ benchpark list
Traceback (most recent call last):
  File "/Users/mckinsey1/Documents/repos/benchpark/lib/main.py", line 334, in <module>
    exit_code = main()
                ^^^^^^
  File "/Users/mckinsey1/Documents/repos/benchpark/lib/main.py", line 102, in main
    exit_code = action(args)
                ^^^^^^^^^^^^
  File "/Users/mckinsey1/Documents/repos/benchpark/lib/benchpark/cmd/list.py", line 135, in command
    raise ValueError(f"Unknown subcommand for 'list': {args.list_subcommand}")
ValueError: Unknown subcommand for 'list': None
Traceback (most recent call last):
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 23, in <module>
    main()
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 19, in main
    subprocess.run([sys.executable, main_py] + sys.argv[1:], check=True)
  File "/opt/anaconda3/envs/bp-3.11.11/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/opt/anaconda3/envs/bp-3.11.11/bin/python3', PosixPath('/Users/mckinsey1/Documents/repos/benchpark/lib/main.py'), 'list']' returned non-zero exit status 1.
```
### #895
```
$ benchpark list
usage: main.py list [-h] {benchmarks,experiments,systems,modifiers} ...
main.py list: error: the following arguments are required: list_subcommand
Traceback (most recent call last):
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 23, in <module>
    main()
  File "/Users/mckinsey1/Documents/repos/benchpark/bin/benchpark", line 19, in main
    subprocess.run([sys.executable, main_py] + sys.argv[1:], check=True)
  File "/opt/anaconda3/envs/bp-3.11.11/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/opt/anaconda3/envs/bp-3.11.11/bin/python3', PosixPath('/Users/mckinsey1/Documents/repos/benchpark/lib/main.py'), 'list']' returned non-zero exit status 2.
```

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `lib/main.py`
