### PR TITLE
Add lammps pace workload

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -31,12 +31,6 @@ include:
           - salmon-tddft
           - smb
           - stream
-      # LAMMPS ACE test
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: $DANE_PARAMS
-        BENCHMARK: [lammps]
-        VARIANT: [workload=pace]
       # +rocm tests
       - HOST: [tuolumne]
         ARCHCONFIG: llnl-elcapitan
@@ -100,11 +94,6 @@ include:
         SCHEDULER_PARAMETERS: $DANE_PARAMS
         BENCHMARK: [amg2023, kripke, lammps, raja-perf, remhos, stream]
         BENCHMARK_VERSION: develop
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        SCHEDULER_PARAMETERS: $DANE_PARAMS
-        BENCHMARK: [lammps]
-        VARIANT: [+rocm]
 nightly_test_run:
   extends: .nightly_rules
   resource_group: $HOST

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -31,6 +31,12 @@ include:
           - salmon-tddft
           - smb
           - stream
+      # LAMMPS ACE test
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        SCHEDULER_PARAMETERS: $DANE_PARAMS
+        BENCHMARK: [lammps]
+        VARIANT: [workload=pace]
       # +rocm tests
       - HOST: [tuolumne]
         ARCHCONFIG: llnl-elcapitan
@@ -94,6 +100,11 @@ include:
         SCHEDULER_PARAMETERS: $DANE_PARAMS
         BENCHMARK: [amg2023, kripke, lammps, raja-perf, remhos, stream]
         BENCHMARK_VERSION: develop
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        SCHEDULER_PARAMETERS: $DANE_PARAMS
+        BENCHMARK: [lammps]
+        VARIANT: [+rocm]
 nightly_test_run:
   extends: .nightly_rules
   resource_group: $HOST

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -86,7 +86,7 @@ run_tests_flux_tuolumne:
     matrix:
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke, laghos, raja-perf]
+        BENCHMARK: [amg2023, kripke, laghos, lammps, raja-perf]
         VARIANT: [+rocm]
         GPUMODE: SPX
       # Test TPX, CPX
@@ -119,6 +119,12 @@ run_tests_flux_tuolumne:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [kripke]
         VARIANT: ['+rocm caliper=mpi,time,rocm']
+        GPUMODE: SPX
+      # lammps workload=pace
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [lammps]
+        VARIANT: [+rocm workload=pace]
         GPUMODE: SPX
 run_tests_flux_tioga:
   extends: .run_tests_flux

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -94,7 +94,7 @@ run_tests_slurm_dane:
         VARIANT: [+openmp, '']
       - HOST: dane
         ARCHCONFIG: llnl-cluster
-        BENCHMARK: [laghos, raja-perf, phloem]
+        BENCHMARK: [laghos, lammps, raja-perf, phloem]
       # Strong scaling runs for "benchpark analyze" test
       - HOST: dane
         ARCHCONFIG: llnl-cluster
@@ -106,6 +106,11 @@ run_tests_slurm_dane:
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke]
         VARIANT: ['caliper=mpi,time hwloc=on affinity=on']
+      # lammps workload=pace
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        BENCHMARK: [lammps]
+        VARIANT: [workload=pace]
 run_tests_slurm_matrix:
   extends: .run_tests_slurm
   tags: [shell, matrix]
@@ -119,6 +124,11 @@ run_tests_slurm_matrix:
           - babelstream
           - kripke
           - laghos
+          - lammps
           - raja-perf
           - saxpy
         VARIANT: [+cuda]
+      - HOST: matrix
+        ARCHCONFIG: llnl-matrix
+        BENCHMARK: [lammps]
+        VARIANT: [+cuda workload=pace]

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -38,7 +38,6 @@ class Lammps(
         "gpu-aware-mpi",
         default=True,
         values=(True, False),
-        when=("+cuda" or "+rocm"),
         description="Enable GPU-aware MPI",
     )
 
