### PR TITLE
add local version of cray's libsci package

### DIFF
--- a/repo/cray_libsci/package.py
+++ b/repo/cray_libsci/package.py
@@ -1,0 +1,106 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+
+class CrayLibsci(Package):
+    """The Cray Scientific Libraries package, LibSci, is a collection of
+    numerical routines optimized for best performance on Cray systems."""
+
+    homepage = "https://docs.nersc.gov/development/libraries/libsci/"
+    has_code = False  # Skip attempts to fetch source that is not available
+
+    version("23.02.1.1")
+    version("22.11.1.2")
+    version("21.08.1.2")
+    version("20.06.1")
+    version("20.03.1")
+    version("19.06.1")
+    version("18.12.1")
+    version("18.11.1.2")
+    version("16.11.1")
+    version("16.09.1")
+    version("16.07.1")
+    version("16.06.1")
+    version("16.03.1")
+
+    conflicts("platform=windows")
+    conflicts("platform=darwin")
+
+    variant("shared", default=True, description="enable shared libs")
+    variant("openmp", default=False, description="link with openmp")
+    variant("mpi", default=False, description="link with mpi libs")
+
+    provides("blas")
+    provides("lapack")
+    provides("scalapack", when="+mpi")
+
+    canonical_names = {
+        "gcc": "GNU",
+        "cce": "CRAY",
+        "intel": "INTEL",
+        "clang": "ALLINEA",
+        "aocc": "AOCC",
+        "nvhpc": "NVIDIA",
+        "rocmcc": "AMD",
+    }
+
+    @property
+    def modname(self):
+        return "cray-libsci/{0}".format(self.version)
+
+    @property
+    def external_prefix(self):
+        libsci_module = module_command("show", self.modname).splitlines()
+
+        for line in libsci_module:
+            if "CRAY_LIBSCI_PREFIX_DIR" in line:
+                return get_path_args_from_module_line(line)[0]
+
+    @property
+    def blas_libs(self):
+        shared = True if "+shared" in self.spec else False
+
+        candidates = [name for name in self.canonical_names.values() if name.lower() in self.prefix.lower()]
+        candidates = [candidates[0]]
+        if len(candidates) != 1:
+            raise RuntimeError("cannot determine libsci libraries")
+
+        lib = []
+        if self.spec.satisfies("+openmp") and self.spec.satisfies("+mpi"):
+            lib = ["libsci_{0}_mpi_mp", "libsci_{0}_mp"]
+        elif self.spec.satisfies("+openmp"):
+            lib = ["libsci_{0}_mp"]
+        elif self.spec.satisfies("+mpi"):
+            lib = ["libsci_{0}_mpi", "libsci_{0}"]
+        else:
+            lib = ["libsci_{0}"]
+
+        libname = []
+        for lib_fmt in lib:
+            libname.append(lib_fmt.format(candidates[0].lower()))
+
+        return find_libraries(libname, root=self.prefix.lib, shared=shared, recursive=False)
+
+    @property
+    def lapack_libs(self):
+        return self.blas_libs
+
+    @property
+    def scalapack_libs(self):
+        return self.blas_libs
+
+    @property
+    def libs(self):
+        return self.blas_libs
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format(
+                "{name} is not installable, you need to specify "
+                "it as an external package in packages.yaml"
+            )
+        )

--- a/repo/cray_libsci/package.py
+++ b/repo/cray_libsci/package.py
@@ -64,9 +64,19 @@ class CrayLibsci(Package):
     def blas_libs(self):
         shared = True if "+shared" in self.spec else False
 
-        candidates = [name for name in self.canonical_names.values() if name.lower() in self.prefix.lower()]
-        candidates = [candidates[0]]
-        if len(candidates) != 1:
+        candidates = []
+        for entry in os.listdir(spack_prefix):
+            if entry.endswith(".so"):
+                candidates.append(entry)
+
+        lib_targets = []
+        for name in canonical_names.values():
+            if any(name.lower() in c for c in candidates):
+                lib_targets.append(name)
+            else:
+                pass
+
+        if len(lib_targets) != 1:
             raise RuntimeError("cannot determine libsci libraries")
 
         lib = []
@@ -81,7 +91,7 @@ class CrayLibsci(Package):
 
         libname = []
         for lib_fmt in lib:
-            libname.append(lib_fmt.format(candidates[0].lower()))
+            libname.append(lib_fmt.format(lib_targets[0].lower()))
 
         return find_libraries(libname, root=self.prefix.lib, shared=shared, recursive=False)
 


### PR DESCRIPTION
## Description

Local version of cray's libsci package

On perlmutter, we were hitting this error:
```
RuntimeError: cannot determine libsci libraries
```

In inspecting further, we see that `candidates = [name for name in self.canonical_names.values() if name.lower() in self.prefix.lower()]` resolves to `candidates = ["GNU", "CRAY"]`, but is looking for a list of length 1. So we take the first element (`GNU`) as it is the identifier to picking the right libsci library. 
