### PR TITLE
Add `user-managed` Package Manager

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -84,7 +84,7 @@ jobs:
           OUTPUT=$(spack find --paths saxpy)
           SAXPY_PATH=$(echo "$OUTPUT" | grep 'saxpy@' | awk '{print $2}')/bin/saxpy
           echo "Extracted Path: $SAXPY_PATH"
-          ./bin/benchpark experiment init --dest=saxpy/binary saxpy+openmp package_manager="None" append_path="$SAXPY_PATH"
+          ./bin/benchpark experiment init --dest=saxpy/binary saxpy+openmp package_manager="user-managed" append_path="$SAXPY_PATH"
           ./bin/benchpark setup saxpy/openmp generic-x86 workspace-binary/
           ./workspace-binary/ramble/bin/ramble \
             --disable-progress-bar \

--- a/docs/run-binary.rst
+++ b/docs/run-binary.rst
@@ -7,14 +7,14 @@
 Running a Binary Using Benchpark
 =================================
 
-If you have a pre-built binary of your application, you can use it in your Benchpark experiment using the `None` package manager. 
-When initializing your experiment, provide the path to the binary, and specify `None` as the package manager.
+If you have a pre-built binary of your application, you can use it in your Benchpark experiment using the `user-managed` package manager.
+When initializing your experiment, provide the path to the binary, and specify `user-managed` as the package manager.
 The steps for initializing the system and setting up the experiment remain the same as before.
 
 Example running the `osu-micro-benchmarks` workload `osu_latency` on the `ruby` system::
 
     benchpark experiment init --dest=osumb osu-micro-benchmarks \
-        package_manager="None" \
+        package_manager="user-managed" \
         workload="osu_latency" \
         append_path="osu-micro-benchmarks/mpi/pt2pt"
     benchpark system init --dest=ruby llnl-cluster cluster=ruby

--- a/docs/run-binary.rst
+++ b/docs/run-binary.rst
@@ -7,15 +7,29 @@
 Running a Binary Using Benchpark
 =================================
 
-If you have a pre-built binary of your application, you can use it in your Benchpark experiment using the `user-managed` package manager.
-When initializing your experiment, provide the path to the binary, and specify `user-managed` as the package manager.
-The steps for initializing the system and setting up the experiment remain the same as before.
+If you have a pre-built binary of your application, you can use it in your Benchpark experiment using the ``user-managed`` Ramble-defined package manager (`see docs <https://ramble.readthedocs.io/en/latest/package_manager_list.html#user-managed>`_).
+When initializing your experiment, provide the path to the binary using ``prepend_path`` which will add the binary path to ``PATH``, and specify ``user-managed`` as the package manager.
+System setup does not change.
 
-Example running the `osu-micro-benchmarks` workload `osu_latency` on the `ruby` system::
+Example running the ``osu-micro-benchmarks`` workload ``osu_latency`` on the ``ruby`` system::
 
     benchpark experiment init --dest=osumb osu-micro-benchmarks \
         package_manager="user-managed" \
         workload="osu_latency" \
-        append_path="osu-micro-benchmarks/mpi/pt2pt"
+        prepend_path="/usr/myuser/osu-micro-benchmarks/mpi/pt2pt"
     benchpark system init --dest=ruby llnl-cluster cluster=ruby
     benchpark setup ./osumb/ ./ruby/ osumb-ruby/
+    # Follow Ramble execution instructions ...
+
+This will execute using the ``osu_latency`` binary located at ``osu-micro-benchmarks/mpi/pt2pt/osu_latency``.
+
+Or for example, if we have a build ``kripke`` with spack on ``dane`` and then used that binary (``bin/kripke.exe``)::
+
+    benchpark experiment init --dest=kripke kripke \
+        package_manager="user-managed" \
+        prepend_path="/usr/myuser/benchpark/wkp/spack/opt/spack/linux-rhel8-sapphirerapids/oneapi-2023.2.1/kripke-develop-ehvoc6dzdprgm3lhaghh7uoiqsc5xcf6/bin"
+    benchpark system init --dest=dane llnl-cluster cluster=dane
+    benchpark setup ./kripke/ ./dane/ kripke-dane/
+    # Follow Ramble execution instructions ...
+
+Using the spack built binary.

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -358,10 +358,9 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
             self.env_vars["set"] |= env_vars["set"]
             self.env_vars["append"][0] |= env_vars["append"][0]
 
+        # Set required variable for package manager (we are not using this variable)
         if self.spec.variants["package_manager"][0] == "user-managed":
-            self.add_experiment_variable(
-                self.name + "_path", self.spec.variants["append_path"][0]
-            )
+            self.add_experiment_variable(self.name + "_path", "None")
 
         self.compute_applications_section()
 

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -359,7 +359,9 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
             self.env_vars["append"][0] |= env_vars["append"][0]
 
         if self.spec.variants["package_manager"][0] == "user-managed":
-            self.add_experiment_variable(self.name+"_path", self.spec.variants["append_path"][0])
+            self.add_experiment_variable(
+                self.name + "_path", self.spec.variants["append_path"][0]
+            )
 
         self.compute_applications_section()
 
@@ -447,7 +449,11 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
                 spack_variants
             ).strip()
 
