### PR TITLE
New scaling implementation for lammps, quicksilver, smb and phloem

### DIFF
--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -6,19 +6,19 @@
 from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.scaling import StrongScaling
 from benchpark.openmp import OpenMPExperiment
 from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
+from benchpark.new_scaling import ScalingMode, Scaling
 
 
 class Lammps(
     Experiment,
     MpiOnlyExperiment,
-    StrongScaling,
     OpenMPExperiment,
     CudaExperiment,
     ROCmExperiment,
+    Scaling(ScalingMode.Strong),
 ):
     variant(
         "workload",
@@ -44,67 +44,54 @@ class Lammps(
     maintainers("simongdg", "rfhaque")
 
     def compute_applications_section(self):
-        if self.spec.satisfies("+openmp"):
-            problem_sizes = {"x": 8, "y": 8, "z": 8}
-            kokkos_mode = "t {n_threads_per_proc}"
-            kokkos_gpu_aware = "off"
-            kokkos_comm = "host"
-        elif self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda"):
-            problem_sizes = {"x": 20, "y": 40, "z": 32}
+        if self.spec.satisfies("exec_mode=test"):
+            total_problem_sizes = {"x": 8, "y": 8, "z": 8}
+        else:
+            total_problem_sizes = {"x": 20, "y": 40, "z": 32}
+
+        self.add_experiment_variable("total_problem_size_dict", total_problem_sizes, True)
+        input_sizes = " ".join(f"-v {k} {{{k}}}" for k in total_problem_sizes.keys())
+
+        if self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda"):
             kokkos_mode = "g 1"
             kokkos_gpu_aware = "on" if self.spec.satisfies("+rocm") else "off"
             kokkos_comm = "device"
-        elif self.spec.satisfies("+cuda"):
-            problem_sizes = {"x": 20, "y": 20, "z": 16}
-            kokkos_mode = "g 1"
-            kokkos_gpu_aware = "on" if self.spec.satisfies("+cuda") else "off"
-            kokkos_comm = "device"
         else:
-            problem_sizes = {"x": 8, "y": 8, "z": 8}
             kokkos_mode = "t {n_threads_per_proc}"
             kokkos_gpu_aware = "off"
             kokkos_comm = "host"
 
-        for nk, nv in problem_sizes.items():
-            self.add_experiment_variable(nk, nv, True)
-
-        input_sizes = " ".join(f"-v {k} {{{k}}}" for k in problem_sizes.keys())
-
-        if self.spec.satisfies("+openmp"):
-            n_resources = {"n_nodes": 1, "n_ranks_per_node": 36}
-            self.add_experiment_variable("n_threads_per_proc", 1, True)
-        elif self.spec.satisfies("+rocm"):
-            n_resources = {"n_nodes": 8, "n_ranks_per_node": 8, "n_gpus": 64}
-        elif self.spec.satisfies("+cuda"):
-            n_resources = {"n_nodes": 4, "n_ranks_per_node": 4, "n_gpus": 16}
-        else:
-            n_resources = {"n_nodes": 1, "n_ranks_per_node": 36}
-            self.add_experiment_variable("n_threads_per_proc", 1, True)
-
-        if self.spec.satisfies("exec_mode=test"):
-            for pk, pv in n_resources.items():
-                self.add_experiment_variable(pk, pv, True)
-        elif self.spec.satisfies("+strong"):
-            scaled_variables = self.generate_strong_scaling_params(
-                {tuple(n_resources.keys()): list(n_resources.values())},
-                int(self.spec.variants["scaling-factor"][0]),
-                int(self.spec.variants["scaling-iterations"][0]),
-            )
-            for pk, pv in scaled_variables.items():
-                self.add_experiment_variable(pk, pv, True)
-
-        self.add_experiment_variable("timesteps", 100, False)
-        self.add_experiment_variable("input_file", "{input_path}/in.reaxff.hns", False)
         self.add_experiment_variable(
             "lammps_flags",
             f"{input_sizes} -k on {kokkos_mode} -sf kk -pk kokkos gpu/aware {kokkos_gpu_aware} neigh half comm {kokkos_comm} neigh/qeq full newton on -nocite",
             False,
         )
 
+        self.add_experiment_variable("n_resources", 1, False)
+
+        self.register_scaling_config(
+            {
+                ScalingMode.Strong: {
+                    "n_resources": lambda var, itr, dim, scaling_factor: var.val(dim)
+                    * scaling_factor,
+                },
+            }
+        )
+
+        if self.spec.satisfies("+openmp"):
+            self.add_experiment_variable("n_threads_per_proc", 1, True)
+
+        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+            self.add_experiment_variable("n_gpus", "{n_resources}", True)
+        else:
+            self.add_experiment_variable("n_ranks", "{n_resources}", True)
+
+        self.add_experiment_variable("timesteps", 100, False)
+        self.add_experiment_variable("input_file", "{input_path}/in.reaxff.hns", False)
+
         self.set_required_variables(
-            n_resources="{n_nodes}*{n_ranks_per_node}",
-            process_problem_size="{xx}*{yy}*{zz}/{n_resources}",
-            total_problem_size="{xx}*{yy}*{zz}",
+            process_problem_size="{x}*{y}*{z}/{n_resources}",
+            total_problem_size="{x}*{y}*{z}",
         )
 
     def compute_package_section(self):

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -76,6 +76,9 @@ class Lammps(
                 ScalingMode.Strong: {
                     "n_resources": lambda var, itr, dim, scaling_factor: var.val(dim)
                     * scaling_factor,
+                    "total_problem_size_dict": lambda var, itr, dim, scaling_factor: var.val(
+                        dim
+                    ),
                 },
             }
         )

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -49,7 +49,9 @@ class Lammps(
         else:
             total_problem_sizes = {"x": 20, "y": 40, "z": 32}
 
-        self.add_experiment_variable("total_problem_size_dict", total_problem_sizes, True)
+        self.add_experiment_variable(
+            "total_problem_size_dict", total_problem_sizes, True
+        )
         input_sizes = " ".join(f"-v {k} {{{k}}}" for k in total_problem_sizes.keys())
 
         if self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda"):

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -6,10 +6,9 @@
 from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.scaling import StrongScaling
 
 
-class Phloem(Experiment, MpiOnlyExperiment, StrongScaling):
+class Phloem(Experiment, MpiOnlyExperiment):
     variant(
         "workload",
         default="sqmr",

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -7,8 +7,7 @@ from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.scaling import StrongScaling
-from benchpark.scaling import WeakScaling
+from benchpark.new_scaling import ScalingMode, Scaling
 from benchpark.caliper import Caliper
 
 
@@ -16,8 +15,7 @@ class Quicksilver(
     Experiment,
     MpiOnlyExperiment,
     OpenMPExperiment,
-    StrongScaling,
-    WeakScaling,
+    Scaling(ScalingMode.Strong, ScalingMode.Weak),
     Caliper,
 ):
     variant(
@@ -36,29 +34,60 @@ class Quicksilver(
     maintainers("rfhaque")
 
     def compute_applications_section(self):
-        self.add_experiment_variable("n_threads_per_proc", "1")
-        self.add_experiment_variable("n_ranks", "{I}*{J}*{K}", True)
+        if self.spec.satisfies("exec_mode=test"):
+            self.add_experiment_variable(
+                "n_resources_dict", {"I": 2, "J": 2, "K": 1}, True
+            )
+
+            self.add_experiment_variable(
+                "total_problem_size_dict", {"X": 16, "Y": 16, "Z": 8}, True
+            )
+        else:
+            self.add_experiment_variable(
+                "n_resources_dict", {"I": 2, "J": 2, "K": 1}, True
+            )
+
+            self.add_experiment_variable(
+                "total_problem_size_dict", {"X": 32, "Y": 32, "Z": 16}, True
+            )
+
+        self.register_scaling_config(
+            {
+                ScalingMode.Strong: {
+                    "n_resources_dict": lambda var, itr, dim, scaling_factor: var.val(
+                        dim
+                    )
+                    * scaling_factor,
+                    "total_problem_size_dict": lambda var, itr, dim, scaling_factor: var.val(
+                        dim
+                    ),
+                },
+                ScalingMode.Weak: {
+                    "n_resources_dict": lambda var, itr, dim, scaling_factor: var.val(
+                        dim
+                    )
+                    * scaling_factor,
+                    "total_problem_size_dict": lambda var, itr, dim, scaling_factor: var.val(
+                        dim
+                    )
+                    * scaling_factor,
+                },
+            }
+        )
+
         self.add_experiment_variable("n", "{x}*{y}*{z}*10")
         self.add_experiment_variable("x", "{X}")
         self.add_experiment_variable("y", "{Y}")
         self.add_experiment_variable("z", "{Z}")
-        if self.spec.satisfies("+weak"):
-            self.add_experiment_variable("X", ["32", "32", "64", "64"])
-            self.add_experiment_variable("Y", ["32", "32", "32", "64"])
-            self.add_experiment_variable("Z", ["16", "32", "32", "32"])
-        else:
-            self.add_experiment_variable("X", "32")
-            self.add_experiment_variable("Y", "32")
-            self.add_experiment_variable("Z", "16")
-        self.add_experiment_variable("I", ["2", "2", "4", "4"])
-        self.add_experiment_variable("J", ["2", "2", "2", "4"])
-        self.add_experiment_variable("K", ["1", "2", "2", "2"])
 
         self.set_required_variables(
-            n_resources="{n_ranks}",
-            process_problem_size="{n}/{n_ranks}",
+            n_resources="{I}*{J}*{K}",
+            process_problem_size="{n}/{n_resources}",
             total_problem_size="{n}",
         )
+
+        self.add_experiment_variable("n_threads_per_proc", "1")
+        self.add_experiment_variable("n_ranks", "{n_resources}", True)
 
     def compute_package_section(self):
         # get package version

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -6,10 +6,9 @@
 from benchpark.directives import variant, maintainers
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.scaling import StrongScaling
 
 
-class Smb(Experiment, MpiOnlyExperiment, StrongScaling):
+class Smb(Experiment, MpiOnlyExperiment):
     variant(
         "workload",
         default="mpi_overhead",


### PR DESCRIPTION
## Description
This PR converts lammps, quicksilver, phloem and smb to the new scaling implemenation

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define a single node and multi-node experiments