### PR TITLE
llnl-elcapitan gcc missing +gtl

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -467,7 +467,7 @@ class LlnlElcapitan(System):
                 gtl_spec = "+gtl"
             else:
                 gtl_spec = "~gtl"
-    
+
             return {
                 "packages": {
                     "cray-mpich": {

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -188,14 +188,14 @@ class LlnlElcapitan(System):
                 self.short_cce_version = (
                     f"{self.cce_version.major}.{self.cce_version.minor}"
                 )
-            if self.rocm_version >= Version("6.0.0"):
-                self.pmi_version = Version("6.1.15.6")
-                self.pals_version = Version("1.2.12")
-                self.llvm_version = Version("18.0.1")
-            else:
-                self.pmi_version = Version("6.1.12")
-                self.pals_version = Version("1.2.9")
-                self.llvm_version = Version("16.0.0")
+        if self.rocm_version >= Version("6.0.0"):
+            self.pmi_version = Version("6.1.15.6")
+            self.pals_version = Version("1.2.12")
+            self.llvm_version = Version("18.0.1")
+        else:
+            self.pmi_version = Version("6.1.12")
+            self.pals_version = Version("1.2.9")
+            self.llvm_version = Version("16.0.0")
         # TODO: Replace this with lookups into the working set
 
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -468,7 +468,7 @@ class LlnlElcapitan(System):
                     "cray-mpich": {
                         "externals": [
                             {
-                                "spec": f"cray-mpich@{self.mpi_version}~gtl+wrappers %gcc@{self.gcc_version}",
+                                "spec": f"cray-mpich@{self.mpi_version}+gtl+wrappers %gcc@{self.gcc_version}",
                                 "prefix": f"/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/10.3",
                                 "extra_attributes": {
                                     "gtl_lib_path": f"/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib",
@@ -755,7 +755,7 @@ class LlnlElcapitan(System):
                     "compiler-gcc": {"pkg_spec": "gcc"},
                     "mpi-rocm-gtl": {"pkg_spec": "cray-mpich+gtl"},
                     "mpi-rocm-no-gtl": {"pkg_spec": "cray-mpich~gtl"},
-                    "mpi-gcc": {"pkg_spec": "cray-mpich~gtl"},
+                    "mpi-gcc": {"pkg_spec": "cray-mpich+gtl"},
                     "blas": {"pkg_spec": f"{self.spec.variants['blas'][0]}"},
                     "blas-rocm": {"pkg_spec": "rocblas"},
                     "lapack": {"pkg_spec": f"{self.spec.variants['lapack'][0]}"},

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -166,8 +166,9 @@ class LlnlElcapitan(System):
 
         # TODO: Replace this with lookups into the working set
         if self.spec.satisfies("compiler=gcc"):
-            self.gcc_version = Version("12.2.0")
-            self.mpi_version = Version("8.1.26")
+            self.gcc_version = Version("11.2.0")
+            self.mpi_version = Version("9.0.1")
+            self.short_gcc_version = f"{self.gcc_version.major}.{self.gcc_version.minor}"
         if self.rocm_version >= Version("6.4.0"):
             self.cce_version = Version("20.0.0")
             self.mpi_version = Version("9.0.1")
@@ -339,8 +340,8 @@ class LlnlElcapitan(System):
                 "cray-libsci": {
                     "externals": [
                         {
-                            "spec": "cray-libsci@23.05.1.4%cce",
-                            "prefix": "/opt/cray/pe/libsci/23.05.1.4/cray/12.0/x86_64/",
+                            "spec": "cray-libsci@25.09.0%cce",
+                            "prefix": f"/opt/cray/pe/libsci/25.09.0/cray/{self.short_cce_version}/x86_64/",
                         }
                     ]
                 }
@@ -350,8 +351,8 @@ class LlnlElcapitan(System):
                 "cray-libsci": {
                     "externals": [
                         {
-                            "spec": "cray-libsci@23.05.1.4%gcc",
-                            "prefix": "/opt/cray/pe/libsci/23.05.1.4/gnu/10.3/x86_64/",
+                            "spec": "cray-libsci@25.09.0%gcc",
+                            "prefix": f"/opt/cray/pe/libsci/25.09.0/gnu/{self.short_gcc_version}/x86_64/",
                         }
                     ]
                 }
@@ -379,8 +380,8 @@ class LlnlElcapitan(System):
             "gcc",
             [
                 compiler_def(
-                    "gcc@12.2.0 languages=c,c++,fortran",
-                    "/opt/cray/pe/gcc/12.2.0/",
+                    f"gcc@{self.gcc_version} languages=c,c++,fortran",
+                    f"/opt/cray/pe/gcc/{self.gcc_version}/",
                     {"c": "gcc", "cxx": "g++", "fortran": "gfortran"},
                 )
             ],
@@ -485,10 +486,11 @@ class LlnlElcapitan(System):
                         "externals": [
                             {
                                 "spec": f"cray-mpich@{self.mpi_version}{gtl_spec}+wrappers %gcc@{self.gcc_version}",
-                                "prefix": f"/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/10.3",
+                                "prefix": f"/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/{self.short_gcc_version}",
                                 "extra_attributes": {
                                     "gtl_lib_path": f"/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib",
-                                    "ldflags": f"-L/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/10.3/lib -lmpi -L/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib -Wl,-rpath=/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib",
+                                    "ldflags": f"-L/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/{self.short_gcc_version}/lib -lmpi -L/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib -Wl,-rpath=/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib",
+                                    "gtl_libs": "libmpi_gtl_hsa",
                                 },
                             }
                         ]

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -383,8 +383,8 @@ class LlnlElcapitan(System):
             "gcc",
             [
                 compiler_def(
-                    f"gcc@12.2.0 languages=c,c++,fortran",
-                    f"/opt/cray/pe/gcc/12.2.0/",
+                    "gcc@12.2.0 languages=c,c++,fortran",
+                    "/opt/cray/pe/gcc/12.2.0/",
                     {"c": "gcc", "cxx": "g++", "fortran": "gfortran"},
                 )
             ],

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -168,7 +168,9 @@ class LlnlElcapitan(System):
         if self.spec.satisfies("compiler=gcc"):
             self.gcc_version = Version("12.2.0")
             self.mpi_version = Version("9.0.1")
-            self.short_gcc_version = f"{self.gcc_version.major}.{self.gcc_version.minor}"
+            self.short_gcc_version = (
+                f"{self.gcc_version.major}.{self.gcc_version.minor}"
+            )
         else:
             if self.rocm_version >= Version("6.4.0"):
                 self.cce_version = Version("20.0.0")
@@ -342,7 +344,7 @@ class LlnlElcapitan(System):
                     "externals": [
                         {
                             "spec": "cray-libsci@25.09.0%cce",
-                            "prefix": f"/opt/cray/pe/libsci/25.09.0/cray/{self.short_cce_version}/x86_64/",
+                            "prefix": "/opt/cray/pe/libsci/25.09.0/cray/20.0/x86_64/",
                         }
                     ]
                 }
@@ -353,7 +355,7 @@ class LlnlElcapitan(System):
                     "externals": [
                         {
                             "spec": "cray-libsci@25.09.0%gcc",
-                            "prefix": f"/opt/cray/pe/libsci/25.09.0/gnu/{self.short_gcc_version}/x86_64/",
+                            "prefix": "/opt/cray/pe/libsci/25.09.0/gnu/12.2/x86_64/",
                         }
                     ]
                 }
@@ -381,8 +383,8 @@ class LlnlElcapitan(System):
             "gcc",
             [
                 compiler_def(
-                    f"gcc@{self.gcc_version} languages=c,c++,fortran",
-                    f"/opt/cray/pe/gcc/{self.gcc_version}/",
+                    f"gcc@12.2.0 languages=c,c++,fortran",
+                    f"/opt/cray/pe/gcc/12.2.0/",
                     {"c": "gcc", "cxx": "g++", "fortran": "gfortran"},
                 )
             ],

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -169,32 +169,33 @@ class LlnlElcapitan(System):
             self.gcc_version = Version("12.2.0")
             self.mpi_version = Version("9.0.1")
             self.short_gcc_version = f"{self.gcc_version.major}.{self.gcc_version.minor}"
-        if self.rocm_version >= Version("6.4.0"):
-            self.cce_version = Version("20.0.0")
-            self.mpi_version = Version("9.0.1")
-            self.short_cce_version = (
-                f"{self.cce_version.major}.{self.cce_version.minor}"
-            )
-        elif self.rocm_version >= Version("6.0.0"):
-            self.cce_version = Version("18.0.1")
-            self.mpi_version = Version("8.1.31")
-            self.short_cce_version = (
-                f"{self.cce_version.major}.{self.cce_version.minor}"
-            )
         else:
-            self.cce_version = Version("16.0.0")
-            self.mpi_version = Version("8.1.26")
-            self.short_cce_version = (
-                f"{self.cce_version.major}.{self.cce_version.minor}"
-            )
-        if self.rocm_version >= Version("6.0.0"):
-            self.pmi_version = Version("6.1.15.6")
-            self.pals_version = Version("1.2.12")
-            self.llvm_version = Version("18.0.1")
-        else:
-            self.pmi_version = Version("6.1.12")
-            self.pals_version = Version("1.2.9")
-            self.llvm_version = Version("16.0.0")
+            if self.rocm_version >= Version("6.4.0"):
+                self.cce_version = Version("20.0.0")
+                self.mpi_version = Version("9.0.1")
+                self.short_cce_version = (
+                    f"{self.cce_version.major}.{self.cce_version.minor}"
+                )
+            elif self.rocm_version >= Version("6.0.0"):
+                self.cce_version = Version("18.0.1")
+                self.mpi_version = Version("8.1.31")
+                self.short_cce_version = (
+                    f"{self.cce_version.major}.{self.cce_version.minor}"
+                )
+            else:
+                self.cce_version = Version("16.0.0")
+                self.mpi_version = Version("8.1.26")
+                self.short_cce_version = (
+                    f"{self.cce_version.major}.{self.cce_version.minor}"
+                )
+            if self.rocm_version >= Version("6.0.0"):
+                self.pmi_version = Version("6.1.15.6")
+                self.pals_version = Version("1.2.12")
+                self.llvm_version = Version("18.0.1")
+            else:
+                self.pmi_version = Version("6.1.12")
+                self.pals_version = Version("1.2.9")
+                self.llvm_version = Version("16.0.0")
         # TODO: Replace this with lookups into the working set
 
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -463,12 +463,17 @@ class LlnlElcapitan(System):
             }
 
         elif self.spec.satisfies("compiler=gcc"):
+            if gtl:
+                gtl_spec = "+gtl"
+            else:
+                gtl_spec = "~gtl"
+    
             return {
                 "packages": {
                     "cray-mpich": {
                         "externals": [
                             {
-                                "spec": f"cray-mpich@{self.mpi_version}+gtl+wrappers %gcc@{self.gcc_version}",
+                                "spec": f"cray-mpich@{self.mpi_version}{gtl_spec}+wrappers %gcc@{self.gcc_version}",
                                 "prefix": f"/opt/cray/pe/mpich/{self.mpi_version}/ofi/gnu/10.3",
                                 "extra_attributes": {
                                     "gtl_lib_path": f"/opt/cray/pe/mpich/{self.mpi_version}/gtl/lib",

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -160,25 +160,24 @@ class LlnlElcapitan(System):
         if self.spec.satisfies("compiler=gcc"):
             self.gcc_version = Version("12.2.0")
             self.mpi_version = Version("8.1.26")
+        if self.rocm_version >= Version("6.4.0"):
+            self.cce_version = Version("20.0.0")
+            self.mpi_version = Version("9.0.1")
+            self.short_cce_version = (
+                f"{self.cce_version.major}.{self.cce_version.minor}"
+            )
+        elif self.rocm_version >= Version("6.0.0"):
+            self.cce_version = Version("18.0.1")
+            self.mpi_version = Version("8.1.31")
+            self.short_cce_version = (
+                f"{self.cce_version.major}.{self.cce_version.minor}"
+            )
         else:
-            if self.rocm_version >= Version("6.4.0"):
-                self.cce_version = Version("20.0.0")
-                self.mpi_version = Version("9.0.1")
-                self.short_cce_version = (
-                    f"{self.cce_version.major}.{self.cce_version.minor}"
-                )
-            elif self.rocm_version >= Version("6.0.0"):
-                self.cce_version = Version("18.0.1")
-                self.mpi_version = Version("8.1.31")
-                self.short_cce_version = (
-                    f"{self.cce_version.major}.{self.cce_version.minor}"
-                )
-            else:
-                self.cce_version = Version("16.0.0")
-                self.mpi_version = Version("8.1.26")
-                self.short_cce_version = (
-                    f"{self.cce_version.major}.{self.cce_version.minor}"
-                )
+            self.cce_version = Version("16.0.0")
+            self.mpi_version = Version("8.1.26")
+            self.short_cce_version = (
+                f"{self.cce_version.major}.{self.cce_version.minor}"
+            )
         if self.rocm_version >= Version("6.0.0"):
             self.pmi_version = Version("6.1.15.6")
             self.pals_version = Version("1.2.12")
@@ -359,7 +358,8 @@ class LlnlElcapitan(System):
             prefs = {"one_of": ["%cce", "%gcc"], "when": "%c"}
             return {"packages": {"all": {"require": [prefs]}}}
         elif compiler == "gcc":
-            return {"packages": {}}
+            prefs = {"one_of": ["%gcc"], "when": "%c"}
+            return {"packages": {"all": {"require": [prefs]}}}
         elif compiler == "rocmcc":
             prefs = {"one_of": ["%rocmcc", "%gcc"], "when": "%c"}
             return {"packages": {"all": {"require": [prefs]}}}
@@ -378,8 +378,11 @@ class LlnlElcapitan(System):
             ],
         )
 
-        if self.spec.satisfies("compiler=cce") or self.spec.satisfies(
-            "compiler=rocmcc"
+        # gcc because we want llvm-amdgpu for hip, even if using gcc for c
+        if (
+            self.spec.satisfies("compiler=gcc")
+            or self.spec.satisfies("compiler=cce")
+            or self.spec.satisfies("compiler=rocmcc")
         ):
             cfg = merge_dicts(cfg, self.rocm_cce_compiler_cfg())
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -166,7 +166,7 @@ class LlnlElcapitan(System):
 
         # TODO: Replace this with lookups into the working set
         if self.spec.satisfies("compiler=gcc"):
-            self.gcc_version = Version("11.2.0")
+            self.gcc_version = Version("12.2.0")
             self.mpi_version = Version("9.0.1")
             self.short_gcc_version = f"{self.gcc_version.major}.{self.gcc_version.minor}"
         if self.rocm_version >= Version("6.4.0"):


### PR DESCRIPTION
## Description

We don't have any cases at the moment using gcc and GTL, but these changes enable it. The package would need to specify the compilers for gcc vs llvm-amdgpu, otherwise gcc will be used and you will get a HIP error.
- [x] Spec `llnl-elcapitan` gcc compiler so it can be `+gtl`
- [x] Add `llvm-amdgpu` to gcc config, such that `gcc+rocm` does not build `llvm-amdgpu`
   - [x] Specify `gcc` preference so `amdclang` is not used in this case 

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Update `llnl-elcapitan/system.py`
