### PR TITLE
Temporarily submit Tuolumne Jobs to pbatch Instead of pci Queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
   # Dane
   DANE_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive --reservation=ci
   # Tuolumne (max 4hr policy)
-  TUOLUMNE_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
+  TUOLUMNE_SHARED_ALLOC: -N 1 -t 2h --queue=pbatch --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive


### PR DESCRIPTION
## Description

- [x] Since a single benchpark pipeline submits 3 resource allocations that can take >1hr each, we end up dominating the pci queue on Tuolumne which is only 4 nodes. To be good citizens we should try using pbatch and see if the queue time is noticeable.
