### PR TITLE
Add Missing GPUMODE to Test

### DIFF
--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -107,6 +107,7 @@ run_tests_flux_tuolumne:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [kripke]
         VARIANT: [+openmp]
+        GPUMODE: SPX
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]


### PR DESCRIPTION
## Description

- [x] Setting GPUMODE is required for test to appropriately attach to running allocation.