### PR TITLE
Add single_memory variant for chai and kripke

### DIFF
--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -107,6 +107,13 @@ run_tests_flux_tuolumne:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [kripke]
         VARIANT: [+openmp]
+        GPUMODE: SPX
+      # Test kripke+rocm+single_memory on tuolumne
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [kripke]
+        VARIANT: [+rocm+single_memory]
+        GPUMODE: SPX
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -35,7 +35,8 @@ class Kripke(
         description="app version",
     )
 
-    variant("single_memory",
+    variant(
+        "single_memory",
         default=False,
         description="Enable single memory space model in rocm",
     )
@@ -126,5 +127,9 @@ class Kripke(
     def compute_package_section(self):
         # get package version
         app_version = self.spec.variants["version"][0]
-        single_memory = "+single_memory" if self.spec.variants["single_memory"][0] else "~single_memory"
+        single_memory = (
+            "+single_memory"
+            if self.spec.variants["single_memory"][0]
+            else "~single_memory"
+        )
         self.add_package_spec(self.name, [f"kripke@{app_version} {single_memory} "])

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -35,6 +35,11 @@ class Kripke(
         description="app version",
     )
 
+    variant("single_memory",
+        default=False,
+        description="Enable single memory space model in rocm",
+    )
+
     maintainers("pearce8")
 
     def compute_applications_section(self):
@@ -121,4 +126,5 @@ class Kripke(
     def compute_package_section(self):
         # get package version
         app_version = self.spec.variants["version"][0]
-        self.add_package_spec(self.name, [f"kripke@{app_version} "])
+        single_memory = "+single_memory" if self.spec.variants["single_memory"][0] else "~single_memory"
+        self.add_package_spec(self.name, [f"kripke@{app_version} {single_memory} "])

--- a/repo/chai/package.py
+++ b/repo/chai/package.py
@@ -8,6 +8,19 @@ from spack.pkg.builtin.chai import Chai as BuiltinChai
 
 
 class Chai(BuiltinChai):
+    variant("single_memory", default=False, description="Enable single memory space model")
+
+    conflicts("+single_memory", when="~rocm")
+
+    def initconfig_hardware_entries(self):
+        spec = self.spec
+        entries = super().initconfig_hardware_entries()
+
+        if spec.satisfies("+single_memory"):
+            entries.append(cmake_cache_option("CHAI_THIN_GPU_ALLOCATE", True))
+            entries.append(cmake_cache_option("CHAI_DISABLE_RM", True))
+
+        return entries
 
     def setup_build_environment(self, env):
         super().setup_build_environment(env)

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -52,6 +52,10 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     variant("mpi", default=True, description="Build with MPI.")
     variant("openmp", default=False, description="Build with OpenMP enabled.")
     variant("caliper", default=False, description="Build with Caliper support enabled.")
+    variant("single_memory", default=False, description="Enable single memory space model in rocm")
+
+    conflicts("+single_memory", when="~rocm")
+    depends_on("chai+single_memory", when="+single_memory")
 
     depends_on("chai@2024.07.0+raja", when="@develop")
     depends_on("fmt@9.1", when=f"^chai@2024.07.0")


### PR DESCRIPTION
## Description
This PR adds a single memory variant to Kripke and CHAI to enable the use elcap single CPU-GPU memory.

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define a single node and multi-node experiments