### PR TITLE
Remove `-v` from smb execution by default

### DIFF
--- a/repo/smb/application.py
+++ b/repo/smb/application.py
@@ -12,7 +12,7 @@ class Smb(ExecutableApplication):
     """Sandia microbenchmarks"""
     name = "Sandia microbenchmarks"
 
-    executable('p1', 'mpi_overhead -v', use_mpi=True)
+    executable('p1', 'mpi_overhead', use_mpi=True)
     executable('p2', 'msgrate -n {ppn}', use_mpi=True)
 
     workload('mpi_overhead', executables=['p1'])


### PR DESCRIPTION
## Description

benchmarks:
   - [x] smb CI failure because `-v` producing too much output, removing this flag by default

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Update `repo/smb/application.py`
