### PR TITLE
Add Single Node CPU Bandwidth experiment to rajaperf experiment

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -58,13 +58,19 @@ class RajaPerf(
             L3size_bytes = sys.sys_cpu_L3_MB * 10**6
             L2size_bytes = sys.sys_cpu_L2_KB * 10**3
             num_cores = sys.sys_cores_per_node / sockets
-            div_constant = 16 # 2 doubles per problem size
-            cache_constant = 4 # Make sure data stays in cache
+            div_constant = 16  # 2 doubles per problem size
+            cache_constant = 4  # Make sure data stays in cache
             if hasattr(sys, "sys_ccd_per_node"):
                 L3size_bytes *= sys.sys_ccd_per_node / sockets
-            problem_size = (sockets * (L3size_bytes + L2size_bytes * num_cores)) * cache_constant / div_constant
+            problem_size = (
+                (sockets * (L3size_bytes + L2size_bytes * num_cores))
+                * cache_constant
+                / div_constant
+            )
             nearest_power_of_two = 2 ** round(math.log2(problem_size))
-            self.add_experiment_variable("process_problem_size", nearest_power_of_two, True)
+            self.add_experiment_variable(
+                "process_problem_size", nearest_power_of_two, True
+            )
             # Number of processes
             self.add_experiment_variable("n_resources", 1, False)
 

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -51,7 +51,7 @@ class RajaPerf(
             self.add_experiment_variable("process_problem_size", 1048576, True)
             self.add_experiment_variable("n_resources", 1, False)
         elif self.spec.satisfies("exec_mode=singlenode_cpu_bandwidth"):
-            # Need large enough problem size to stress cache, so sytem dependent.
+            # Need large enough problem size to stress cache, so system dependent.
             # Examples dane: 128*1024**2, lassen: 64*1024**2, tuolumne: 256*1024**2, rzgenie: 32*1024*1024, poodle: 128*1024*1024
             sys = self.system_spec.system
             sockets = sys.sys_sockets_per_node

--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 from benchpark.caliper import Caliper
 from benchpark.cuda import CudaExperiment
 from benchpark.directives import maintainers, variant
@@ -35,12 +37,34 @@ class RajaPerf(
         description="app version",
     )
 
+    variant(
+        "exec_mode",
+        default="test",
+        values=("test", "perf", "singlenode_cpu_bandwidth"),
+        description="Execution mode",
+    )
+
     maintainers("michaelmckinsey1")
 
     def compute_applications_section(self):
         if self.spec.satisfies("exec_mode=test"):
-            # Per-process size
             self.add_experiment_variable("process_problem_size", 1048576, True)
+            self.add_experiment_variable("n_resources", 1, False)
+        elif self.spec.satisfies("exec_mode=singlenode_cpu_bandwidth"):
+            # Need large enough problem size to stress cache, so sytem dependent.
+            # Examples dane: 128*1024**2, lassen: 64*1024**2, tuolumne: 256*1024**2, rzgenie: 32*1024*1024, poodle: 128*1024*1024
+            sys = self.system_spec.system
+            sockets = sys.sys_sockets_per_node
+            L3size_bytes = sys.sys_cpu_L3_MB * 10**6
+            L2size_bytes = sys.sys_cpu_L2_KB * 10**3
+            num_cores = sys.sys_cores_per_node / sockets
+            div_constant = 16 # 2 doubles per problem size
+            cache_constant = 4 # Make sure data stays in cache
+            if hasattr(sys, "sys_ccd_per_node"):
+                L3size_bytes *= sys.sys_ccd_per_node / sockets
+            problem_size = (sockets * (L3size_bytes + L2size_bytes * num_cores)) * cache_constant / div_constant
+            nearest_power_of_two = 2 ** round(math.log2(problem_size))
+            self.add_experiment_variable("process_problem_size", nearest_power_of_two, True)
             # Number of processes
             self.add_experiment_variable("n_resources", 1, False)
 


### PR DESCRIPTION
## Description

- [x] From https://github.com/LLNL/benchpark/pull/1050/
- [x] Add Single Node CPU Bandwidth experiment to rajaperf experiment, that determines the correct problem size from the cache size (system information).

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Update `experiments/raja-perf`