@@ -67,7 +66,7 @@ class Lammps(
 
         if self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda"):
             kokkos_mode = "g 1"
-            kokkos_gpu_aware = "on" if self.spec.satisfies("+rocm") else "off"
+            kokkos_gpu_aware = "on" if self.spec.satisfies("+gpu-aware-mpi") else "off"
             kokkos_comm = "device"
         else:
             kokkos_mode = "t {n_threads_per_proc}"
@@ -80,7 +79,7 @@ class Lammps(
             False,
         )
 
-        self.add_experiment_variable("n_resources", 1, False)
+        self.add_experiment_variable("n_resources", 4, False)
 
         self.register_scaling_config(
             {

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -23,14 +23,14 @@ class Lammps(
     variant(
         "workload",
         default="hns-reaxff",
-        values=("hns-reaxff", "lj", "eam", "chain", "chute", "rhodo"),
+        values=("hns-reaxff", "lj", "eam", "chain", "chute", "rhodo", "pace"),
         description="workloads",
     )
 
     variant(
         "version",
         default="20250722",
-        values=("develop", "latest", "20250722", "stable_29Aug2024_update3"),
+        values=("develop", "latest", "20250722"),
         description="app version",
     )
 
@@ -45,10 +45,20 @@ class Lammps(
     maintainers("simongdg", "rfhaque")
 
     def compute_applications_section(self):
+        if self.spec.satisfies("workload=pace"):
+            self.add_experiment_variable("lc", 3.597, True)
+            self.add_experiment_variable("lattice", "fcc", True)
+
         if self.spec.satisfies("exec_mode=test"):
-            total_problem_sizes = {"x": 8, "y": 8, "z": 8}
+            if self.spec.satisfies("workload=hns-reaxff"):
+                total_problem_sizes = {"x": 8, "y": 8, "z": 8}
+            if self.spec.satisfies("workload=pace"):
+                total_problem_sizes = {"x": 8, "y": 8, "z": 8}
         else:
-            total_problem_sizes = {"x": 20, "y": 40, "z": 32}
+            if self.spec.satisfies("workload=hns-reaxff"):
+                total_problem_sizes = {"x": 20, "y": 40, "z": 32}
+            if self.spec.satisfies("workload=pace"):
+                total_problem_sizes = {"x": 8, "y": 8, "z": 8}
 
         self.add_experiment_variable(
             "total_problem_size_dict", total_problem_sizes, True
@@ -93,12 +103,20 @@ class Lammps(
             self.add_experiment_variable("n_ranks", "{n_resources}", True)
 
         self.add_experiment_variable("timesteps", 100, False)
-        self.add_experiment_variable("input_file", "{input_path}/in.reaxff.hns", False)
+        if self.spec.satisfies("workload=pace"):
+            self.add_experiment_variable("input_file", "{input_path}/in.pace.product", False)
 
-        self.set_required_variables(
-            process_problem_size="{x}*{y}*{z}/{n_resources}",
-            total_problem_size="{x}*{y}*{z}",
-        )
+            self.set_required_variables(
+                process_problem_size="{x}*{y}*{z}*4/{n_resources}", # placeholder value using fcc lattice with 4 atoms per unit cell
+                total_problem_size="{x}*{y}*{z}*4", # placeholder value using fcc lattice with 4 atoms per unit cell
+            )
+        if self.spec.satisfies("workload=hns-reaxff"):
+            self.add_experiment_variable("input_file", "{input_path}/in.reaxff.hns", False)
+
+            self.set_required_variables(
+                process_problem_size="{x}*{y}*{z}/{n_resources}",
+                total_problem_size="{x}*{y}*{z}",
+            )
 
     def compute_package_section(self):
         fft_kokkos = (
@@ -106,9 +124,12 @@ class Lammps(
             if self.spec.satisfies("+cuda")
             else "fft_kokkos=hipfft" if self.spec.satisfies("+rocm") else ""
         )
+
+        pace = "+pace" if self.spec.satisfies("workload=pace") else "~pace"
+
         self.add_package_spec(
             self.name,
             [
-                f"lammps{self.determine_version()} +opt+manybody+molecule+kspace+rigid+kokkos+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth+reaxff lammps_sizes=bigbig {fft_kokkos} "
+                f"lammps{self.determine_version()} +opt+manybody+molecule+kspace+rigid+kokkos+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth+reaxff lammps_sizes=bigbig {pace} {fft_kokkos} "
             ],
         )

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -103,14 +103,17 @@ class Lammps(
 
         self.add_experiment_variable("timesteps", 100, False)
         if self.spec.satisfies("workload=pace"):
-            self.add_experiment_variable("input_file", "{input_path}/in.pace.product", False)
-
+            self.add_experiment_variable(
+                "input_file", "{input_path}/in.pace.product", False
+            )
             self.set_required_variables(
-                process_problem_size="{x}*{y}*{z}*4/{n_resources}", # placeholder value using fcc lattice with 4 atoms per unit cell
-                total_problem_size="{x}*{y}*{z}*4", # placeholder value using fcc lattice with 4 atoms per unit cell
+                process_problem_size="{x}*{y}*{z}*4/{n_resources}",  # placeholder value using fcc lattice with 4 atoms per unit cell
+                total_problem_size="{x}*{y}*{z}*4",  # placeholder value using fcc lattice with 4 atoms per unit cell
             )
         if self.spec.satisfies("workload=hns-reaxff"):
-            self.add_experiment_variable("input_file", "{input_path}/in.reaxff.hns", False)
+            self.add_experiment_variable(
+                "input_file", "{input_path}/in.reaxff.hns", False
+            )
 
             self.set_required_variables(
                 process_problem_size="{x}*{y}*{z}/{n_resources}",

--- a/repo/lammps/application.py
+++ b/repo/lammps/application.py
@@ -284,6 +284,95 @@ class Lammps(ExecutableApplication):
         workloads=["hns-reaxff"],
     )
 
+    pace_input_test_path = os.path.join(
+        "{lammps}/src", "examples", "PACKAGES", "pace"
+    )
+
+    executable(
+        "set-lattice",
+        template=[
+            "sed -i -e 's/a equal .*/a equal {lc}/g' -i input.txt",
+            "sed -i -e 's/lattice .*/lattice {lattice} $a/g' -i input.txt",
+        ],
+        use_mpi=False,
+    )
+
+    executable(
+        "set-size",
+        template=[
+            "sed -i -e 's/box block .*/box block 0 {x} 0 {y} 0 {z}/g' -i input.txt",
+        ],
+        use_mpi=False,
+    )
+
+    workload(
+        "pace",
+        executables=["copy-contents", "set-lattice", "set-size", "set-timesteps", "execute"],
+    )
+
+    workload_variable(
+        "lc",
+        default="3.597",
+        description="Lattice constant",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "lattice",
+        default="fcc",
+        description="Lattice type",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "x",
+        default="4",
+        description="Unit cells in the x direction",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "y",
+        default="4",
+        description="Unit cells in the y direction",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "z",
+        default="4",
+        description="Unit cells in the z direction",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "input_file",
+        default="in.pace.product",
+        description="PACE input file name",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "input_path",
+        default=os.path.join(f"{pace_input_test_path}"),
+        description="Path to input directory for pace workload",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "timesteps",
+        default="100",
+        description="Number of timesteps",
+        workloads=["pace"],
+    )
+
+    workload_variable(
+        "lammps_flags",
+        default="",
+        description="Additional execution flags for lammps",
+        workloads=["pace"],
+    )
+
     success_criteria(
         "walltime",
         mode="string",

--- a/repo/lammps/package.py
+++ b/repo/lammps/package.py
@@ -30,6 +30,10 @@ class Lammps(BuiltinLammps):
     if "+cuda" in self.spec:
       env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
 
+      if "+mpi" in spec:
+          if spec["mpi"].extra_attributes and "ldflags" in spec["mpi"].extra_attributes:
+              env.append_flags("LDFLAGS", spec["mpi"].extra_attributes["ldflags"])
+
   def cmake_args(self):
     args = super().cmake_args()
     args.append(f"-DMPI_CXX_LINK_FLAGS='{self.spec['mpi'].libs.ld_flags}'")

--- a/repo/lammps/package.py
+++ b/repo/lammps/package.py
@@ -9,15 +9,12 @@ from spack_repo.builtin.packages.lammps.package import Lammps as BuiltinLammps
 
 class Lammps(BuiltinLammps):
 
-  version("stable_29Aug2024_update3", tag="stable_29Aug2024_update3")
+  variant("pace", default=False, description="Enable the ML PACE module")
+  depends_on("pace", when="+pace")
 
   depends_on("kokkos+openmp cxxstd=17", when="+openmp")
-  depends_on("kokkos+rocm", when="+rocm")
-  depends_on("kokkos+cuda cxxstd=17", when="+cuda")
+  depends_on("kokkos+wrapper", when="+cuda")
   
-  conflicts("+rocm", when="+cuda")
-  conflicts("+cuda", when="+rocm")
-
   flag_handler = build_system_flags
 
   def setup_run_environment(self, env):
@@ -38,6 +35,8 @@ class Lammps(BuiltinLammps):
     args.append(f"-DMPI_CXX_LINK_FLAGS='{self.spec['mpi'].libs.ld_flags}'")
     args.append(f"-DMPI_C_COMPILER='{self.spec['mpi'].mpicc}'")
     args.append(f"-DMPI_CXX_COMPILER={self.spec['mpi'].mpicxx}")
+    if "+pace" in self.spec:
+        args.append(f"-DPKG_ML-PACE=ON")
 
     return args
  

--- a/repo/lammps/package.py
+++ b/repo/lammps/package.py
@@ -30,9 +30,9 @@ class Lammps(BuiltinLammps):
     if "+cuda" in self.spec:
       env.set("NVCC_APPEND_FLAGS", "-allow-unsupported-compiler")
 
-      if "+mpi" in spec:
-          if spec["mpi"].extra_attributes and "ldflags" in spec["mpi"].extra_attributes:
-              env.append_flags("LDFLAGS", spec["mpi"].extra_attributes["ldflags"])
+      if "+mpi" in self.spec:
+          if self.spec["mpi"].extra_attributes and "ldflags" in self.spec["mpi"].extra_attributes:
+              env.append_flags("LDFLAGS", self.spec["mpi"].extra_attributes["ldflags"])
 
   def cmake_args(self):
     args = super().cmake_args()


### PR DESCRIPTION
## Description
This PR add the PACE workload to lammps

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.
- [x] If application.py upstreamed to Ramble is insufficient, add/modify `repo/benchmark_name/application.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Ramble repo.
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define an experiment