### PR TITLE
Remove Vestigal ramble Argument

### DIFF
--- a/.github/utils/dryrun.sh
+++ b/.github/utils/dryrun.sh
@@ -17,6 +17,5 @@ system="s-$timestamp"
 . workspace/setup.sh
 ramble \
     --workspace-dir "workspace/$benchmark/$system/workspace" \
-    --disable-progress-bar \
     --disable-logger \
     workspace setup --dry-run

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           ramble \
             --workspace-dir . \
-            --disable-progress-bar \
             --disable-logger \
             -c config:spack_flags:install:'--no-check-signature' \
             workspace setup
@@ -37,7 +36,6 @@ jobs:
         run: |
           ramble \
             --workspace-dir . \
-            --disable-progress-bar \
             --disable-logger \
             on \
             --executor '{execute_experiment}' \
@@ -47,7 +45,6 @@ jobs:
         run: |
           ramble \
             --workspace-dir . \
-            --disable-progress-bar \
             --disable-logger \
             workspace analyze
       - name: Archive Experiment Workspace
@@ -56,7 +53,6 @@ jobs:
         run: |
           ramble \
             --workspace-dir . \
-            --disable-progress-bar \
             --disable-logger \
             workspace archive
       - name: Upload Workspace Archive as CI Artifact
@@ -87,12 +83,10 @@ jobs:
           ./bin/benchpark experiment init --dest=saxpy/binary saxpy+openmp package_manager="user-managed" append_path="$SAXPY_PATH"
           ./bin/benchpark setup saxpy/openmp generic-x86 workspace-binary/
           ./workspace-binary/ramble/bin/ramble \
-            --disable-progress-bar \
             --workspace-dir \
             /home/runner/work/benchpark/benchpark/workspace-binary/saxpy/openmp/generic-x86/workspace \
             workspace setup
           ./workspace-binary/ramble/bin/ramble \
-            --disable-progress-bar \
             --workspace-dir \
             /home/runner/work/benchpark/benchpark/workspace-binary/saxpy/openmp/generic-x86/workspace \
             on \

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -75,11 +75,11 @@ What to rerun after edits
    * - What I changed
      - Commands to rerun
    * - configs
-     - ``ramble --disable-progress-bar --workspace-dir . workspace setup``
+     - ``ramble --workspace-dir . workspace setup``
    * - benchmark's package.py
-     - ``ramble --disable-progress-bar --workspace-dir . workspace setup``
+     - ``ramble --workspace-dir . workspace setup``
    * - dependency of package.py
-     - ``ramble --disable-progress-bar --workspace-dir . workspace setup``
+     - ``ramble --workspace-dir . workspace setup``
    * - experiment parameters
      - delete ``workspace/experiments``
    * - wish to rerun experiments

--- a/docs/analyze-experiment.rst
+++ b/docs/analyze-experiment.rst
@@ -9,7 +9,7 @@ Experiment pass/fail and FOMs
 
 Once the experiments completed running, the command::
 
-  ramble --disable-progress-bar --workspace-dir . workspace analyze 
+  ramble --workspace-dir . workspace analyze 
 
 can be used to analyze figures of merit and evaluate 
 `success/failure <https://ramble.readthedocs.io/en/latest/success_criteria.html#success-criteria>`_

--- a/docs/basic-tutorial.rst
+++ b/docs/basic-tutorial.rst
@@ -199,7 +199,7 @@ Next, build any necessary software and generate all necessary files for the Krip
 
 .. code-block:: bash
 
-    ramble --disable-progress-bar \
+    ramble \
     --workspace-dir /home/jovyan/benchpark/wkp/kripke-benchmark/hpdc-tutorial/workspace \
     workspace setup
 
@@ -243,7 +243,7 @@ Next, run the Kripke strong scaling experiment by running the following command:
 
 .. code-block:: bash
 
-    ramble --disable-progress-bar \
+    ramble \
     --workspace-dir /home/jovyan/benchpark/wkp/kripke-benchmark/hpdc-tutorial/workspace \
     on
 

--- a/docs/build-experiment.rst
+++ b/docs/build-experiment.rst
@@ -11,7 +11,7 @@ Building an Experiment in Benchpark
 The next step is setting up the Ramble workspace and building the code::
 
    cd <experiments_root>/<Benchmark/ProgrammingModel>/<System>/workspace
-   ramble --disable-progress-bar --workspace-dir . workspace setup
+   ramble --workspace-dir . workspace setup
 
 
 Ramble will build the source code and set up the following workspace directory structure::

