### PR TITLE
Adding GPU time option to Caliper modifier

### DIFF
--- a/docs/modifiers.rst
+++ b/docs/modifiers.rst
@@ -94,7 +94,12 @@ is created which contains the collected performance metrics.
        | - Profiles MPI functions
    * - cuda
      - NVIDIA GPUs
-     - | - CUDA API functions (e.g., time.gpu)
+     - | - CUDA API functions 
+     - | - GPU time
+   * - rocm
+     - AMD GPUs
+     - | - HIP API functions 
+     - | - GPU time
    * - topdown-counters-all
      - x86 Intel CPUs
      - | - Raw counter values for Intel top-down analysis (all levels)

--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -18,6 +18,8 @@ class Caliper:
             "mpi",
             "cuda",
             "rocm",
+            "cuda-gputime",
+            "rocm-gputime"
             "topdown-counters-all",
             "topdown-counters-toplevel",
             "topdown-all",

--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -18,8 +18,6 @@ class Caliper:
             "mpi",
             "cuda",
             "rocm",
-            "cuda-gputime",
-            "rocm-gputime"
             "topdown-counters-all",
             "topdown-counters-toplevel",
             "topdown-all",

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -79,7 +79,7 @@ class Caliper(BasicModifier):
     )
 
     add_mode(
-        mode_name="cuda-api-functions",
+        mode_name="cuda",
         mode_option="profile.cuda",
         description="Profile CUDA API functions",
     )
@@ -91,7 +91,7 @@ class Caliper(BasicModifier):
     )
 
     add_mode(
-        mode_name="hip-api-functions",
+        mode_name="hip",
         mode_option="profile.hip",
         description="Profile HIP API functions",
     )

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -80,26 +80,14 @@ class Caliper(BasicModifier):
 
     add_mode(
         mode_name="cuda",
-        mode_option="profile.cuda",
-        description="Profile CUDA API functions",
+        mode_option="profile.cuda,cuda.gputime",
+        description="Profile CUDA API functions, time spent on GPU",
     )
 
     add_mode(
-        mode_name="cuda-gputime",
-        mode_option="cuda.gputime",
-        description="Time spent on GPU",
-    )
-
-    add_mode(
-        mode_name="hip",
-        mode_option="profile.hip",
-        description="Profile HIP API functions",
-    )
-
-    add_mode(
-        mode_name="rocm-gputime",
-        mode_option="rocm.gputime",
-        description="Time spent on GPU",
+        mode_name="rocm",
+        mode_option="profile.hip,rocm.gputime",
+        description="Profile HIP API functions, time spent on GPU",
     )
 
     add_mode(

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -79,15 +79,27 @@ class Caliper(BasicModifier):
     )
 
     add_mode(
-        mode_name="cuda",
+        mode_name="cuda-api-functions",
         mode_option="profile.cuda",
         description="Profile CUDA API functions",
     )
 
     add_mode(
-        mode_name="rocm",
+        mode_name="cuda-gputime",
+        mode_option="cuda.gputime",
+        description="Time spent on GPU",
+    )
+
+    add_mode(
+        mode_name="hip-api-functions",
         mode_option="profile.hip",
         description="Profile HIP API functions",
+    )
+
+    add_mode(
+        mode_name="rocm-gputime",
+        mode_option="rocm.gputime",
+        description="Time spent on GPU",
     )
 
     add_mode(


### PR DESCRIPTION
Add gputime options to Caliper modifier
- [x] cuda: api-functions , GPU time
- [x] rocm: api-functions , GPU time
- [x] docs
- [x] test

Use ``benchpark analyze --yaxis-metric "Avg GPU time/rank"`` to see results