### PR TITLE
Add Matrix GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,8 @@ variables:
   FLUX_ARGS: -N 1 --exclusive
   # Dane
   DANE_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive --reservation=ci
+  # Matrix (NODES ARE SHARED WITHOUT --exclusive)
+  MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive
   # Tuolumne (max 4hr policy)
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 2h --queue=pbatch --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -5,6 +5,7 @@ include:
   variables:
     DASHBOARD_NAME: Nightly [benchpark-develop]
     DANE_PARAMS: -N 1 -t 01:00:00 --exclusive --reservation=ci
+    MATRIX_PARAMS: -N 1 -t 01:00:00 --exclusive
     ELCAP_PARAMS: -N 1 -t 60m --queue=pci --exclusive
   parallel:
     matrix:
@@ -60,6 +61,22 @@ include:
           - raja-perf
           - salmon-tddft
         VARIANT: [+openmp]
+      # +cuda tests
+      - HOST: matrix
+        ARCHCONFIG: llnl-matrix
+        SCHEDULER_PARAMETERS: $MATRIX_PARAMS
+        BENCHMARK:
+          - amg2023
+          - babelstream
+          - gromacs
+          - kripke
+          - laghos
+          - lammps
+          - osu-micro-benchmarks
+          - raja-perf
+          - remhos
+          - saxpy
+        VARIANT: [+cuda]
       #############
       # Other tests
       #############

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -9,35 +9,75 @@ workflow:
 #############################
 # Resource Allocation Section
 #############################
-allocate_resources_dane:
-  tags: [shell, dane]
-  needs: [dane-up-check]
+.allocate_resources_slurm:
   extends: .on_host_template
   stage: allocate-resources
   script:
-    - sbatch ${DANE_SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME} --wrap="srun
-      -N 1 -n 1 flux start sleep inf"
+    - set -x
+    # Allow optional GPUMODE suffix (defaults to empty so existing names still work)
+    - sbatch ${SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME}${GPUMODE:-}
+      \ --wrap="srun -N 1 -n 1 flux start sleep inf"
   after_script:
-    - |-
+    - |
       if [[ "$CI_JOB_STATUS" == "canceled" ]]; then
         . .gitlab/utils/cancel-slurm.sh
       fi
+allocate_resources_dane:
+  extends: .allocate_resources_slurm
+  variables:
+    HOST: dane
+    SHARED_ALLOC: $DANE_SHARED_ALLOC
+  tags: [shell, dane]
+  needs: [dane-up-check]
+allocate_resources_matrix:
+  extends: .allocate_resources_slurm
+  variables:
+    HOST: matrix
+    SHARED_ALLOC: $MATRIX_SHARED_ALLOC
+  tags: [shell, matrix]
+  needs: [matrix-up-check]
 ##########################
 # Resource Release Section
 ##########################
-release_resources_dane:
-  tags: [shell, dane]
-  needs: [allocate_resources_dane, run_tests_slurm_dane]
+.release_resources_slurm:
   extends: .on_host_template
   stage: release-resources
   # Do not cleanup dir yet
-  script:
-    - . .gitlab/utils/cancel-slurm.sh --no-clean
+  script: [. .gitlab/utils/cancel-slurm.sh --no-clean]
+release_resources_dane:
+  extends: .release_resources_slurm
+  tags: [shell, dane]
+  needs: [allocate_resources_dane, run_tests_slurm_dane]
+release_resources_matrix:
+  extends: .release_resources_slurm
+  tags: [shell, matrix]
+  needs: [allocate_resources_matrix, run_tests_slurm_matrix]
 ##################
 # Test Run Section
 ##################
-.run_tests_slurm: &run_tests_slurm
+.run_tests_slurm:
   extends: .on_host_template
