### PR TITLE
Update Affinity Package Flags

### DIFF
--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -136,7 +136,7 @@ class Affinity:
                 if self.spec.satisfies("+cuda"):
                     package_specs["affinity"]["pkg_spec"] += "+cuda"
                 elif self.spec.satisfies("+rocm"):
-                    package_specs["affinity"]["pkg_spec"] += "+rocm"
+                    package_specs["affinity"]["pkg_spec"] += "+rocm amdgpu_target={rocm_arch}"
 
             return {
                 "packages": {k: v for k, v in package_specs.items() if v},

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -136,7 +136,9 @@ class Affinity:
                 if self.spec.satisfies("+cuda"):
                     package_specs["affinity"]["pkg_spec"] += "+cuda"
                 elif self.spec.satisfies("+rocm"):
-                    package_specs["affinity"]["pkg_spec"] += "+rocm amdgpu_target={rocm_arch}"
+                    package_specs["affinity"][
+                        "pkg_spec"
+                    ] += "+rocm amdgpu_target={rocm_arch}"
 
             return {
                 "packages": {k: v for k, v in package_specs.items() if v},

--- a/repo/affinity/package.py
+++ b/repo/affinity/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Affinity(CMakePackage, CudaPackage):
+class Affinity(CMakePackage, CudaPackage, ROCmPackage):
     """Simple applications for determining Linux thread and gpu affinity."""
 
     homepage = "https://github.com/bcumming/affinity"
@@ -31,12 +31,15 @@ class Affinity(CMakePackage, CudaPackage):
         if '+mpi' in spec:
             args.append('-DCMAKE_CXX_COMPILER={0}'.format(spec["mpi"].mpicxx))
             args.append("-DMPI_CXX_LINK_FLAGS={0}".format(spec["mpi"].libs.ld_flags))
+            args.append("-DAFFINITY_MPI=on")
 
         if '+cuda' in spec:
             args.append('-DCMAKE_CUDA_HOST_COMPILER={0}'.format(spec["mpi"].mpicxx))
             args.append('-DCMAKE_CUDA_COMPILER={0}'.format(spec["cuda"].prefix + "/bin/nvcc"))
+            args.append("-DAFFINITY_GPU_BACKEND=cuda")
 
         if '+rocm' in spec:
             args.append("-DROCM_PATH={0}".format(spec['hip'].prefix))
+            args.append("-DAFFINITY_GPU_BACKEND=rocm")
 
         return args

--- a/repo/affinity/package.py
+++ b/repo/affinity/package.py
@@ -41,5 +41,9 @@ class Affinity(CMakePackage, CudaPackage, ROCmPackage):
         if '+rocm' in spec:
             args.append("-DROCM_PATH={0}".format(spec['hip'].prefix))
             args.append("-DAFFINITY_GPU_BACKEND=rocm")
+            rocm_archs = spec.variants["amdgpu_target"].value
+            if "none" not in rocm_archs:
+                args.append("-DHIP_HIPCC_FLAGS=--amdgpu-target={0}".format(",".join(rocm_archs)))
+                args.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(rocm_archs))
 
         return args


### PR DESCRIPTION
## Description

- [x] `DAFFINITY_GPU_BACKEND` is now required to build `affinity.rocm` or `affinity.cuda`

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Update `repo/affinity/package.py`