-        if "append_path" in self.spec.variants and self.spec.variants["append_path"][0] != " ":
+        if "append_path" in self.spec.variants and (
+            # Don't append " " to path (default value)
+            self.spec.variants["append_path"][0]
+            != " "
+        ):
             self.append_environment_variable(
                 "PATH", self.spec.variants["append_path"][0]
             )

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -26,6 +26,7 @@ class ExperimentHelper:
         self.env_vars = {
             "set": {},
             "append": [{"paths": {}, "vars": {}}],
+            "prepend": [{"paths": {}, "vars": {}}],
         }
 
     def compute_include_section(self):
@@ -57,11 +58,12 @@ class ExperimentHelper:
         self.env_vars["set"][name] = value
 
     def append_environment_variable(self, name, value, target="paths"):
-        """Append to existing environment variable PATH ('paths') or other variable ('vars')
-        Matches expected ramble format. Example:
-        https://ramble.readthedocs.io/en/latest/workspace_config.html#environment-variable-control
-        """
+        """Append to existing environment variable PATH ('paths') or other variable ('vars')"""
         self.env_vars["append"][0][target][name] = value
+
+    def prepend_environment_variable(self, name, value, target="paths"):
+        """Prepend to existing environment variable PATH ('paths') or other variable ('vars')"""
+        self.env_vars["prepend"][0][target][name] = value
 
     def compute_config_variables(self):
         pass
@@ -210,6 +212,12 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
         description="Append to environment PATH during experiment execution",
     )
 
+    variant(
+        "prepend_path",
+        default=" ",
+        description="Prepend to environment PATH during experiment execution",
+    )
+
     def __init__(self, spec):
         self.spec: "benchpark.spec.ConcreteExperimentSpec" = spec
         # Device type must be set before super with absence of mpionly experiment type
@@ -324,14 +332,18 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
         self.env_vars["set"][name] = values
 
     def append_environment_variable(self, name, values, target="paths"):
-        """Append to existing environment variable PATH ('paths') or other variable ('vars')
-        Matches expected ramble format. Example:
-        https://ramble.readthedocs.io/en/latest/workspace_config.html#environment-variable-control
-        """
+        """Append to existing environment variable PATH ('paths') or other variable ('vars')"""
         if target not in ["paths", "vars"]:
             raise ValueError("Invalid target specified. Must be 'paths' or 'vars'.")
 
         self.env_vars["append"][0][target][name] = values
+
+    def prepend_environment_variable(self, name, values, target="paths"):
+        """Prepend to existing environment variable PATH ('paths') or other variable ('vars')"""
+        if target not in ["paths", "vars"]:
+            raise ValueError("Invalid target specified. Must be 'paths' or 'vars'.")
+
+        self.env_vars["prepend"][0][target][name] = values
 
     def add_experiment_exclude(self, exclude_clause):
         self.excludes.append(exclude_clause)
@@ -346,6 +358,7 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
         self.env_vars = {
             "set": {},
             "append": [{"paths": {}, "vars": {}}],
+            "prepend": [{"paths": {}, "vars": {}}],
         }
         self.variables = {}
         self.zips = {}
@@ -357,6 +370,7 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
             self.expr_vars.extend(variables)
             self.env_vars["set"] |= env_vars["set"]
             self.env_vars["append"][0] |= env_vars["append"][0]
+            self.env_vars["prepend"][0] |= env_vars["prepend"][0]
 
         # Set required variable for package manager (we are not using this variable)
         if self.spec.variants["package_manager"][0] == "user-managed":
@@ -455,6 +469,14 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
         ):
             self.append_environment_variable(
                 "PATH", self.spec.variants["append_path"][0]
+            )
+        if "prepend_path" in self.spec.variants and (
+            # Don't append " " to path (default value)
+            self.spec.variants["prepend_path"][0]
+            != " "
+        ):
+            self.prepend_environment_variable(
+                "PATH", self.spec.variants["prepend_path"][0]
             )
 
         return {

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -200,7 +200,7 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
     variant(
         "package_manager",
         default="spack",
-        values=("spack", "environment-modules", "user-managed", "None"),
+        values=("spack", "environment-modules", "user-managed"),
         description="package manager to use",
     )
 

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -200,7 +200,7 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
     variant(
         "package_manager",
         default="spack",
-        values=("spack", "environment-modules", "None"),
+        values=("spack", "environment-modules", "user-managed", "None"),
         description="package manager to use",
     )
 

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -358,6 +358,9 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
             self.env_vars["set"] |= env_vars["set"]
             self.env_vars["append"][0] |= env_vars["append"][0]
 
+        if self.spec.variants["package_manager"][0] == "user-managed":
+            self.add_experiment_variable(self.name+"_path", self.spec.variants["append_path"][0])
+
         self.compute_applications_section()
 
         if "scaling" in self.spec.variants and not self.spec.satisfies("scaling=off"):
@@ -444,7 +447,7 @@ class Experiment(ExperimentSystemBase, SingleNode, Affinity, Hwloc):
                 spack_variants
             ).strip()
 
-        if "append_path" in self.spec.variants:
+        if "append_path" in self.spec.variants and self.spec.variants["append_path"][0] != " ":
             self.append_environment_variable(
                 "PATH", self.spec.variants["append_path"][0]
             )


### PR DESCRIPTION
## Description

- [x] Add option to use ramble's `user-managed` package manager, which is the preferred way to run pre-build binaries over the `None` manager.
- [x] Add `prepend_path` variant for experiment as alternative to `append_path`

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.github/workflows/run.yml` unit test
- [x] Update docs `docs/run-binary.rst`
- [x] Add option in `lib/benchpark/experiment.py`