### PR TITLE
Redesign `benchpark list` Output

### DIFF
--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -8,6 +8,7 @@ import time
 import sys
 import argparse
 import os
+import re
 
 import benchpark.paths
 
@@ -64,7 +65,9 @@ def main():
     expr_str = run_subprocess_cmd(
         ["./bin/benchpark", "list", "experiments", "--no-title"], decode=True
     )
-    experiments = [e for e in expr_str.replace(" ", "").replace("\t", "").split("\n") if e != ""]
+    experiments = [
+        e for e in expr_str.replace(" ", "").replace("\t", "").split("\n") if e != ""
+    ]
 
     mpi_only_expr = set()
     cuda_expr = []
@@ -75,21 +78,21 @@ def main():
     throughput_expr = []
 
     for e in experiments:
-        if "+" not in e and "=" not in e:
-            mpi_only_expr.add(e)
+        benchmark = e.split("+")[0]
+        mpi_only_expr.add(benchmark)
 
         if "cuda" in e:
-            cuda_expr.append(e)
-        elif "rocm" in e:
-            rocm_expr.append(e)
-        elif "openmp" in e:
-            openmp_expr.append(e)
-        elif "strong" in e:
-            strong_expr.append(e)
-        elif "weak" in e:
-            weak_expr.append(e)
-        elif "throughput" in e:
-            throughput_expr.append(e)
+            cuda_expr.append(benchmark + "+cuda")
+        if "rocm" in e:
+            rocm_expr.append(benchmark + "+rocm")
+        if "openmp" in e:
+            openmp_expr.append(benchmark + "+openmp")
+        if "strong" in e:
+            strong_expr.append(benchmark + "+strong")
+        if "weak" in e:
+            weak_expr.append(benchmark + "+weak")
+        if "throughput" in e:
+            throughput_expr.append(benchmark + "+throughput")
 
     str_dict = {}
     for pmodel in ["mpi", "cuda", "rocm", "openmp"]:
@@ -97,11 +100,25 @@ def main():
         if pmodel != "mpi":
             cmd += ["-p", pmodel]
         output = run_subprocess_cmd(cmd, decode=True)
+        lines = output.splitlines()
+        expanded_lines = []
+        for line in lines:
+            # Match patterns like key= [a|b|c]
+            match = re.search(r"(.*?)(\w+)=\[(.*?)\]", line)
+            if match:
+                prefix, key, values = match.groups()
+                for v in values.split("|"):
+                    expanded_lines.append(f"{prefix}{key}={v}")
+            else:
+                expanded_lines.append(line)
+        print(expanded_lines)
+        print("1")
         str_dict[pmodel] = [
             i
-            for i in output.replace(" " * 4, "").replace("\t", "").split("\n")
+            for i in [j.replace(" " * 4, "").replace("\t", "") for j in expanded_lines]
             if i != ""
         ]
+        print(str_dict[pmodel])
 
     mods_str = run_subprocess_cmd(
         ["./bin/benchpark", "list", "modifiers", "--no-title"], decode=True
@@ -113,9 +130,13 @@ def main():
     ]
 
     caliper_exp = [
-        e.replace("+caliper", " caliper=time") for e in benchpark_experiments(exclude_variants=[]) if "+caliper" in e and e.split("+")[0] in mpi_only_expr
+        e.replace("+caliper", " caliper=time")
+        for e in benchpark_experiments(exclude_variants=[])
+        if "+caliper" in e and e.split("+")[0] in mpi_only_expr
     ]
-    modifiers_expr = caliper_exp + [e + " " + m + "=on" for e in mpi_only_expr for m in nmods]
+    modifiers_expr = caliper_exp + [
+        e + " " + m + "=on" for e in mpi_only_expr for m in nmods
+    ]
 
     exprs_to_sys = [
         ("mpi", mpi_only_expr, str_dict["mpi"]),
@@ -159,7 +180,7 @@ def main():
                         ["bash", ".github/utils/dryrun.sh", espec, sspec],
                         env={**os.environ},
                         capture_output=True,
-                        check=True
+                        check=True,
                     )
                 except subprocess.CalledProcessError as e:
                     errors[f"{espec} {sspec}"] = e.stderr.decode()
@@ -172,7 +193,9 @@ def main():
         print(value)
 
     print(f"Elapsed: {(end - start) / 60:.2f} minutes")
-    print(f"{ran_tests - fail_tests} Passing. {fail_tests} Failing. {skip_tests} Skipped.")
+    print(
+        f"{ran_tests - fail_tests} Passing. {fail_tests} Failing. {skip_tests} Skipped."
+    )
 
     sys.exit(1 if fail_tests > 0 else 0)
 

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -10,11 +10,6 @@ import argparse
 import os
 import re
 
