### PR TITLE
Add cuda allow-unsupported-compiler flag for camp, chai, raja, umpire

### DIFF
--- a/repo/camp/package.py
+++ b/repo/camp/package.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spack.package import *
+from spack.pkg.builtin.camp import Camp as BuiltinCamp
+
+
+class Camp(BuiltinCamp):
+
+    def setup_build_environment(self, env):
+        super().setup_build_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")

--- a/repo/chai/package.py
+++ b/repo/chai/package.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spack.package import *
+from spack.pkg.builtin.chai import Chai as BuiltinChai
+
+
+class Chai(BuiltinChai):
+
+    def setup_build_environment(self, env):
+        super().setup_build_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")

--- a/repo/raja/package.py
+++ b/repo/raja/package.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spack.package import *
+from spack.pkg.builtin.raja import Raja as BuiltinRaja
+
+
+class Raja(BuiltinRaja):
+
+    def setup_build_environment(self, env):
+        super().setup_build_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")

--- a/repo/umpire/package.py
+++ b/repo/umpire/package.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spack.package import *
+from spack.pkg.builtin.umpire import Umpire as BuiltinUmpire
+
+
+class Umpire(BuiltinUmpire):
+
+    depends_on("fmt@9.1: cxxstd=17", when="@2024.02.0: %oneapi")
+
+    def setup_build_environment(self, env):
+        super().setup_build_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+        if "+cuda" in self.spec:
+            env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")


### PR DESCRIPTION
## Description
Add cuda allow-unsupported-compiler flag for camp, chai, raja, umpire

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.