--- a/docs/create-mirror.rst
+++ b/docs/create-mirror.rst
@@ -18,7 +18,7 @@ On the networked system, if you created/built the benchmark with::
     benchpark system init --dest=def-ruby llnl-cluster cluster=ruby compiler=gcc
     benchpark setup def-raja-perf/ def-ruby/ workspace/
     . `pwd`/workspace/setup.sh
-    ramble --disable-progress-bar --workspace-dir `pwd`/workspace/def-raja-perf/def-ruby/workspace workspace setup
+    ramble --workspace-dir `pwd`/workspace/def-raja-perf/def-ruby/workspace workspace setup
 
 You can then create a directory that bundles all the resources needed to build
 that benchmark with::

--- a/docs/for-the-impatient.rst
+++ b/docs/for-the-impatient.rst
@@ -45,7 +45,7 @@ Building the Experiment in Benchpark
 ::
 
    cd <experiments_root>/<Benchmark/ProgrammingModel>/<System>/workspace
-   ramble --disable-progress-bar --workspace-dir . workspace setup
+   ramble --workspace-dir . workspace setup
 
 -----------------------------------
 Running the Experiment in Benchpark
@@ -53,7 +53,7 @@ Running the Experiment in Benchpark
 
 To run all of the experiments in the workspace::
 
-   ramble --disable-progress-bar --workspace-dir . on
+   ramble --workspace-dir . on
 
 To run a single experiment in the workspace, invoke the ``execute_experiment`` script for the specific experiment
 (e.g., ``$workspace/experiments/amg2023/problem1/amg2023_cuda11.8.0_problem1_1_8_2_2_2_10_10_10/execute_experiment``).
@@ -65,7 +65,7 @@ Analyzing Experiments in Benchpark
 
 Once the experiments completed running, the command::
 
-  ramble --disable-progress-bar --workspace-dir . workspace analyze 
+  ramble --workspace-dir . workspace analyze 
 
 can be used to analyze figures of merit and evaluate 
 `success/failure <https://ramble.readthedocs.io/en/latest/success_criteria.html#success-criteria>`_ 

--- a/docs/llnl-tutorial.rst
+++ b/docs/llnl-tutorial.rst
@@ -62,12 +62,12 @@ Run the setup script for dependency software, Ramble and Spack::
 Then setup the Ramble experiment workspace, this builds all software and may take some time::
 
     cd ./workspace/amg2023-benchmark/ruby-system/workspace/
-    ramble --workspace-dir . --disable-progress-bar workspace setup
+    ramble --workspace-dir . workspace setup
 
 Next, we run the AMG2023 experiments, which will launch jobs through the
 scheduler on the CTS system::
 
-    ramble --workspace-dir . --disable-progress-bar on
+    ramble --workspace-dir . on
 
 ------
 Tioga
@@ -83,5 +83,5 @@ different variants defined for the system. For example, the variant ``~gtl`` tur
     benchpark setup ./saxpy-benchmark ./tioga-system workspace/
     . workspace/setup.sh
     cd ./workspace/saxpy-benchmark/Tioga-975af3c/workspace/
-    ramble --workspace-dir . --disable-progress-bar workspace setup
-    ramble --workspace-dir . --disable-progress-bar on
+    ramble --workspace-dir . workspace setup
+    ramble --workspace-dir . on

--- a/docs/run-experiment.rst
+++ b/docs/run-experiment.rst
@@ -9,7 +9,7 @@ Running an Experiment in Benchpark
 
 To run all of the experiments in the workspace::
 
-   ramble --disable-progress-bar --workspace-dir . on
+   ramble --workspace-dir . on
 
 An output file is generated for each experiment in its unique directory::
 
@@ -41,6 +41,6 @@ Note that re-running the experiment may overwrite any existing output files in t
 Further, if the benchmark has restart capability, existing output may alter the experiments
 benchpark would run in the second run.  Generally, we would advise the user to remove the
 ``$workspace/experiments`` directory before re-running the experiments using
-``ramble --disable-progress-bar --workspace-dir . on``.
+``ramble --workspace-dir . on``.
 
 Once you have run your experiment you can try :doc:`analyze-experiment`.

--- a/docs/showBuild.rst
+++ b/docs/showBuild.rst
@@ -15,7 +15,7 @@ bin/benchpark experiment init --dest=def-raja-perf raja-perf
 bin/benchpark system init --dest=def-ruby llnl-cluster cluster=ruby compiler=gcc
 bin/benchpark setup def-raja-perf/ def-ruby/ workspace/
 . `pwd`/workspace/setup.sh
