### PR TITLE
Limit GitLab Pipelines Based on File Changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ workflow:
     # Run pipelines only when these files/dirs change
     - changes:
         - .gitlab/**
+        - .gitlab-ci.yml
         - 'bin/**'
         - 'configs/**'
         - 'checkout-versions.yaml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,18 +6,23 @@ workflow:
 
     # Run pipelines only when these files/dirs change
     - changes:
-        - .gitlab/**
-        - .gitlab-ci.yml
+        - '.gitlab/**'
         - 'bin/**'
         - 'configs/**'
-        - 'checkout-versions.yaml'
         - 'experiments/**'
         - 'lib/**'
+        - 'modifiers/**'
         - 'repo/**'
-        - 'requirements.txt'
         - 'var/**'
         - 'systems/llnl-elcapitan/system.py'
         - 'systems/llnl-cluster/system.py'
+        - '.gitlab-ci.yml'
+        - 'checkout-versions.yaml'
+        - 'CTestConfig.cmake'
+        - 'CTestGitlab.cmake'
+        - 'pyproject.toml'
+        - 'remote-urls.yaml'
+        - 'requirements.txt'
 
     # Otherwise, don't create a pipeline
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,6 @@ workflow:
     # Run pipelines only when these files/dirs change
     - changes:
         - .gitlab/**
-        - .gitlab-ci.yml
         - 'bin/**'
         - 'configs/**'
         - 'checkout-versions.yaml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,26 @@
+workflow:
+  rules:
+    # Always allow scheduled pipelines
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: always
+
+    # Run pipelines only when these files/dirs change
+    - changes:
+        - .gitlab/**
+        - .gitlab-ci.yml
+        - 'bin/**'
+        - 'configs/**'
+        - 'checkout-versions.yaml'
+        - 'experiments/**'
+        - 'lib/**'
+        - 'repo/**'
+        - 'requirements.txt'
+        - 'var/**'
+        - 'systems/llnl-elcapitan/system.py'
+        - 'systems/llnl-cluster/system.py'
+
+    # Otherwise, don't create a pipeline
+    - when: never
 variables:
   LLNL_SERVICE_USER: benchpark
   # Required information about GitHub repository


### PR DESCRIPTION
## Description

- [x] Add file restrictions to when gitlab jobs are triggered. e.g. changes to a `system.py` that is not a system that runs in gitlab should not trigger a gitlab pipeline. This avoids triggering pipelines for:
    - [x] docs changes
    - [x] systems other than llnl-elcapitan or llnl-cluster
    - [x] various files at top-level repo
    - [x] changes to `.github` files

Ideally, downstream rules could also be improved such that only tests for a certain experiment are triggered when that experiment is changed.