+  stage: test
+  before_script:
+    - !reference [.report_status, before_script]
+  script:
+    - |
+      echo -e "### Allocation name is ${ALLOC_NAME}"
+      export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+      echo -e "### Job ID is ${JOBID}"
+    - |
+      PROXY="$( [[ -n "${JOBID}" ]] && echo "flux proxy slurm:${JOBID}" || echo "" )"
+      ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS} .gitlab/utils/run-experiment.sh )
+  after_script:
+    - !reference [.report_status, after_script]
+    - |
+      if [[ "$CI_JOB_STATUS" == "canceled" ]]; then
+        . .gitlab/utils/cancel-slurm.sh
+      fi
+run_tests_slurm_dane:
+  extends: .run_tests_slurm
+  tags: [shell, dane]
+  needs: [allocate_resources_dane]
   parallel:
     matrix:
       - HOST: dane
@@ -58,24 +98,19 @@ release_resources_dane:
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke]
         VARIANT: ['caliper=mpi,time hwloc=on affinity=on']
-run_tests_slurm_dane:
-  tags: [shell, dane]
-  needs: [allocate_resources_dane]
-  stage: test
-  <<: *run_tests_slurm
-  before_script:
-    - !reference [.report_status, before_script]
-  script:
-    - |
-      echo -e "### Allocation name is ${ALLOC_NAME}"
-      export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
-      echo -e "### Job ID is ${JOBID}"
-    - |
-      PROXY="$( [[ -n "${JOBID}" ]] && echo "flux proxy slurm:${JOBID}" || echo "" )"
-      ${PROXY} flux watch $( ${PROXY} flux batch -o output.stdout.type=kvs ${FLUX_ARGS} .gitlab/utils/run-experiment.sh )
-  after_script:
-    - !reference [.report_status, after_script]
-    - |-
-      if [[ "$CI_JOB_STATUS" == "canceled" ]]; then
-        . .gitlab/utils/cancel-slurm.sh
-      fi
+run_tests_slurm_matrix:
+  extends: .run_tests_slurm
+  tags: [shell, matrix]
+  needs: [allocate_resources_matrix]
+  parallel:
+    matrix:
+      - HOST: matrix
+        ARCHCONFIG: llnl-matrix
+        BENCHMARK:
+          - amg2023
+          - babelstream
+          - kripke
+          - laghos
+          - raja-perf
+          - saxpy
+        VARIANT: [+cuda]

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -14,9 +14,8 @@ workflow:
   stage: allocate-resources
   script:
     - set -x
-    # Allow optional GPUMODE suffix (defaults to empty so existing names still work)
-    - sbatch ${SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME}${GPUMODE:-}
-      \ --wrap="srun -N 1 -n 1 flux start sleep inf"
+    - sbatch ${SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME} --wrap="srun
+      -N 1 -n 1 flux start sleep inf"
   after_script:
     - |
       if [[ "$CI_JOB_STATUS" == "canceled" ]]; then

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -20,7 +20,9 @@ workflow:
     - echo "Slurm job = ${JOBID}"
     # wait until SLURM job running
     # 1..2160 is up to 6 hours
-    - for i in {1..2160}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting... total duration has been $(( (i-1)*10 ))s" && sleep 10; done
+    - for i in {1..2160}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head
+      -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting...
+      total duration has been $(( (i-1)*10 ))s" && sleep 10; done
     #- for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1 && break; echo "waiting..." sleep 10; done
     #- flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -20,8 +20,8 @@ workflow:
     - echo "Slurm job = ${JOBID}"
     # wait until Flux is actually reachable (not just the Slurm job RUNNING)
     # 1..1080 is up to 3 hours
-    - for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1
-      && break; sleep 10; done
+    - for i in {1..1080}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting..." && sleep 10; done
+    #- for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1 && break; echo "waiting..." sleep 10; done
     - flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:
     - |

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -13,9 +13,16 @@ workflow:
   extends: .on_host_template
   stage: allocate-resources
   script:
