### PR TITLE
Decrease Kripke Problem Sizes for Test Mode

### DIFF
--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -52,7 +52,7 @@ class Kripke(
 
             # Per-process size (in zones) in each dimension
             self.add_experiment_variable(
-                "total_problem_size_dict", {"nzx": 64, "nzy": 64, "nzz": 32}, True
+                "total_problem_size_dict", {"nzx": 32, "nzy": 32, "nzz": 16}, True
             )
 
             self.add_experiment_variable("ngroups", 64, True)


### PR DESCRIPTION
## Description

- [x] The default problem sizes can be smaller for the test mode, which will be helpful to speed up the tutorial.

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Update `kripke/experiment.py`
