### PR TITLE
Default Exclusive Allocation for Slurm Jobs

### DIFF
--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -319,6 +319,8 @@ class Allocation(BasicModifier):
         if v.timeout:
             sbatch_opts.append(f"--time {v.timeout}")
 
+        sbatch_opts.append("--exclusive")
+
         sbatch_directives = list(f"#SBATCH {x}" for x in (srun_opts + sbatch_opts))
 
         v.mpi_command = f"srun {' '.join(srun_opts)}"


### PR DESCRIPTION
## Description

- [x] Currently slurm job files do not have the exclusive flag as a directive, so allocations for shared clusters will default to sharing resources (such as Matrix). This enforces that the resources are never shared.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `modifiers/allocation/modifier.py`