-import benchpark.paths
-
-sys.path.append(str(benchpark.paths.benchpark_home) + "/spack/lib/spack")
-from lib.benchpark.accounting import benchpark_experiments  # noqa: E402
-
 DEFAULT_SYSTEM = "llnl-cluster cluster=dane"
 # Skip experiments
 SKIP_EXPR = [

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -117,30 +117,31 @@ def main():
         ["./bin/benchpark", "list", "modifiers", "--no-title"], decode=True
     )
     nmods = [i for i in mods_str.replace(" " * 4, "").split("\n") if i != ""]
+    print(nmods)
     modifiers_expr = []
     exclude_mods = ["allocation"]
     i = 0
     while i < len(nmods):
         if nmods[i] in exclude_mods:
             # Skip modifier and "(all benchmarks) line"
-            i += 1
+            i += 2
             continue
         if not nmods[i].startswith("\t"):
             curmod = nmods[i]
+            print(curmod)
             end = "=on" if curmod != "caliper" else "=time"
             if "(all benchmarks)" in nmods[i + 1]:
                 for b in mpi_only_expr:
                     modifiers_expr.append(b + " " + curmod + end)
-                i += 1
+                i += 2
                 continue
             else:
                 i += 1
                 while nmods[i].startswith("\t"):
-                    modifiers_expr.append(nmods[i].lstrip("\t") + " " + curmod + end)
+                    bmark = nmods[i].lstrip("\t")
+                    if bmark in mpi_only_expr:
+                        modifiers_expr.append(bmark + " " + curmod + end)
                     i += 1
