### PR TITLE
`benchpark analyze`: Add error check that provided argument is valid value

### DIFF
--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -421,6 +421,9 @@ def prepare_data(**kwargs):
 
     top_n = kwargs.get("top_n_regions", -1)
     if top_n != -1:
+        num_nodes = len(ctk.graph)
+        if num_nodes < kwargs.get("top_n_regions", -1):
+            raise ValueError(f"Value for '--top-n-regions' must be less than number of regions ({num_nodes})")
         temp_df_idx = ctk.dataframe.nlargest(
             top_n, [(list(grouped.keys())[0], metric)]
         ).index

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -423,7 +423,9 @@ def prepare_data(**kwargs):
     if top_n != -1:
         num_nodes = len(ctk.graph)
         if num_nodes < kwargs.get("top_n_regions", -1):
-            raise ValueError(f"Value for '--top-n-regions' must be less than number of regions ({num_nodes})")
+            raise ValueError(
+                f"Value for '--top-n-regions' must be less than number of regions ({num_nodes})"
+            )
         temp_df_idx = ctk.dataframe.nlargest(
             top_n, [(list(grouped.keys())[0], metric)]
         ).index


### PR DESCRIPTION
## Description

- [x] If the user provides a value for `--top-n-regions` that is less than the number of regions in the calltree, they may get a confusing error message. This provides a clear error message.