### PR TITLE
Add Instructions for Fixing Linter Errors and Fix Linter Checks

### DIFF
--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import time
-import sys
 import argparse
 import os
 import re
+import subprocess
+import sys
+import time
 
 DEFAULT_SYSTEM = "llnl-cluster cluster=dane"
 # Skip experiments

--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -1,6 +1,6 @@
 black==25.9.0
 flake8==7.3.0
-isort==7.0.0
+isort[colors]==7.0.0
 codespell==2.4.1
 yamlfix==1.19.0
 docstrfmt==1.11.1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,7 +19,7 @@ jobs:
         run: |-
           black --diff --check .
           codespell --ignore-words=.codespellignore
-          isort
-          flake8
+          isort --check-only .
+          flake8 .
           yamlfix --check --verbose .
           docstrfmt -p .github/workflows/requirements/docstrfmt.toml --check --verbose docs/

--- a/.gitlab/bin/exit-codes
+++ b/.gitlab/bin/exit-codes
@@ -3,6 +3,7 @@
 import json
 import sys
 
+
 def main(results_file):
     with open(results_file, "r") as f:
         data = json.load(f)

--- a/bin/benchpark
+++ b/bin/benchpark
@@ -5,11 +5,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pathlib
 import subprocess
 import sys
 import uuid
-import os
 
 
 def main():

--- a/docs/ci-developer-guide.rst
+++ b/docs/ci-developer-guide.rst
@@ -143,10 +143,15 @@ style.yml - Lint
 The linter step checks:
 
 - Check Python code formatting using ``black``
+   - Fix black linter errors using ``python -m black dir/filename.py`` or ``python -m black .`` (in source code dir).
 - Check spelling using ``codespell``
+   - Fix the spelling errors manually.
 - Sort imports using ``isort``
 - ``flake8`` for checking Python style enforcement
 - ``yamlfix`` for formatting ``.yaml``/``.yml`` files
+   - Fix yaml linter errors using ``yamlfix dir.filename.yaml``
+- ``docstrfmt`` for formatting ``.rst`` files
+   - Fix docs linter errors using ``docstrfmt -p .github/workflows/requirements/docstrfmt.toml docs/``
 
 Code Coverage
 ~~~~~~~~~~~~~

--- a/docs/ci-developer-guide.rst
+++ b/docs/ci-developer-guide.rst
@@ -143,7 +143,8 @@ style.yml - Lint
 The linter step checks:
 
 - Check Python code formatting using ``black``
-   - Fix black linter errors using ``python -m black dir/filename.py`` or ``python -m black .`` (in source code dir).
+   - Fix black linter errors using ``python -m black dir/filename.py`` or
+      ``python -m black .`` (in source code dir).
 - Check spelling using ``codespell``
    - Fix the spelling errors manually.
 - Sort imports using ``isort``

--- a/docs/ci-developer-guide.rst
+++ b/docs/ci-developer-guide.rst
@@ -143,18 +143,19 @@ style.yml - Lint
 The linter step checks:
 
 - Check Python code formatting using ``black``
-   - Fix black linter errors using ``python -m black dir/filename.py`` or
-      ``python -m black .`` (in source code dir).
+      - Fix black linter errors using ``python -m black dir/filename.py`` or
+            ``python -m black .`` (in source code dir).
 - Check spelling using ``codespell``
-   - Fix the spelling errors manually.
+      - Fix the spelling errors manually.
 - Sort imports using ``isort``
-   - Fix isort linter errors using ``isort .``
+      - Fix isort linter errors using ``isort .``
 - ``flake8`` for checking Python style enforcement
-   - Fix flake linter errors manually
+      - Fix flake linter errors manually
 - ``yamlfix`` for formatting ``.yaml``/``.yml`` files
-   - Fix yaml linter errors using ``yamlfix dir.filename.yaml``
+      - Fix yaml linter errors using ``yamlfix dir.filename.yaml``
 - ``docstrfmt`` for formatting ``.rst`` files
-   - Fix docs linter errors using ``docstrfmt -p .github/workflows/requirements/docstrfmt.toml docs/``
+      - Fix docs linter errors using ``docstrfmt -p
+        .github/workflows/requirements/docstrfmt.toml docs/``
 
 Code Coverage
 ~~~~~~~~~~~~~

