### PR TITLE
Fix Broken Test from Prepend Path

### DIFF
--- a/lib/benchpark/test/caliper.py
+++ b/lib/benchpark/test/caliper.py
@@ -40,6 +40,7 @@ def test_experiment_compute_variables_section_caliper(monkeypatch):
             "append_path": "'",
             "caliper": "time",
             "package_manager": "spack",
+            'prepend_path': "'",
             "version": "1.0.0",
             "workload": "problem",
             "n_resources": "{n_resources}",
@@ -117,6 +118,7 @@ def test_caliper_modifier(monkeypatch):
         "caliper": "time",
         "hwloc": "none",
         "package_manager": "spack",
+        'prepend_path': "'",
         "version": "1.0.0",
         "workload": "problem",
     }

--- a/lib/benchpark/test/caliper.py
+++ b/lib/benchpark/test/caliper.py
@@ -40,7 +40,7 @@ def test_experiment_compute_variables_section_caliper(monkeypatch):
             "append_path": "'",
             "caliper": "time",
             "package_manager": "spack",
-            'prepend_path': "'",
+            "prepend_path": "'",
             "version": "1.0.0",
             "workload": "problem",
             "n_resources": "{n_resources}",
@@ -118,7 +118,7 @@ def test_caliper_modifier(monkeypatch):
         "caliper": "time",
         "hwloc": "none",
         "package_manager": "spack",
-        'prepend_path': "'",
+        "prepend_path": "'",
         "version": "1.0.0",
         "workload": "problem",
     }


### PR DESCRIPTION
## Description

- [x] #919 Introduced a failure in the pytest tests.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `lib/benchpark/test/caliper.py`
