### PR TITLE
llnl-elcapitan system: set default-compiler correctly

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -739,10 +739,16 @@ class LlnlElcapitan(System):
         will fail if these variables are not defined though, so for now
         they are still generated (but with more-generic values).
         """
+        default_compiler = "gcc"
+        if self.spec.satisfies("compiler=cce"):
+            default_compiler = "cce"
+        elif self.spec.satisfies("compiler=rocmcc"):
+            default_compiler = "llvm-amdgpu"
+
         return {
             "software": {
                 "packages": {
-                    "default-compiler": {"pkg_spec": "gcc"},
+                    "default-compiler": {"pkg_spec": default_compiler},
                     "default-mpi": {"pkg_spec": "cray-mpich"},
                     "compiler-rocm": {"pkg_spec": "cce"},
                     "compiler-amdclang": {"pkg_spec": "clang"},


### PR DESCRIPTION
Fixes https://github.com/LLNL/benchpark/issues/1052

I thought setting default compiler wouldn't matter given the preferences established in package config, but it seems to be added as a preference; therefore I match up the choice of default-compiler with compiler= from the system spec (rather than just setting it always to `gcc`).