### PR TITLE
Allow either host.cluster or cluster in analyze

### DIFF
--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -326,9 +326,10 @@ def prepare_data(**kwargs):
         list(grouped.values()), headers=list(grouped.keys()), axis="columns"
     )
 
+    cluster_col = "cluster" if "cluster" in tk.metadata.columns else "host.cluster"
     # Check these values are constant
     app = validate_single_metadata_value("application_name", tk)
-    cluster = validate_single_metadata_value("host.cluster", tk)
+    cluster = validate_single_metadata_value(cluster_col, tk)
     version = validate_single_metadata_value("version", tk)
 
     # Find programming model from spec


### PR DESCRIPTION
## Description

- [x] Use `cluster` from caliper metadata if `host.cluster` not available from `/etc/node_info.json`

## Adding/modifying core functionality, CI, or documentation:

- [ ] Update `lib/benchpark/cmd/analyze.py`
