### PR TITLE
Fix lammps/remhos nightly builds

### DIFF
--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -29,8 +29,8 @@ class Lammps(
 
     variant(
         "version",
-        default="20250204",
-        values=("develop", "latest", "20250204", "stable_29Aug2024_update3"),
+        default="20250722",
+        values=("develop", "latest", "20250722", "stable_29Aug2024_update3"),
         description="app version",
     )
 

--- a/repo/remhos/package.py
+++ b/repo/remhos/package.py
@@ -52,7 +52,7 @@ class Remhos(MakefilePackage, CudaPackage, ROCmPackage):
 
     depends_on("mpi")
     depends_on("hypre+mpi")
-    depends_on("hypre+cuda+cublas+mpi", when="+cuda")
+    depends_on("hypre+cuda+mpi", when="+cuda")
     depends_on("hypre+mixedint~fortran")
     depends_on("hypre+caliper", when="+caliper")
 
@@ -63,7 +63,7 @@ class Remhos(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("mfem +cuda+mpi", when="+cuda")
     depends_on("mfem +rocm+mpi", when="+rocm")
 
-    depends_on("hypre +rocm+rocblas +mpi", when="+rocm")
+    depends_on("hypre +rocm +mpi", when="+rocm")
     requires("+rocm", when="^hypre+rocm")
     for target in ("none", "gfx803", "gfx900", "gfx906", "gfx908", "gfx90a", "gfx942"):
         depends_on(f"hypre amdgpu_target={target}", when=f"amdgpu_target={target}")


### PR DESCRIPTION
#953 broke some nightly tests that were passing before. I think this will fix four of them (`lammps+rocm`, `remhos+rocm`, `remhos`, `lammps+openmp`).

- lammps older version was deprecated in newer spack
- remhos refers to hypre variants that dont exist in current spack