### PR TITLE
Add provider for blas and lapack on aws-tutorial

### DIFF
--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -237,7 +237,7 @@ this function, followed by our AWS example:
    ``compiler_section_for()``.
 3. Merge the compiler definitions with merge_dicts (this part is unnecessary if you have
    only one type of compiler).
-4. Generally, you will want to compose a minimal list of compilers: e.g. if you want to
+4. Generally, you will want to compose a minimal list of compilers: e.g., if you want to
    compile your benchmark with the oneAPI compiler, and have multiple versions to choose
    from, you would add a variant to the system, and the config would expose only one of
    them.
@@ -247,9 +247,9 @@ For our AWS system, the compiler we define is ``gcc@11.4.0``. For the
 
 1. ``spec`` - Similar to package specs, ``name@version``. GCC in particular also needs
    the ``languages`` variant, where the list of languages depends on the available
-   ``exes`` (e.g. do not include "fortran" if ``gfortran`` is not available). If you are
+   ``exes`` (e.g., do not include "fortran" if ``gfortran`` is not available). If you are
    **not** using GCC or Spack as your package manager, ``languages`` is unnecessary.
-2. ``prefix`` - Prefix to the compiler binary directory, e.g. ``/usr/`` for
+2. ``prefix`` - Prefix to the compiler binary directory, e.g., ``/usr/`` for
    ``/usr/bin/gcc``
 3. ``exes`` - Dictionary to map ``c``, ``cxx``, and ``fortran`` to the appropriate file
    found in the prefix.
@@ -320,24 +320,26 @@ instead. For each package that you include, you need to define its spec ``name@v
 and the system path ``prefix`` to the package. Additionally for Spack, you need to set
 ``buildable: False`` to tell Spack not to build that package.
 
-At minimum, we recommend you define externals for ``cmake`` and ``mpi`` (users also
-typically define externals for other libraries, e.g. math libraries like ``blas`` and
-``lapack``). This is because certain packages (e.g. ``cmake``) can take a long time to
+At minimum, we recommend to define externals for ``cmake`` and ``mpi`` (users also
+typically define externals for other libraries, e.g., math libraries like ``blas`` and
+``lapack``). This is because certain packages (e.g., ``cmake``) can take a long time to
 build, and packages such as ``mpi``, ``blas``, and ``lapack`` can influence runtime
-performance significantly. Additionally, for systems with accelerators, define externals
+performance significantly so it is prudent to use the versions optimized for our system.
+Additionally, for systems with accelerators, define externals
 for CUDA and ROCm runtime libraries (see externals examples for a `CUDA system
 <https://github.com/LLNL/benchpark/blob/e82e3a26aef54855cf281c088b8f149ab7d87d9d/systems/llnl-matrix/system.py#L274>`_,
 or a `ROCm system
 <https://github.com/LLNL/benchpark/blob/e82e3a26aef54855cf281c088b8f149ab7d87d9d/systems/llnl-elcapitan/system.py#L483>`_).
-Also, see :ref:`adding-sys-packages`, for help on how to search for the packages
+See :ref:`adding-sys-packages`, for help on how to search for the packages
 available on your system.
 
 .. note::
 
-    For packages that declare virtual dependencies, e.g. ``depends_on("mpi")``, you need
-    to define ``"mpi": {"buildable": False},`` as a virtual package, and then define
-    your MPI package as we have for the ``openmpi`` package. This is to ensure Spack
-    uses our MPI, and does not try to build another MPI package. See a similar example
+    For packages that declare virtual dependencies, e.g., ``depends_on("mpi")``, you need
+    to define a virtual package ``"mpi": {"buildable": False},``, followed by a definition
+    of at least one provider of this package (see the provider definition for ``openmpi``
+    in our example). This is to ensure Spack uses the provider we specified,
+    and does not try to build another MPI package. See a similar example
     for ``blas``, ``lapack``, and their provider ``atlas``.
 
 ::
@@ -469,7 +471,7 @@ cluster=<cluster>``:
     'tar': {'buildable': False,
             'externals': [{'prefix': '/usr', 'spec': 'tar@1.30'}]}}
 
-where the command should be ran on a cluster that is defined for the given system, e.g.
+where the command should be ran on a cluster that is defined for the given system, e.g.,
 ruby for llnl-cluster. Use this output to update your package definitions in your
 ``system.py``'s ``compute_package_section()``.
 

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -334,9 +334,11 @@ available on your system.
 
 .. note::
 
-    For ``mpi``, you need to define ``"mpi": {"buildable": False},`` as a virtual
-    package, and then define your MPI package as we have for the ``openmpi`` package.
-    This is to ensure Spack uses our MPI, and does not try to build another MPI package.
+    For packages that declare virtual dependencies, e.g. ``depends_on("mpi")``, you need
+    to define ``"mpi": {"buildable": False},`` as a virtual package, and then define
+    your MPI package as we have for the ``openmpi`` package. This is to ensure Spack
+    uses our MPI, and does not try to build another MPI package. See a similar example
+    for ``blas``, ``lapack``, and their provider ``atlas``.
 
 ::
 
@@ -354,6 +356,11 @@ available on your system.
         def compute_packages_section(self):
             return {
                 "packages": {
+                    "blas": {"buildable": False},
+                    "lapack": {"buildable": False},
+                    "atlas": {
+                        "externals": [{"spec": "atlas@3.10.3", "prefix": "/usr"}],
+                    },
                     "mpi": {"buildable": False},
                     "openmpi": {
                         "externals": [
@@ -364,7 +371,7 @@ available on your system.
                         ]
                     },
                     "cmake": {
-                        "externals": [{"spec": "cmake@4.0.2", "prefix": "/usr"}],
+                        "externals": [{"spec": "cmake@4.1.1", "prefix": "/usr"}],
                         "buildable": False,
                     },
                     ...

--- a/systems/aws-tutorial/system.py
+++ b/systems/aws-tutorial/system.py
@@ -75,9 +75,10 @@ class AwsTutorial(System):
                     "buildable": False,
                 },
                 "gmake": {"externals": [{"spec": "gmake@4.3", "prefix": "/usr"}]},
-                "lapack": {
-                    "externals": [{"spec": "lapack@0.29.2", "prefix": "/usr"}],
-                    "buildable": False,
+                "blas": {"buildable": False},
+                "lapack": {"buildable": False},
+                "atlas": {
+                    "externals": [{"spec": "atlas@3.10.3", "prefix": "/usr"}],
                 },
                 "mpi": {"buildable": False},
                 "openmpi": {
@@ -89,7 +90,7 @@ class AwsTutorial(System):
                     ]
                 },
                 "cmake": {
-                    "externals": [{"spec": "cmake@4.0.2", "prefix": "/usr"}],
+                    "externals": [{"spec": "cmake@4.1.1", "prefix": "/usr"}],
                     "buildable": False,
                 },
                 "git": {


### PR DESCRIPTION
## Description

- [x] Add `atlas` as blas/lapack provider and update docs
- [x] Bump cmake version

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `aws-tutorial

## Adding/modifying core functionality, CI, or documentation:

- [x] Update docs