--- a/docs/ci-developer-guide.rst
+++ b/docs/ci-developer-guide.rst
@@ -147,7 +147,9 @@ The linter step checks:
 - Check spelling using ``codespell``
    - Fix the spelling errors manually.
 - Sort imports using ``isort``
+   - Fix isort linter errors using ``isort .``
 - ``flake8`` for checking Python style enforcement
+   - Fix flake linter errors manually
 - ``yamlfix`` for formatting ``.yaml``/``.yml`` files
    - Fix yaml linter errors using ``yamlfix dir.filename.yaml``
 - ``docstrfmt`` for formatting ``.rst`` files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
 import subprocess
 import sys
-import os
 
 subprocess.call(
     [

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -75,8 +75,3 @@ documentation, render the pages with the following:
     make html
 
 Then, open ``_build/html/index.html`` in a browser to view the rendered documentation.
-
-Code Formatting
----------------
-
-If lint check fails on your PR, please run `python -m black dir/filename.py` or `python -m black .` (in source code dir)

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -75,3 +75,8 @@ documentation, render the pages with the following:
     make html
 
 Then, open ``_build/html/index.html`` in a browser to view the rendered documentation.
+
+Code Formatting
+---------------
+
+If lint check fails on your PR, please run `python -m black dir/filename.py` or `python -m black .` (in source code dir)

--- a/docs/generate-benchmark-list.py
+++ b/docs/generate-benchmark-list.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
+import subprocess
+import sys
+
 import pandas as pd
 import yaml
-import sys
-import subprocess
 
 sys.path.append("../lib/")
 import benchpark.accounting  # noqa: E402

--- a/experiments/ad/experiment.py
+++ b/experiments/ad/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 

--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Amg2023(

--- a/experiments/babelstream/experiment.py
+++ b/experiments/babelstream/experiment.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
-from benchpark.experiment import Experiment
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
-from benchpark.rocm import ROCmExperiment
+from benchpark.directives import maintainers, variant
+from benchpark.experiment import Experiment
 from benchpark.openmp import OpenMPExperiment
+from benchpark.rocm import ROCmExperiment
 
 
 class Babelstream(

--- a/experiments/genesis/experiment.py
+++ b/experiments/genesis/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment

--- a/experiments/gpcnet/experiment.py
+++ b/experiments/gpcnet/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 

--- a/experiments/gromacs/experiment.py
+++ b/experiments/gromacs/experiment.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
 
 

--- a/experiments/hpcg/experiment.py
+++ b/experiments/hpcg/experiment.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Hpcg(

--- a/experiments/hpl/experiment.py
+++ b/experiments/hpl/experiment.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from benchpark.caliper import Caliper
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
-from benchpark.directives import variant, maintainers
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Hpl(

--- a/experiments/ior/experiment.py
+++ b/experiments/ior/experiment.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.scaling import ScalingMode, Scaling
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Ior(Experiment, MpiOnlyExperiment, Scaling(ScalingMode.Strong, ScalingMode.Weak)):

--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Kripke(

--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
-from benchpark.experiment import Experiment
-from benchpark.mpi import MpiOnlyExperiment
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
+from benchpark.experiment import Experiment
+from benchpark.mpi import MpiOnlyExperiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.scaling import Scaling, ScalingMode
 

--- a/experiments/lammps/experiment.py
+++ b/experiments/lammps/experiment.py
@@ -3,13 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.scaling import ScalingMode, Scaling
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Lammps(

--- a/experiments/md-test/experiment.py
+++ b/experiments/md-test/experiment.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.scaling import ScalingMode, Scaling
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class MdTest(

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.cuda import CudaExperiment
 
 
 class OsuMicroBenchmarks(

--- a/experiments/phloem/experiment.py
+++ b/experiments/phloem/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 

--- a/experiments/quicksilver/experiment.py
+++ b/experiments/quicksilver/experiment.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class Quicksilver(

--- a/experiments/qws/experiment.py
+++ b/experiments/qws/experiment.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.caliper import Caliper
 
 
 class Qws(Experiment, MpiOnlyExperiment, OpenMPExperiment, Caliper):

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.scaling import ScalingMode, Scaling
-from benchpark.caliper import Caliper
+from benchpark.scaling import Scaling, ScalingMode
 
 
 class RajaPerf(

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
-from benchpark.experiment import Experiment
-from benchpark.mpi import MpiOnlyExperiment
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
+from benchpark.experiment import Experiment
+from benchpark.mpi import MpiOnlyExperiment
 from benchpark.rocm import ROCmExperiment
 from benchpark.scaling import Scaling, ScalingMode
 

--- a/experiments/saxpy/experiment.py
+++ b/experiments/saxpy/experiment.py
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.cuda import CudaExperiment
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 from benchpark.openmp import OpenMPExperiment
-from benchpark.cuda import CudaExperiment
 from benchpark.rocm import ROCmExperiment
-from benchpark.caliper import Caliper
 
 
 class Saxpy(

--- a/experiments/smb/experiment.py
+++ b/experiments/smb/experiment.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
 

--- a/experiments/stream/experiment.py
+++ b/experiments/stream/experiment.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from benchpark.caliper import Caliper
+from benchpark.directives import maintainers, variant
 from benchpark.experiment import Experiment
 from benchpark.mpi import MpiOnlyExperiment
-from benchpark.caliper import Caliper
 
 
 class Stream(

--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
+
 from benchpark.directives import variant
 from benchpark.experiment import ExperimentHelper
 

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -3,19 +3,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import re
-import logging
-import sys
 import shlex
-import tarfile
 import shutil
+import sys
+import tarfile
 import warnings
-from glob import glob
 from datetime import datetime
+from glob import glob
 
-import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 import pandas as pd
 import thicket as th
 

--- a/lib/benchpark/cmd/audit.py
+++ b/lib/benchpark/cmd/audit.py
@@ -8,10 +8,9 @@ import pathlib
 import re
 import sys
 
-import benchpark.repo
-
 import ramble.config as cfg  # noqa
 
+import benchpark.repo
 
 sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]
 exp_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -2,8 +2,8 @@ import os
 import subprocess
 import textwrap
 
-import yaml
 import llnl.util.tty.color as color
+import yaml
 
 import benchpark.paths
 

--- a/lib/benchpark/cmd/system.py
+++ b/lib/benchpark/cmd/system.py
@@ -10,15 +10,15 @@ import pickle
 import shutil
 import subprocess
 import sys
-import yaml
 from pprint import pprint
 
+import llnl.util.tty.color as color
+import yaml
 from deepdiff import DeepDiff
 
-import benchpark.system
-import benchpark.spec
 import benchpark.paths
-import llnl.util.tty.color as color
+import benchpark.spec
+import benchpark.system
 
 
 def system_init(args):

--- a/lib/benchpark/cmd/unit_test.py
+++ b/lib/benchpark/cmd/unit_test.py
@@ -5,14 +5,14 @@
 import argparse
 import collections
 import io
-import pytest
 import os
 import re
 import sys
 
 import llnl.util.filesystem
-import llnl.util.tty.color as color
 import llnl.util.tty.colify as colify
+import llnl.util.tty.color as color
+import pytest
 
 import benchpark.paths
 

--- a/lib/benchpark/directives.py
+++ b/lib/benchpark/directives.py
@@ -13,16 +13,16 @@ import os
 import re
 from typing import Any, Callable, Optional, Tuple, Union
 
-import benchpark.spec
-import benchpark.paths
-import benchpark.repo
-import benchpark.runtime
-import benchpark.variant
-
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.language.shared_language
 from ramble.language.language_base import DirectiveError
+
+import benchpark.paths
+import benchpark.repo
+import benchpark.runtime
+import benchpark.spec
+import benchpark.variant
 
 
 # TODO remove this when it is added to ramble.lang (when ramble updates from spack)

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -3,19 +3,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict
-import yaml  # TODO: some way to ensure yaml available
 import sys
-
-from benchpark.error import BenchparkError
-from benchpark.directives import ExperimentSystemBase
-from benchpark.directives import variant
-from benchpark.variables import VariableDict
-import benchpark.spec
-import benchpark.variant
+from typing import Dict
 
 import ramble.language.language_base  # noqa
 import ramble.language.language_helpers  # noqa
+import yaml  # TODO: some way to ensure yaml available
+
+import benchpark.spec
+import benchpark.variant
+from benchpark.directives import ExperimentSystemBase, variant
+from benchpark.error import BenchparkError
+from benchpark.variables import VariableDict
 
 
 class ExperimentHelper:

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from contextlib import contextmanager
 import os
 import pathlib
 import shlex
 import subprocess
 import sys
+from contextlib import contextmanager
 
 import yaml
 

--- a/lib/benchpark/scaling.py
+++ b/lib/benchpark/scaling.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.error import BenchparkError
-from benchpark.directives import variant
-from benchpark.experiment import ExperimentHelper
 from enum import Enum
+
+from benchpark.directives import variant
+from benchpark.error import BenchparkError
+from benchpark.experiment import ExperimentHelper
 
 
 class ScalingMode(Enum):

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -12,10 +12,10 @@ import pathlib
 import re
 from typing import Iterable, Iterator, List, Match, Optional, Union
 
-from benchpark.error import BenchparkError
-import benchpark.repo
-
 import llnl.util.lang  # noqa
+
+import benchpark.repo
+from benchpark.error import BenchparkError
 
 repo_path = benchpark.repo.paths[benchpark.repo.ObjectTypes.experiments]
 sys_repo = benchpark.repo.paths[benchpark.repo.ObjectTypes.systems]

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -5,14 +5,15 @@
 
 import hashlib
 import os
-import packaging.version
-import yaml
 import sys
 from typing import Dict, Tuple
 
-from benchpark.directives import ExperimentSystemBase, provides, variant
+import packaging.version
+import yaml
+
 import benchpark.spec
 import benchpark.variant
+from benchpark.directives import ExperimentSystemBase, provides, variant
 
 
 def _hash_id(content_list):

--- a/lib/benchpark/test/caliper.py
+++ b/lib/benchpark/test/caliper.py
@@ -3,15 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import json
+import sys
 import tempfile
 
 from ramble.expander import Expander
 
 import benchpark.caliper
-import benchpark.spec
 import benchpark.paths
+import benchpark.spec
 
 
 def get_caliper_vars_section(expr_spec):

--- a/lib/benchpark/test/experiment.py
+++ b/lib/benchpark/test/experiment.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 import sys
 
 import pytest
+import yaml
 
 import benchpark.spec
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -10,6 +10,7 @@ import inspect
 import shlex
 import subprocess
 import sys
+
 import yaml
 
 __version__ = "0.1.0"
@@ -49,15 +50,15 @@ bootstrapper = RuntimeResources(benchpark.paths.benchpark_home)  # noqa
 bootstrapper.bootstrap()  # noqa
 
 import benchpark.cmd.audit  # noqa: E402
-import benchpark.cmd.system  # noqa: E402
+import benchpark.cmd.bootstrap  # noqa: E402
 import benchpark.cmd.experiment  # noqa: E402
-import benchpark.cmd.setup  # noqa: E402
-import benchpark.cmd.show_build  # noqa: E402
-import benchpark.cmd.unit_test  # noqa: E402
-import benchpark.cmd.mirror  # noqa: E402
 import benchpark.cmd.info  # noqa: E402
 import benchpark.cmd.list  # noqa: E402
-import benchpark.cmd.bootstrap  # noqa: E402
+import benchpark.cmd.mirror  # noqa: E402
+import benchpark.cmd.setup  # noqa: E402
+import benchpark.cmd.show_build  # noqa: E402
+import benchpark.cmd.system  # noqa: E402
+import benchpark.cmd.unit_test  # noqa: E402
 from benchpark.accounting import benchpark_benchmarks  # noqa: E402
 
 try:

--- a/lib/scripts/diffBuildSpecs.py
+++ b/lib/scripts/diffBuildSpecs.py
@@ -1,9 +1,9 @@
+import argparse
+
 import spack.cmd
 import spack.environment as ev
 import spack.traverse as traverse
 from llnl.util.tty.color import cwrite
-
-import argparse
 
 
 def diff_specs(spec_a, spec_b, truncate=False):

--- a/lib/scripts/diffExperimentBuilds.py
+++ b/lib/scripts/diffExperimentBuilds.py
@@ -1,8 +1,8 @@
 import argparse
 import os
+import shutil
 import subprocess
 import sys
-import shutil
 
 import benchpark.paths
 

--- a/lib/scripts/diffExperimentSpecs.py
+++ b/lib/scripts/diffExperimentSpecs.py
@@ -3,8 +3,9 @@ import os
 import subprocess
 import sys
 
-import benchpark.paths
 from diffSystems import compare_yaml
+
+import benchpark.paths
 
 sys.path.append(str(benchpark.paths.benchpark_home) + "/spack/lib/spack")
 import llnl.util.tty.color as color  # noqa: E402

--- a/lib/scripts/diffPackageCommits.py
+++ b/lib/scripts/diffPackageCommits.py
@@ -1,9 +1,9 @@
 import argparse
 import difflib
+import itertools
 import os
 import subprocess
 import sys
-import itertools
 
 import benchpark.paths
 

--- a/lib/scripts/diffSystemSpecs.py
+++ b/lib/scripts/diffSystemSpecs.py
@@ -1,10 +1,10 @@
 import argparse
 import os
 import subprocess
-import yaml
 import sys
 from pprint import pprint
 
+import yaml
 from deepdiff import DeepDiff
 
 import benchpark.paths

--- a/lib/scripts/env-collect-branch-tips.py
+++ b/lib/scripts/env-collect-branch-tips.py
@@ -1,8 +1,9 @@
-import spack.environment as ev
-from spack.fetch_strategy import GitFetchStrategy
-import sys
 import os
 import shutil
+import sys
+
+import spack.environment as ev
+from spack.fetch_strategy import GitFetchStrategy
 
 
 def main():

--- a/lib/scripts/experiment-build-info.py
+++ b/lib/scripts/experiment-build-info.py
@@ -1,6 +1,7 @@
-import spack.environment as ev
 import json
 import sys
+
+import spack.environment as ev
 
 
 def main():

--- a/modifiers/affinity/modifier.py
+++ b/modifiers/affinity/modifier.py
@@ -36,6 +36,7 @@ class Affinity(BasicModifier):
 
     def affinity(self, executable_name, executable, app_inst=None):
         import os
+
         from ramble.util.executable import CommandExecutable
 
         affinity_file = f"{{experiment_run_dir}}/affinity.{self._usage_mode}"

--- a/modifiers/affinity/parse_affinity_log.py
+++ b/modifiers/affinity/parse_affinity_log.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import json
 import re
-import argparse
 from pathlib import Path
 
 

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -5,6 +5,7 @@
 
 import math
 from enum import Enum
+
 from ramble.modkit import *
 
 

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ramble.modkit import *
 import json
+
+from ramble.modkit import *
 
 
 def add_mode(mode_name, mode_option, description):

--- a/modifiers/hwloc/modifier.py
+++ b/modifiers/hwloc/modifier.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+
 from ramble.modkit import *
 
 
@@ -46,6 +47,7 @@ class Hwloc(BasicModifier):
 
     def hwloc(self, executable_name, executable, app_inst=None):
         import os
+
         from ramble.util.executable import CommandExecutable
 
         hwloc_parser_dir = os.path.dirname(f"{self._file_path}")

--- a/modifiers/hwloc/parse_hwloc_output.py
+++ b/modifiers/hwloc/parse_hwloc_output.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import re
 import json
+import re
 from collections import defaultdict
+
 import xmltodict
 
 

--- a/repo/babelstream/application.py
+++ b/repo/babelstream/application.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import os
+import sys
 
 from ramble.appkit import *
 from ramble.expander import Expander
+
 
 class Babelstream(ExecutableApplication):
     """Babelstream benchmark"""

--- a/repo/cuda/package.py
+++ b/repo/cuda/package.py
@@ -6,9 +6,9 @@
 import pathlib
 
 import llnl.util.tty as tty
-from spack.package import *
 import spack_repo.builtin.packages.cuda.package
 from llnl.util.filesystem import find_headers
+from spack.package import *
 
 
 class Cuda(spack_repo.builtin.packages.cuda.package.Cuda):

--- a/repo/genesis/application.py
+++ b/repo/genesis/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class Genesis(ExecutableApplication):
     """GENESIS package contains two MD programs (atdyn and spdyn), trajectory

--- a/repo/gpcnet/package.py
+++ b/repo/gpcnet/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Gpcnet(MakefilePackage):
 
 

--- a/repo/gromacs/application.py
+++ b/repo/gromacs/application.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 from ramble.appkit import *
 from ramble.expander import Expander
 

--- a/repo/gromacs/package.py
+++ b/repo/gromacs/package.py
@@ -6,11 +6,10 @@
 import os
 
 import llnl.util.filesystem as fs
-
-from spack_repo.builtin.build_systems.cmake import CMakePackage, CMakeBuilder
+from spack.package import *
+from spack_repo.builtin.build_systems.cmake import CMakeBuilder, CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
-from spack.package import *
 
 
 class Gromacs(CMakePackage, CudaPackage, ROCmPackage):

--- a/repo/hipsycl/package.py
+++ b/repo/hipsycl/package.py
@@ -7,7 +7,6 @@ import json
 from os import path
 
 from llnl.util import filesystem
-
 from spack.package import *
 
 

--- a/repo/hpcc/application.py
+++ b/repo/hpcc/application.py
@@ -5,8 +5,8 @@
 
 import sys
 
-from ramble.appkit import *
 from ramble.app.builtin.hpcc import Hpcc as HpccBase
+from ramble.appkit import *
 
 
 class Hpcc(HpccBase):

--- a/repo/hpcg/application.py
+++ b/repo/hpcg/application.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 from ramble.appkit import *
 from ramble.expander import Expander
 

--- a/repo/hpl/application.py
+++ b/repo/hpl/application.py
@@ -5,8 +5,8 @@
 
 import sys
 
-from ramble.appkit import *
 from ramble.app.builtin.hpl import Hpl as HplBase
+from ramble.appkit import *
 
 
 class Hpl(HplBase):

--- a/repo/kripke/application.py
+++ b/repo/kripke/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class Kripke(ExecutableApplication):
     """Kripke benchmark uses RAJA Portability Layer"""

--- a/repo/md-test/application.py
+++ b/repo/md-test/application.py
@@ -5,8 +5,8 @@
 
 import sys
 
-from ramble.appkit import *
 from ramble.app.builtin.md_test import MdTest as MdTestBase
+from ramble.appkit import *
 
 
 class MdTest(MdTestBase):

--- a/repo/osu-micro-benchmarks/application.py
+++ b/repo/osu-micro-benchmarks/application.py
@@ -5,8 +5,10 @@
 
 import sys
 
+from ramble.app.builtin.osu_micro_benchmarks import (
+    OsuMicroBenchmarks as OsuMicroBenchmarksBase,
+)
 from ramble.appkit import *
-from ramble.app.builtin.osu_micro_benchmarks import OsuMicroBenchmarks as OsuMicroBenchmarksBase
 
 
 class OsuMicroBenchmarks(OsuMicroBenchmarksBase):

--- a/repo/osu-micro-benchmarks/package.py
+++ b/repo/osu-micro-benchmarks/package.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from spack.package import *
-from spack_repo.builtin.packages.osu_micro_benchmarks.package import OsuMicroBenchmarks as BuiltinOsu
+from spack_repo.builtin.packages.osu_micro_benchmarks.package import (
+    OsuMicroBenchmarks as BuiltinOsu,
+)
 
 
 class OsuMicroBenchmarks(BuiltinOsu, ROCmPackage):

--- a/repo/phloem/package.py
+++ b/repo/phloem/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Phloem(MakefilePackage):
     tags = []
 

--- a/repo/qws/application.py
+++ b/repo/qws/application.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from ramble.appkit import *
 
-import sys
 
 class Qws(ExecutableApplication):
     """QWS benchmark for Lattice quantum chromodynamics simulation library for

--- a/repo/smb/package.py
+++ b/repo/smb/package.py
@@ -2,9 +2,11 @@
 # Benchpark Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: Apache-2.0
-from spack.package import *
-import llnl.util.filesystem as fs
 import inspect
+
+import llnl.util.filesystem as fs
+from spack.package import *
+
 
 class Smb(MakefilePackage):
     tags = []

--- a/repo/stream/application.py
+++ b/repo/stream/application.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 from ramble.appkit import *
 from ramble.expander import Expander
 

--- a/repo/stream/package.py
+++ b/repo/stream/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Stream(CMakePackage):
     """The STREAM benchmark is a simple synthetic benchmark program that
     measures sustainable memory bandwidth (in MB/s) and the corresponding

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.system import System, compiler_def, compiler_section_for
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for
 
 
 class AwsPcluster(System):

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -4,11 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
+from packaging.version import Version
+
+from benchpark.directives import maintainers, variant
 from benchpark.paths import hardware_descriptions
 from benchpark.rocmsystem import ROCmSystem
 from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
-from packaging.version import Version
 
 
 class CscLumi(System):

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -4,11 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
-from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
-from benchpark.cudasystem import CudaSystem
 from packaging.version import Version
+
+from benchpark.cudasystem import CudaSystem
+from benchpark.directives import maintainers, variant
 from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
 
 
 class CscsDaint(System):

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
-from benchpark.system import System, compiler_def, compiler_section_for
-from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from packaging.version import Version
+
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for
 
 
 class CscsEiger(System):

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from benchpark.directives import maintainers
-from benchpark.system import System
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
+from benchpark.system import System
 
 
 class GenericX86(System):

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
-from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
-from benchpark.cudasystem import CudaSystem
 from packaging.version import Version
+
+from benchpark.cudasystem import CudaSystem
+from benchpark.directives import maintainers, variant
 from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
 
 
 class JscJuwels(System):

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -4,11 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
-from benchpark.cudasystem import CudaSystem
-from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
-from benchpark.paths import hardware_descriptions
 from packaging.version import Version
+
+from benchpark.cudasystem import CudaSystem
+from benchpark.directives import maintainers, variant
+from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for, merge_dicts
 
 
 class LanlVenado(System):

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
+from benchpark.paths import hardware_descriptions
 from benchpark.system import (
-    System,
     JobQueue,
+    System,
     compiler_def,
     compiler_section_for,
     merge_dicts,
 )
-from benchpark.openmpsystem import OpenMPCPUOnlySystem
-from benchpark.paths import hardware_descriptions
 
 
 class LlnlCluster(System):

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
+from packaging.version import Version
+
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
 from benchpark.rocmsystem import ROCmSystem
 from benchpark.system import (
-    System,
     JobQueue,
+    System,
     compiler_def,
     compiler_section_for,
     merge_dicts,
 )
-from benchpark.openmpsystem import OpenMPCPUOnlySystem
-from packaging.version import Version
 
 
 class LlnlElcapitan(System):

--- a/systems/llnl-matrix/system.py
+++ b/systems/llnl-matrix/system.py
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
+from packaging.version import Version
+
 from benchpark.cudasystem import CudaSystem
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
 from benchpark.system import (
-    System,
     JobQueue,
+    System,
     compiler_def,
     compiler_section_for,
     merge_dicts,
 )
-from benchpark.openmpsystem import OpenMPCPUOnlySystem
-from packaging.version import Version
 
 
 class LlnlMatrix(System):

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -3,19 +3,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchpark.directives import variant, maintainers
+from packaging.version import Version
+
 from benchpark.cudasystem import CudaSystem
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
 from benchpark.system import (
-    System,
     JobQueue,
+    System,
     compiler_def,
     compiler_section_for,
-    merge_dicts,
     hybrid_compiler_requirements,
+    merge_dicts,
 )
-from benchpark.openmpsystem import OpenMPCPUOnlySystem
-from packaging.version import Version
 
 
 class LlnlSierra(System):

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from benchpark.directives import variant, maintainers
-from benchpark.system import System, compiler_def, compiler_section_for
+from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
+from benchpark.system import System, compiler_def, compiler_section_for
 
 
 class RikenFugaku(System):


### PR DESCRIPTION
- [x] Update `ci-developer-guide.rst` on how to fix each type of linter error
- [x] Fix `isort` and `flake8` checks, which were previously not being ran
- [x] Changes to `*.py` Files are from running isort
