### PR TITLE
Make Alternate Workload Nightly Tests for Lammps and AMG

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -94,6 +94,34 @@ include:
         SCHEDULER_PARAMETERS: $DANE_PARAMS
         BENCHMARK: [amg2023, kripke, lammps, raja-perf, remhos, stream]
         BENCHMARK_VERSION: develop
+      # Lammps workload=pace
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        BENCHMARK: [lammps]
+        VARIANT: [workload=pace]
+      - HOST: matrix
+        ARCHCONFIG: llnl-matrix
+        BENCHMARK: [lammps]
+        VARIANT: [+cuda workload=pace]
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [lammps]
+        VARIANT: [+rocm workload=pace]
+        GPUMODE: SPX
+      # AMG2023 workload=problem2
+      - HOST: dane
+        ARCHCONFIG: llnl-cluster
+        BENCHMARK: [amg2023]
+        VARIANT: [workload=problem2]
+      - HOST: matrix
+        ARCHCONFIG: llnl-matrix
+        BENCHMARK: [amg2023]
+        VARIANT: [+cuda workload=problem2]
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [amg2023]
+        VARIANT: [+rocm workload=problem2]
+        GPUMODE: SPX
 nightly_test_run:
   extends: .nightly_rules
   resource_group: $HOST

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -120,12 +120,6 @@ run_tests_flux_tuolumne:
         BENCHMARK: [kripke]
         VARIANT: ['+rocm caliper=mpi,time,rocm']
         GPUMODE: SPX
-      # lammps workload=pace
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [lammps]
-        VARIANT: [+rocm workload=pace]
-        GPUMODE: SPX
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -106,11 +106,6 @@ run_tests_slurm_dane:
         ARCHCONFIG: llnl-cluster
         BENCHMARK: [kripke]
         VARIANT: ['caliper=mpi,time hwloc=on affinity=on']
-      # lammps workload=pace
-      - HOST: dane
-        ARCHCONFIG: llnl-cluster
-        BENCHMARK: [lammps]
-        VARIANT: [workload=pace]
 run_tests_slurm_matrix:
   extends: .run_tests_slurm
   tags: [shell, matrix]
@@ -128,7 +123,3 @@ run_tests_slurm_matrix:
           - raja-perf
           - saxpy
         VARIANT: [+cuda]
-      - HOST: matrix
-        ARCHCONFIG: llnl-matrix
-        BENCHMARK: [lammps]
-        VARIANT: [+cuda workload=pace]

--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -35,8 +35,8 @@
         # Map cluster names to their full dashboard names
         DASHBOARD_NAMES["tuolumne"]="Tuolumne HPECray-zen4-MI300A-Slingshot [benchpark system init --dest=tuolumne-system llnl-elcapitan cluster=tuolumne]"
         DASHBOARD_NAMES["tioga"]="Tioga HPECray-zen3-MI250X-Slingshot [benchpark system init --dest=tioga-system llnl-elcapitan cluster=tioga]"
-        DASHBOARD_NAMES["lassen"]="Lassen IBM-power9-V100-Infiniband [benchpark system init --dest=lassen-system llnl-sierra]"
         DASHBOARD_NAMES["dane"]="Dane DELL-sapphirerapids-OmniPath [benchpark system init --dest=dane-system llnl-cluster cluster=dane]"
+        DASHBOARD_NAMES["matrix"]="Matrix DELL-sapphirerapids-H100-Infiniband [benchpark system init --dest=matrix-system llnl-matrix]"
         # Set DASHBOARD_NAME to env var if set, otherwise from array
         DASHBOARD_NAME="${DASHBOARD_NAME:-${DASHBOARD_NAMES[$HOST]}}"
         # Run ctest


### PR DESCRIPTION
## Description

- [x] Add matrix dashboard name
- [x] Move lammps pace tests to nightly test
- [x] Make amg workload problem2 nightly test

## Adding/modifying core functionality, CI, or documentation:

- [x] Update `nightlies`