-        i += 1
-
-    print(modifiers_expr)
 
     exprs_to_sys = [
         ("mpi", mpi_only_expr, str_dict["mpi"]),

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -111,14 +111,11 @@ def main():
                     expanded_lines.append(f"{prefix}{key}={v}")
             else:
                 expanded_lines.append(line)
-        print(expanded_lines)
-        print("1")
         str_dict[pmodel] = [
             i
             for i in [j.replace(" " * 4, "").replace("\t", "") for j in expanded_lines]
             if i != ""
         ]
-        print(str_dict[pmodel])
 
     mods_str = run_subprocess_cmd(
         ["./bin/benchpark", "list", "modifiers", "--no-title"], decode=True

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -127,17 +127,20 @@ def main():
             continue
         if not nmods[i].startswith("\t"):
             curmod = nmods[i]
+            end = "=on" if curmod != "caliper" else "=time"
             if "(all benchmarks)" in nmods[i + 1]:
                 for b in mpi_only_expr:
-                    modifiers_expr.append(b + " " + curmod + "=on")
+                    modifiers_expr.append(b + " " + curmod + end)
                 i += 1
                 continue
             else:
                 i += 1
                 while nmods[i].startswith("\t"):
-                    modifiers_expr.append(nmods[i].lstrip("\t") + " " + curmod + "=on")
+                    modifiers_expr.append(nmods[i].lstrip("\t") + " " + curmod + end)
                     i += 1
         i += 1
+
+    print(modifiers_expr)
 
     exprs_to_sys = [
         ("mpi", mpi_only_expr, str_dict["mpi"]),

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -121,20 +121,28 @@ def main():
     mods_str = run_subprocess_cmd(
         ["./bin/benchpark", "list", "modifiers", "--no-title"], decode=True
     )
-    nmods = [
-        i
-        for i in mods_str.replace(" " * 4, "").replace("\t", "").split("\n")
-        if i != "" and i not in ["allocation", "caliper"]
-    ]
-
-    caliper_exp = [
-        e.replace("+caliper", " caliper=time")
-        for e in benchpark_experiments(exclude_variants=[])
-        if "+caliper" in e and e.split("+")[0] in mpi_only_expr
-    ]
-    modifiers_expr = caliper_exp + [
-        e + " " + m + "=on" for e in mpi_only_expr for m in nmods
-    ]
+    nmods = [i for i in mods_str.replace(" " * 4, "").split("\n") if i != ""]
+    modifiers_expr = []
+    exclude_mods = ["allocation"]
+    i = 0
+    while i < len(nmods):
+        if nmods[i] in exclude_mods:
+            # Skip modifier and "(all benchmarks) line"
+            i += 1
+            continue
+        if not nmods[i].startswith("\t"):
+            curmod = nmods[i]
+            if "(all benchmarks)" in nmods[i + 1]:
+                for b in mpi_only_expr:
+                    modifiers_expr.append(b + " " + curmod + "=on")
+                i += 1
+                continue
+            else:
+                i += 1
+                while nmods[i].startswith("\t"):
+                    modifiers_expr.append(nmods[i].lstrip("\t") + " " + curmod + "=on")
+                    i += 1
+        i += 1
 
     exprs_to_sys = [
         ("mpi", mpi_only_expr, str_dict["mpi"]),

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -79,8 +79,9 @@ def main():
 
     for e in experiments:
         benchmark = e.split("+")[0]
-        mpi_only_expr.add(benchmark)
 
+        if "mpi" in e:
+            mpi_only_expr.add(benchmark)
         if "cuda" in e:
             cuda_expr.append(benchmark + "+cuda")
         if "rocm" in e:

--- a/docs/basic-tutorial.rst
+++ b/docs/basic-tutorial.rst
@@ -64,61 +64,66 @@ You should see an output like:
 
 .. code-block:: text
 
-    Experiments:
-        ...
-        hpcg
-        hpcg+openmp
-        hpcg+strong
-        hpcg+weak
-        hpl
-        hpl+openmp
-        hpl+strong
-        hpl+weak
-        ior
-        ior+strong
-        ior+weak
-        kripke
-        kripke+openmp
-        kripke+cuda
-        kripke+rocm
-        laghos
-        laghos+cuda
-        laghos+rocm
-        lammps
-        lammps+openmp
-        lammps+cuda
-        lammps+rocm
-        lammps+strong
-        ...
+    Experiments - BENCHMARK+PROGRAMMING_MODEL+SCALING
+        ad+[mpi]
+        amg2023+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        babelstream+[openmp|cuda|rocm]
+        genesis+[openmp|mpi]
+        gpcnet+[mpi]
+        gromacs+[openmp|cuda|rocm|mpi]
+        hpcg+[openmp|mpi]+[strong|weak]
+        hpl+[openmp|mpi]+[strong|weak]
+        ior+[mpi]+[strong|weak]
+        kripke+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        laghos+[cuda|rocm|mpi]+[strong]
+        lammps+[openmp|cuda|rocm|mpi]+[strong]
+        md-test+[mpi]+[strong]
+        mpi-pingpong
+        osu-micro-benchmarks+[cuda|rocm|mpi]
+        phloem+[mpi]
+        quicksilver+[openmp|mpi]+[strong|weak]
+        qws+[openmp|mpi]
+        raja-perf+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        remhos+[cuda|rocm|mpi]+[strong]
+        salmon-tddft+[openmp|mpi]
+        saxpy+[openmp|cuda|rocm|mpi]
+        smb+[mpi]
+        stream+[mpi]
 
 From this output, you can see that Benchpark experiments are specified
 using Spack-like conventions (e.g., ~, +). For example, the spec
 ``kripke`` describes an experiment using the Kripke benchmark
 running on a single node.
 
-Additionally, you can get only the experiments associated with a particular
-benchmark by adding :code:`--experiment <experiment_name>` to the above command.
-For example, to get only the experiments associated with Kripke, run:
+Additionally, you can get only the benchmarks implementing a particular
+experiment by adding :code:`--experiment <experiment_name>` to the above command.
+For example, to get only CUDA benchmarks, run:
 
 .. code-block:: bash
 
-    benchpark list experiments --experiment kripke
+    benchpark list experiments --experiment cuda
 
 You should see the following:
 
 .. code-block:: text
 
-    Experiments:
-        kripke
-        kripke+openmp
-        kripke+cuda
-        kripke+rocm
+    Experiments - BENCHMARK+PROGRAMMING_MODEL+SCALING
+        amg2023+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        babelstream+[openmp|cuda|rocm]
+        gromacs+[openmp|cuda|rocm|mpi]
+        kripke+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        laghos+[cuda|rocm|mpi]+[strong]
+        lammps+[openmp|cuda|rocm|mpi]+[strong]
+        osu-micro-benchmarks+[cuda|rocm|mpi]
+        raja-perf+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
+        remhos+[cuda|rocm|mpi]+[strong]
+        saxpy+[openmp|cuda|rocm|mpi]
 
 .. note::
 
-    For Kripke, the default experiment is ``kripke``. For Kripke,
-    we specify the strong scaling experiment on the command line using ``kripke
-    +strong`` as shown in Step 4.
+    For all benchmarks, the default experiment is ``+mpi`` only without scaling. For Kripke,
+    we specify the strong scaling mpi experiment on the command line using ``kripke
+    +strong`` as shown in Step 4 (``+mpi`` is implied).
 
 .. _step3_label:
 ------------------------------------------

--- a/docs/benchpark-commands.rst
+++ b/docs/benchpark-commands.rst
@@ -83,9 +83,9 @@ Additionally, this command can be used to search for experiments with one or mor
 
 Or search which experiments have the Caliper modifier (see :doc:`modifiers`) available::
   
-  $ benchpark list modifiers --name caliper --experiments
+  $ benchpark list modifiers
 
-.. program-output:: ../bin/benchpark list modifiers --name caliper --experiments
+.. program-output:: ../bin/benchpark list modifiers
 
 
 Now that you know the existing benchmarks and systems, you can determine your necessary workflow in :doc:`benchpark-workflow`.

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -35,6 +35,8 @@ def benchpark_experiments(exclude_variants=non_experiments):
     experiments_dir = source_dir / "experiments"
 
     for x in sorted(os.listdir(experiments_dir)):
+        if not os.path.isdir(experiments_dir / x):
+            continue
         exp_pmodels_scaling = defaultdict(list)
         if x not in exclude_exper:
             expr_file = str(experiments_dir) + "/" + x + "/experiment.py"

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -7,7 +7,6 @@ import os
 from collections import defaultdict
 
 import benchpark.paths
-from benchpark.spec import SystemSpec
 
 PROGRAMMING_MODEL_CATEGORY = "programming_model"
 SCALING_CATEGORY = "scaling"
@@ -70,14 +69,14 @@ def benchpark_modifiers():
 
 
 def benchpark_systems(programming_model=None):
-    import benchpark.spec
+    from benchpark.spec import SystemSpec
 
     source_dir = benchpark.paths.benchpark_root
     systems = []
     exclude = ["all_hardware_descriptions", "common", "repo.yaml"]
     for x in sorted(os.listdir(source_dir / "systems")):
         if x not in exclude and "system.py" in os.listdir(source_dir / "systems" / x):
-            system_spec = benchpark.spec.SystemSpec(x)
+            system_spec = SystemSpec(x)
             system_class = system_spec.system_class
             # aws uses 'instance_type' not 'cluster'
             cluster_variant = "instance_type" if "aws" in x else "cluster"

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -10,9 +10,7 @@ import benchpark.paths
 
 PROGRAMMING_MODEL_CATEGORY = "programming_model"
 SCALING_CATEGORY = "scaling"
-
-exclude_exper = ["repo.yaml"]
-exp_dict = {
+EXP_DICT = {
     "OpenMPExperiment": (PROGRAMMING_MODEL_CATEGORY, "openmp"),
     "CudaExperiment": (PROGRAMMING_MODEL_CATEGORY, "cuda"),
     "ROCmExperiment": (PROGRAMMING_MODEL_CATEGORY, "rocm"),
@@ -20,17 +18,18 @@ exp_dict = {
     "ScalingMode.Strong": (SCALING_CATEGORY, "strong"),
     "ScalingMode.Weak": (SCALING_CATEGORY, "weak"),
     "ScalingMode.Throughput": (SCALING_CATEGORY, "throughput"),
-    "Caliper": ("modifier", "caliper"),
 }
-sys_dict = {
+SYS_DICT = {
     "OpenMPSystem": "openmp",
     "CudaSystem": "cuda",
     "ROCmSystem": "rocm",
 }
-non_experiments = ["Caliper", "Affinity"]
+MOD_DICT = {
+    "Caliper": ("modifier", "caliper"),
+}
 
 
-def benchpark_experiments(exclude_variants=non_experiments):
+def benchpark_experiments(exp_dict=EXP_DICT, exclude_variants=[]):
     source_dir = benchpark.paths.benchpark_root
     experiments = []
     experiments_dir = source_dir / "experiments"
@@ -39,15 +38,14 @@ def benchpark_experiments(exclude_variants=non_experiments):
         if not os.path.isdir(experiments_dir / x):
             continue
         exp_pmodels_scaling = defaultdict(list)
-        if x not in exclude_exper:
-            expr_file = str(experiments_dir) + "/" + x + "/experiment.py"
-            if os.path.isfile(expr_file):
-                with open(expr_file, "r") as file:
-                    file_text = file.read()
-                    for var in exp_dict.keys():
-                        if var in file_text and var not in exclude_variants:
-                            category, option = exp_dict[var]
-                            exp_pmodels_scaling[category].append(option)
+        expr_file = str(experiments_dir) + "/" + x + "/experiment.py"
+        if os.path.isfile(expr_file):
+            with open(expr_file, "r") as file:
+                file_text = file.read()
+                for var in exp_dict.keys():
+                    if var in file_text and var not in exclude_variants:
+                        category, option = exp_dict[var]
+                        exp_pmodels_scaling[category].append(option)
         end_str = ""
         for category in [PROGRAMMING_MODEL_CATEGORY, SCALING_CATEGORY]:
             if len(exp_pmodels_scaling[category]) == 0:

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -7,6 +7,7 @@ import os
 from collections import defaultdict
 
 import benchpark.paths
+from benchpark.spec import SystemSpec
 
 PROGRAMMING_MODEL_CATEGORY = "programming_model"
 SCALING_CATEGORY = "scaling"
@@ -68,7 +69,7 @@ def benchpark_modifiers():
     return modifiers
 
 
-def benchpark_systems():
+def benchpark_systems(programming_model=None):
     import benchpark.spec
 
     source_dir = benchpark.paths.benchpark_root
@@ -84,13 +85,29 @@ def benchpark_systems():
             if len(variants) > 0:
                 variants = variants[0]
             clusters = None
+            has_clusters = True
             if cluster_variant in variants:
                 clusters = list(variants[cluster_variant].values)
-            if clusters:
-                for c in clusters:
-                    systems.append(x + "/" + c)
             else:
-                systems.append(x)
+                clusters = [x]
+                has_clusters = False
+            if programming_model:
+                new_clusters = []
+                for c in clusters:
+                    fullspec = f"{x} {cluster_variant}={c}" if has_clusters else x
+                    p_models_list = (
+                        SystemSpec(fullspec).concretize().system.programming_models
+                    )
+                    if any([programming_model == p.name for p in p_models_list]):
+                        new_clusters.append(c)
+                clusters = new_clusters
+            if len(clusters) > 0:
+                if has_clusters:
+                    systems.append(
+                        x + " " + cluster_variant + "=[" + "|".join(clusters) + "]"
+                    )
+                else:
+                    systems.append(x)
     return systems
 
 

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -16,6 +16,7 @@ exp_dict = {
     "OpenMPExperiment": (PROGRAMMING_MODEL_CATEGORY, "openmp"),
     "CudaExperiment": (PROGRAMMING_MODEL_CATEGORY, "cuda"),
     "ROCmExperiment": (PROGRAMMING_MODEL_CATEGORY, "rocm"),
+    "MpiOnlyExperiment": (PROGRAMMING_MODEL_CATEGORY, "mpi"),
     "ScalingMode.Strong": (SCALING_CATEGORY, "strong"),
     "ScalingMode.Weak": (SCALING_CATEGORY, "weak"),
     "ScalingMode.Throughput": (SCALING_CATEGORY, "throughput"),

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -4,18 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from collections import defaultdict
 
 import benchpark.paths
 
+PROGRAMMING_MODEL_CATEGORY = "programming_model"
+SCALING_CATEGORY = "scaling"
+
 exclude_exper = ["repo.yaml"]
 exp_dict = {
-    "OpenMPExperiment": "openmp",
-    "CudaExperiment": "cuda",
-    "ROCmExperiment": "rocm",
-    "Caliper": "caliper",
-    "ScalingMode.Strong": "strong",
-    "ScalingMode.Weak": "weak",
-    "ScalingMode.Throughput": "throughput",
+    "OpenMPExperiment": (PROGRAMMING_MODEL_CATEGORY, "openmp"),
+    "CudaExperiment": (PROGRAMMING_MODEL_CATEGORY, "cuda"),
+    "ROCmExperiment": (PROGRAMMING_MODEL_CATEGORY, "rocm"),
+    "ScalingMode.Strong": (SCALING_CATEGORY, "strong"),
+    "ScalingMode.Weak": (SCALING_CATEGORY, "weak"),
+    "ScalingMode.Throughput": (SCALING_CATEGORY, "throughput"),
+    "Caliper": ("modifier", "caliper"),
 }
 sys_dict = {
     "OpenMPSystem": "openmp",
@@ -31,20 +35,25 @@ def benchpark_experiments(exclude_variants=non_experiments):
     experiments_dir = source_dir / "experiments"
 
     for x in sorted(os.listdir(experiments_dir)):
+        exp_pmodels_scaling = defaultdict(list)
         if x not in exclude_exper:
             expr_file = str(experiments_dir) + "/" + x + "/experiment.py"
             if os.path.isfile(expr_file):
                 with open(expr_file, "r") as file:
                     file_text = file.read()
-                    if "MpiOnlyExperiment" in file_text:
-                        experiments.append(x)  # default expr
                     for var in exp_dict.keys():
                         if var in file_text and var not in exclude_variants:
-                            if "=" in exp_dict[var]:
-                                joiner = " "
-                            else:
-                                joiner = "+"
-                            experiments.append(f"{x}{joiner}{exp_dict[var]}")
+                            category, option = exp_dict[var]
+                            exp_pmodels_scaling[category].append(option)
+        end_str = ""
+        for category in [PROGRAMMING_MODEL_CATEGORY, SCALING_CATEGORY]:
+            if len(exp_pmodels_scaling[category]) == 0:
+                break
+            cat_str = "+["
+            cat_str += "|".join(exp_pmodels_scaling[category])
+            cat_str += "]"
+            end_str += cat_str
+        experiments.append(x + end_str)
     return experiments
 
 

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -66,11 +66,11 @@ def benchpark_modifiers():
     exclude = ["modifier_repo.yaml"]
     for x in sorted(os.listdir(source_dir / "modifiers")):
         check_experiments = True
-        if x in all_benchmark_modifiers:
-            x = x + " (all benchmarks)"
-            check_experiments = False
         if x not in exclude:
             modifiers.append(x)
+        if x in all_benchmark_modifiers:
+            modifiers.append("\t!(all benchmarks)")
+            check_experiments = False
         if check_experiments:
             for exp in sorted(os.listdir(experiments_dir)):
                 if not os.path.isdir(experiments_dir / exp):

--- a/lib/benchpark/accounting.py
+++ b/lib/benchpark/accounting.py
@@ -59,12 +59,28 @@ def benchpark_experiments(exp_dict=EXP_DICT, exclude_variants=[]):
 
 
 def benchpark_modifiers():
+    all_benchmark_modifiers = ["affinity", "allocation", "hwloc"]
     source_dir = benchpark.paths.benchpark_root
+    experiments_dir = source_dir / "experiments"
     modifiers = []
     exclude = ["modifier_repo.yaml"]
     for x in sorted(os.listdir(source_dir / "modifiers")):
+        check_experiments = True
+        if x in all_benchmark_modifiers:
+            x = x + " (all benchmarks)"
+            check_experiments = False
         if x not in exclude:
             modifiers.append(x)
+        if check_experiments:
+            for exp in sorted(os.listdir(experiments_dir)):
+                if not os.path.isdir(experiments_dir / exp):
+                    continue
+                expr_file = str(experiments_dir) + "/" + exp + "/experiment.py"
+                if os.path.isfile(expr_file):
+                    with open(expr_file, "r") as file:
+                        file_text = file.read()
+                        if x in file_text:
+                            modifiers.append("\t" + "!" + exp)
 
     return modifiers
 
@@ -116,6 +132,7 @@ def benchpark_benchmarks():
     benchmarks = []
     experiments_dir = source_dir / "experiments"
     for x in sorted(os.listdir(experiments_dir)):
-        if x not in exclude_exper:
-            benchmarks.append(f"{x}")
+        if not os.path.isdir(experiments_dir / x):
+            continue
+        benchmarks.append(f"{x}")
     return benchmarks

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -67,19 +67,8 @@ def list_systems(args):
 
 
 def list_modifiers(args):
-    modifiers = benchpark_modifiers() if not args.name else [args.name]
-    if args.experiments:
-        collection = []
-        all_experiments = benchpark_experiments(exclude_variants=[])
-        for modifier in modifiers:
-            collection.append(modifier)
-            exprs = [e.split("+")[0] for e in all_experiments if modifier in e]
-            for benchmark in benchpark_benchmarks():
-                if any([benchmark == e for e in exprs]):
-                    collection.append("\t" + "@*c" + benchmark + "@.")
-        _print_helper("Modifiers:" if not args.no_title else None, collection)
-    else:
-        _print_helper("Modifiers:" if not args.no_title else None, modifiers)
+    modifiers = benchpark_modifiers()
+    _print_helper("Modifiers:" if not args.no_title else None, modifiers)
 
 
 def setup_parser(root_parser):
@@ -102,6 +91,7 @@ def setup_parser(root_parser):
         type=str,
         nargs="*",
         default=None,
+        choices=["cuda", "rocm", "openmp", "strong", "weak", "throughput"],
         help="Filter experiments containing a specific substring (e.g., 'cuda').",
     )
     experiments_parser.add_argument(
@@ -117,21 +107,13 @@ def setup_parser(root_parser):
         "-p",
         type=str,
         default=None,
+        choices=["cuda", "rocm", "openmp"],
         help="Filter systems that support a specific programming model (e.g., 'cuda').",
     )
 
     modifiers_parser = list_subparser.add_parser("modifiers")
     modifiers_parser.add_argument(
         "--no-title", action="store_true", help="Turn off printing title in output."
-    )
-    modifiers_parser.add_argument(
-        "--experiments",
-        "-e",
-        action="store_true",
-        help="See experiments for modifier, if applicable.",
-    )
-    modifiers_parser.add_argument(
-        "--name", default=None, type=str, help="Optional modifier name"
     )
 
 

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -12,7 +12,6 @@ from benchpark.accounting import (  # noqa: E402
     benchpark_modifiers,
     benchpark_systems,
 )
-from benchpark.spec import SystemSpec
 
 
 def _print_helper(name, collection, filter=None):
@@ -38,13 +37,13 @@ def _print_helper(name, collection, filter=None):
         collection = [item for item in collection if any([f in item for f in filter])]
 
     for item in collection:
-        if "/" not in item and "+" not in item:
+        if "=" not in item and "+" not in item:
             color.cprint(f"    {strs[0]+item+end}")
         else:
-            char = "/" if "/" in item else "+"
+            char = "=" if "=" in item else "+"
             item = item.split(char)
             color.cprint(
-                f"    {strs[0]+item[0]+end+'+'+char.join([strs[i]+item[i]+end for i in range(1,len(item))])}"
+                f"    {strs[0]+item[0]+end+char+char.join([strs[i]+item[i]+end for i in range(1,len(item))])}"
             )
 
 
@@ -61,19 +60,10 @@ def list_experiments(args):
 
 
 def list_systems(args):
-    systems = benchpark_systems()
-    new_systems = []
-    for system in systems:
-        sspec, cluster = system.split("/") if "/" in system else (system, None)
-        cluster_variant = "instance_type" if "aws" in sspec else "cluster"
-        # List of valid programming models for system (MPI assumed to be valid)
-        fullspec = sspec if not cluster else f"{sspec} {cluster_variant}={cluster}"
-        p_models_list = SystemSpec(fullspec).concretize().system.programming_models
-        if not args.programming_model or any(
-            [args.programming_model == p.name for p in p_models_list]
-        ):
-            new_systems.append(fullspec)
-    _print_helper("Systems:" if not args.no_title else None, new_systems)
+    _print_helper(
+        "Systems:" if not args.no_title else None,
+        benchpark_systems(args.programming_model),
+    )
 
 
 def list_modifiers(args):

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -30,7 +30,7 @@ def _print_helper(name, collection, filter=None):
         name = "@*b" + name + "@."
         color.cprint(name)
 
-    strs = ["@*r", "@*c"]
+    strs = ["@*r", "@*c", "@*m"]
     end = "@."
 
     # Compute filtering
@@ -43,7 +43,9 @@ def _print_helper(name, collection, filter=None):
         else:
             char = "/" if "/" in item else "+"
             item = item.split(char)
-            color.cprint(f"    {strs[0]+item[0]+end+char+strs[1]+item[1]+end}")
+            color.cprint(
+                f"    {strs[0]+item[0]+end+'+'+char.join([strs[i]+item[i]+end for i in range(1,len(item))])}"
+            )
 
 
 def list_benchmarks(args):

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -47,8 +47,12 @@ def _print_helper(name, collection, filter=None):
         collection = [item for item in collection if any([f in item for f in filter])]
 
     for item in collection:
+        idx = 0
+        if "!" in item:
+            item = item.replace("!", "")
+            idx = 1
         if "=" not in item and "+" not in item:
-            color.cprint(f"    {strs[0]+item+end}")
+            color.cprint(f"    {strs[idx]+item+end}")
         else:
             char = "=" if "=" in item else "+"
             item = item.split(char)

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -25,12 +25,22 @@ def _print_helper(name, collection, filter=None):
                                 Only items containing this substring will be displayed.
                                 If None, all items in the collection are displayed.
     """
-    if name:
-        name = "@*b" + name + "@."
-        color.cprint(name)
-
     strs = ["@*r", "@*c", "@*m"]
     end = "@."
+
+    if name:
+        if isinstance(name, list):
+            name = (
+                "@*b"
+                + name[0]
+                + "@."
+                + "".join([strs[i - 1] + name[i] + end for i in range(1, len(name))])
+            )
+        elif isinstance(name, str):
+            name = "@*b" + name + "@."
+        else:
+            raise ValueError(f"'name' is type {type(name)}. Must be list or str.")
+        color.cprint(name)
 
     # Compute filtering
     if filter:
@@ -53,7 +63,11 @@ def list_benchmarks(args):
 
 def list_experiments(args):
     _print_helper(
-        "Experiments:" if not args.no_title else None,
+        (
+            ["Experiments - ", "BENCHMARK@.+", "PROGRAMMING_MODEL@.+", "SCALING"]
+            if not args.no_title
+            else None
+        ),
         benchpark_experiments(),
         filter=args.experiment,
     )
@@ -61,7 +75,11 @@ def list_experiments(args):
 
 def list_systems(args):
     _print_helper(
-        "Systems:" if not args.no_title else None,
+        (
+            ["Systems - ", "SYSTEM_DEFINITION", " CLUSTER/INSTANCE"]
+            if not args.no_title
+            else None
+        ),
         benchpark_systems(args.programming_model),
     )
 

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -20,7 +20,7 @@ def _print_helper(name, collection, filter=None):
     Args:
         name (str): The title to display above the collection. If None, no title is displayed.
         collection (list of str): A list of strings to display. Items can optionally contain
-                                  special characters (e.g., '/' or '+') for additional formatting.
+                                special characters (e.g., '/' or '+') for additional formatting.
         filter (list, optional): A substring to filter the items in the collection.
                                 Only items containing this substring will be displayed.
                                 If None, all items in the collection are displayed.

--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -90,6 +90,8 @@ def list_systems(args):
 
 def list_modifiers(args):
     modifiers = benchpark_modifiers()
+    if args.hide_benchmarks:
+        modifiers = [m for m in modifiers if not m.startswith("\t")]
     _print_helper("Modifiers:" if not args.no_title else None, modifiers)
 
 
@@ -136,6 +138,11 @@ def setup_parser(root_parser):
     modifiers_parser = list_subparser.add_parser("modifiers")
     modifiers_parser.add_argument(
         "--no-title", action="store_true", help="Turn off printing title in output."
+    )
+    modifiers_parser.add_argument(
+        "--hide-benchmarks",
+        action="store_true",
+        help="Do not show benchmarks under each modifier in output.",
     )
 
 

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -50,8 +50,10 @@ def test_list():
         capture_output=True,
         text=True,
     )
-    assert "+cuda" in check_cuda.stdout
-    assert "+rocm" not in check_cuda.stdout
+    # CUDA benchmark
+    assert "amg2023" in check_cuda.stdout
+    # Non CUDA benchmark
+    assert "gpcnet" not in check_cuda.stdout
 
 
 def test_tags():

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -18,7 +18,7 @@ def test_list():
             text=True,
         )
         assert (
-            f"{subcmd.capitalize()}:" in result_with_title.stdout
+            f"{subcmd.capitalize()}" in result_with_title.stdout
         ), f"Title missing for {subcmd} in output with title"
 
         # Test without title (--no-title flag)
@@ -36,6 +36,9 @@ def test_list():
         assert (
             f"{subcmd.capitalize()}:" not in result_no_title.stdout
         ), f"Title found for {subcmd} in output without title"
+
+        if subcmd == "modifiers":
+            assert "amg2023" in result_with_title.stdout and "amg2023" in result_no_title.stdout
 
     # Check filtering
     check_cuda = subprocess.run(

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -38,7 +38,10 @@ def test_list():
         ), f"Title found for {subcmd} in output without title"
 
         if subcmd == "modifiers":
-            assert "amg2023" in result_with_title.stdout and "amg2023" in result_no_title.stdout
+            assert (
+                "amg2023" in result_with_title.stdout
+                and "amg2023" in result_no_title.stdout
+            )
 
     # Check filtering
     check_cuda = subprocess.run(


### PR DESCRIPTION
## Description

- [x] Update output of `benchpark list` to be more intuitive e.g. programming models and scaling options can be used together. Update coloring and titles.
- [x] Depends on #987
- [x] Addresses #902

## Adding/modifying core functionality, CI, or documentation:

- [x] Update docs
- [x] Update `.github/workflows`
- [x] Update `list.py` and `accounting.py`

## Example

`benchpark list experiments`
<img width="587" height="351" alt="image" src="https://github.com/user-attachments/assets/3fcb7aa6-af7f-415d-af31-f971d7aac98e" />
`benchpark list systems`
<img width="587" height="184" alt="image" src="https://github.com/user-attachments/assets/1b3eb5c7-554b-4983-ad27-abddf437aa75" />
`benchpark list modifiers`
<img width="587" height="285" alt="image" src="https://github.com/user-attachments/assets/bf721429-6b2e-4160-bcc5-52ce138d1420" />