-    - set -x
-    - sbatch ${SHARED_ALLOC} --wait-all-nodes=1 --job-name=${ALLOC_NAME} --wrap="srun
-      -N 1 -n 1 flux start sleep inf"
+    - set -e
+    # submit and grab JobID
+    - JOBID=$(sbatch --parsable ${SHARED_ALLOC} --wait-all-nodes=1 --job-name="${ALLOC_NAME}"
+      --wrap='srun -N 1 -n 1 flux start sleep inf')
+    - echo "Slurm job = ${JOBID}"
+    # wait until Flux is actually reachable (not just the Slurm job RUNNING)
+    # 1..1080 is up to 3 hours
+    - for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1
+      && break; sleep 10; done
+    - flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:
     - |
       if [[ "$CI_JOB_STATUS" == "canceled" ]]; then

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -18,11 +18,11 @@ workflow:
     - JOBID=$(sbatch --parsable ${SHARED_ALLOC} --wait-all-nodes=1 --job-name="${ALLOC_NAME}"
       --wrap='srun -N 1 -n 1 flux start sleep inf')
     - echo "Slurm job = ${JOBID}"
-    # wait until Flux is actually reachable (not just the Slurm job RUNNING)
+    # wait until SLURM job running
     # 1..1080 is up to 3 hours
     - for i in {1..1080}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting..." && sleep 10; done
     #- for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1 && break; echo "waiting..." sleep 10; done
-    - flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
+    #- flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:
     - |
       if [[ "$CI_JOB_STATUS" == "canceled" ]]; then

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -19,8 +19,8 @@ workflow:
       --wrap='srun -N 1 -n 1 flux start sleep inf')
     - echo "Slurm job = ${JOBID}"
     # wait until SLURM job running
-    # 1..1080 is up to 3 hours
-    - for i in {1..1080}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting..." && sleep 10; done
+    # 1..2160 is up to 6 hours
+    - for i in {1..2160}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting... $(( (i-1)*10 ))s" && sleep 10; done
     #- for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1 && break; echo "waiting..." sleep 10; done
     #- flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -20,7 +20,7 @@ workflow:
     - echo "Slurm job = ${JOBID}"
     # wait until SLURM job running
     # 1..2160 is up to 6 hours
-    - for i in {1..2160}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting... $(( (i-1)*10 ))s" && sleep 10; done
+    - for i in {1..2160}; do state=$(sacct -j ${JOBID} -n -o State 2>/dev/null | head -1 | awk '{print $1}'); [[ "$state" == "RUNNING" ]] && break; echo "waiting... total duration has been $(( (i-1)*10 ))s" && sleep 10; done
     #- for i in {1..1080}; do flux proxy slurm:${JOBID} flux ping -c1 >/dev/null 2>&1 && break; echo "waiting..." sleep 10; done
     #- flux proxy slurm:${JOBID} flux ping -c1  # final check (fails the job if still not ready)
   after_script:

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -28,3 +28,8 @@ dane-up-check:
   variables:
     CI_MACHINE: dane
   extends: [.machine-check]
+matrix-up-check:
+  stage: machine-checks
+  variables:
+    CI_MACHINE: matrix
+  extends: [.machine-check]

--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -4,7 +4,7 @@ set -e
 # Activate Virtual Environment
 . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
 
-echo "./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} cluster=$HOST $SYSTEM_ARGS"
+echo "./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} $([ "$HOST" != "matrix" ] && echo "cluster=$HOST") $SYSTEM_ARGS"
 echo "./bin/benchpark experiment init --dest=${BENCHMARK} --system=${HOST} ${BENCHMARK} ${VARIANT}"
 echo "./bin/benchpark setup ${BENCHMARK} wkp/"
 echo ". wkp/setup.sh"
@@ -14,7 +14,7 @@ echo "ramble --disable-logger --workspace-dir . on --executor '{execute_experime
 echo "ramble --disable-logger --workspace-dir . workspace analyze --format json yaml text"
 
 # Initialize System
-./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} cluster=$HOST $SYSTEM_ARGS
+./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} $([ "$HOST" != "matrix" ] && echo "cluster=$HOST") $SYSTEM_ARGS
 
 # Initialize Experiment
 BV=""


### PR DESCRIPTION
## Description

- [x] Add GitLab CUDA tests for matrix.
- [x] I noticed some CI looking jobs running in the matrix queue, and after some investigation found that LC added matrix GitLab CI runners. Unfortunately, these may only end up holding up our pipelines, as the node contention on Matrix is very high at the moment.
- [x] try testing nightlies through manual trigger

## Adding/modifying core functionality, CI, or documentation:

- [x] Add tests in `.gitlab` for matrix and extra infastructure