-ramble --disable-progress-bar --workspace-dir `pwd`/workspace/def-raja-perf/def-ruby/workspace workspace setup
+ramble --workspace-dir `pwd`/workspace/def-raja-perf/def-ruby/workspace workspace setup
 ```
 
 You will now be able to `benchpark show-build dump`, a command that will dump a log of how Spack built the experiment:

--- a/docs/system/fugaku.rst
+++ b/docs/system/fugaku.rst
@@ -67,7 +67,7 @@ Build the benchmark:
     source ${WSDIR}/setup.sh
     export TMP=/local
     export TMPDIR=/local
-    ramble --disable-progress-bar --workspace-dir ${WSDIR}/${BM}-test/${SYS}-system/workspace workspace setup
+    ramble --workspace-dir ${WSDIR}/${BM}-test/${SYS}-system/workspace workspace setup
 
 
 Go back to login node and submit benchmarks:
@@ -84,7 +84,7 @@ Go back to login node and submit benchmarks:
     export BM="saxpy"
     export SYS="fugaku"
     export WSDIR="$(pwd)/workspace"
-    ${WSDIR}/ramble/bin/ramble --disable-progress-bar --workspace-dir ${WSDIR}/${BM}-test/${SYS}-system/workspace on
+    ${WSDIR}/ramble/bin/ramble --workspace-dir ${WSDIR}/${BM}-test/${SYS}-system/workspace on
 
 
 Finding the benchmark output (Fujitsu MPI does not write to STDOUT):

--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -219,7 +219,7 @@ ramble config --scope=site add \"config:spack:global:args:'-d'\"
     ramble_workspace_mirror_dest = os.path.join(dest, "ramble-workspace-mirror")
     if not os.path.exists(ramble_workspace_mirror_dest):
         run_command(
-            f"ramble --disable-progress-bar --workspace-dir {ramble_workspace} workspace mirror -d file://{ramble_workspace_mirror_dest}"
+            f"ramble --workspace-dir {ramble_workspace} workspace mirror -d file://{ramble_workspace_mirror_dest}"
         )
 
 

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -187,9 +187,9 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
 """
             )
 
-    ramble_setup = f"ramble --disable-progress-bar --workspace-dir {ramble_workspace_dir} workspace setup"
+    ramble_setup = f"ramble --workspace-dir {ramble_workspace_dir} workspace setup"
     ramble_run = (
-        f"ramble --disable-progress-bar --workspace-dir {ramble_workspace_dir} on"
+        f"ramble --workspace-dir {ramble_workspace_dir} on"
     )
 
     instructions = f"""\

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -188,9 +188,7 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
             )
 
     ramble_setup = f"ramble --workspace-dir {ramble_workspace_dir} workspace setup"
-    ramble_run = (
-        f"ramble --workspace-dir {ramble_workspace_dir} on"
-    )
+    ramble_run = f"ramble --workspace-dir {ramble_workspace_dir} on"
 
     instructions = f"""\
 To complete the benchpark setup, do the following:


### PR DESCRIPTION
## Description

- [x] There is no difference when providing `--disable-progress-bar` because we set a global configuration during setup to disable the progress bar (https://github.com/LLNL/benchpark/blob/0b4b563a6b24ee6a5f712b479b533b2dd9fa2500/lib/benchpark/cmd/setup.py#L177). This argument is generated from the recommended commands when running `benchpark setup`, so we should remove it.

```
(bp-x86-3.11.5) [mckinsey@dane5:bp_bank_debug]$ ramble --workspace-dir /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace workspace setup
==> Streaming details to log:
==>   /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.34.49.out
==>   Setting up 2 out of 2 experiments:
==> Experiment #1 (1/2):
==>     name: stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_16_650000000
==>     root experiment_index: 1
==>     log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.34.49/stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_16_650000000.out
==>   Returning to log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.34.49.out
==> Experiment #2 (2/2):
==>     name: stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_32_650000000
==>     root experiment_index: 2
==>     log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.34.49/stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_32_650000000.out
==>   Returning to log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.34.49.out
(bp-x86-3.11.5) [mckinsey@dane5:bp_bank_debug]$ ramble --disable-progress-bar --workspace-dir /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace workspace setup
==> Streaming details to log:
==>   /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.35.04.out
==>   Setting up 2 out of 2 experiments:
==> Experiment #1 (1/2):
==>     name: stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_16_650000000
==>     root experiment_index: 1
==>     log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.35.04/stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_16_650000000.out
==>   Returning to log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.35.04.out
==> Experiment #2 (2/2):
==>     name: stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_32_650000000
==>     root experiment_index: 2
==>     log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.35.04/stream.stream.stream_stream_single_node_mpi_caliper_none_1_1_32_650000000.out
==>   Returning to log file: /usr/WS1/mckinsey/bp_bank_debug/wkp/stream/dane/workspace/logs/setup.2025-08-04_21.35.04.out
```