### PR TITLE
Add CI Check to Validate Docs Scripts Before Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
               - '.gitlab-ci.yml'
               - 'docs/**'
             run:
+              - '.github/**'
               - 'bin/**'
               - 'configs/**'
               - 'checkout-versions.yaml'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -184,3 +184,21 @@ jobs:
       - name: Run
         run: |-
           ./bin/benchpark unit-test
+  validate_docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: .github/workflows/requirements/docs.txt
+      - name: Install deps
+        run: |
+          pip install -r .github/workflows/requirements/docs.txt
+      - name: Test Docs Scripts
+        run: |-
+          python docs/generate-sys-defs-list.py
+          python docs/generate-benchmark-list.py

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -200,5 +200,6 @@ jobs:
           pip install -r .github/workflows/requirements/docs.txt
       - name: Test Docs Scripts
         run: |-
-          python docs/generate-sys-defs-list.py
-          python docs/generate-benchmark-list.py
+          cd docs/
+          python generate-sys-defs-list.py
+          python generate-benchmark-list.py

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -9,6 +9,7 @@ sys.path.append("../lib/")
 import benchpark.accounting  # noqa: E402
 import benchpark.paths  # noqa: E402
 
+raise ValueError("test")
 
 def construct_tag_groups(tag_groups, tag_dicts, dictionary):
     # everything is a dict

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -9,7 +9,6 @@ sys.path.append("../lib/")
 import benchpark.accounting  # noqa: E402
 import benchpark.paths  # noqa: E402
 
-raise ValueError("test")
 
 def construct_tag_groups(tag_groups, tag_dicts, dictionary):
     # everything is a dict


### PR DESCRIPTION
## Description

- [x] Resolves #999 
- [x] The tables at https://software.llnl.gov/benchpark/benchmark-list.html and https://software.llnl.gov/benchpark/system-list.html depend on python scripts, that sometimes fail when the underlying benchpark library changes. We do not catch this, because the CI that builds the docs only runs when merged into develop. So this is adding a CI check that the scripts are working, that will run on PRs.

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `.github/workflows`
