### PR TITLE
Locate spack stages/cache in benchpark workspace

### DIFF
--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -171,6 +171,7 @@ def command(args):
 
     pkg_str = ""
     if pkg_manager == "spack":
+        spack_build_stage = experiments_root / "builds"
         spack, first_time_spack = per_workspace_setup.spack_first_time_setup()
         if first_time_spack:
             site_repos = (
@@ -184,6 +185,7 @@ repos::
   builtin: {per_workspace_setup.pkgs_location}/repos/spack_repo/builtin/
 """
                 )
+            spack(f'config --scope=site add "config:build_stage:[\'{spack_build_stage}\']"')
 
         pkg_str = f"""\
 . {per_workspace_setup.spack_location}/share/spack/setup-env.sh

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -172,6 +172,7 @@ def command(args):
     pkg_str = ""
     if pkg_manager == "spack":
         spack_build_stage = experiments_root / "builds"
+        spack_user_cache_path = experiments_root / "spack-cache"
         spack, first_time_spack = per_workspace_setup.spack_first_time_setup()
         if first_time_spack:
             site_repos = (
@@ -188,9 +189,9 @@ repos::
             spack(f'config --scope=site add "config:build_stage:[\'{spack_build_stage}\']"')
 
         pkg_str = f"""\
-. {per_workspace_setup.spack_location}/share/spack/setup-env.sh
-
+export SPACK_USER_CACHE_PATH={spack_user_cache_path}
 export SPACK_DISABLE_LOCAL_CONFIG=1
+. {per_workspace_setup.spack_location}/share/spack/setup-env.sh
 """
 
     ramble, first_time_ramble = per_workspace_setup.ramble_first_time_setup()

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -186,7 +186,9 @@ repos::
   builtin: {per_workspace_setup.pkgs_location}/repos/spack_repo/builtin/
 """
                 )
-            spack(f'config --scope=site add "config:build_stage:[\'{spack_build_stage}\']"')
+            spack(
+                f"config --scope=site add \"config:build_stage:['{spack_build_stage}']\""
+            )
 
         pkg_str = f"""\
 export SPACK_USER_CACHE_PATH={spack_user_cache_path}


### PR DESCRIPTION
* Setting SPACK_USER_CACHE_PATH will ensure isolation between different benchpark instances and benchpark workspaces (I thought setting `config:misc_cache` would achieve this, but people have been reporting problems like https://github.com/LLNL/benchpark/issues/1068)
* Moving the stage into the benchpark workspace means that spack build stages are no longer stored in a temporary dir (so can be examined after an allocation ends)