### PR TITLE
Fix Metadata Variables in HPL

### DIFF
--- a/docs/add-an-experiment.rst
+++ b/docs/add-an-experiment.rst
@@ -252,8 +252,8 @@ by default.
 
        # Set the variables required by the experiment
        self.set_required_variables(
-         n_resources="{n_procs}",
-         process_problem_size="{Ns}/{n_procs}",
+         n_resources="{n_ranks}",
+         process_problem_size="{Ns}/{n_ranks}",
          total_problem_size="{Ns}",
        )
 

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -65,8 +65,8 @@ class Hpl(
 
         # Set the variables required by the experiment
         self.set_required_variables(
-            n_resources="{n_procs}",
-            process_problem_size="{Ns}/{n_procs}",
+            n_resources="{n_ranks}",
+            process_problem_size="{Ns}/{n_ranks}",
             total_problem_size="{Ns}",
         )
 


### PR DESCRIPTION
## Description

- [x] Fix variable name from `n_procs` -> `r_ranks`, so metadata for `benchpark analyze` will be correct.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `docs/add-an-experiment.rst`
- [x] Update `experiments/hpl/experiment.py`
