### PR TITLE
Change `job kill` to `cancel` in GitLab

### DIFF
--- a/.gitlab/utils/cancel-flux.sh
+++ b/.gitlab/utils/cancel-flux.sh
@@ -7,7 +7,7 @@ if [[ "$1" == "--no-clean" ]]; then
 fi
 
 export URI=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME}${GPUMODE} | awk '{print $1}')
-([[ -n "${URI}" ]] && flux job kill ${URI} || exit 0)
+([[ -n "${URI}" ]] && flux cancel ${URI} || exit 0)
 
 if ! $NO_CLEAN; then
     rm -rf $CUSTOM_CI_BUILDS_DIR


### PR DESCRIPTION
## Description

- [x] Change `flux job kill` to `flux cancel` so we can cancel jobs that have not started yet (i.e. if a job gets canceled/fails before it starts running the allocation isn't getting canceled correctly)

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.gitlab/utils/cancel-flux.sh`