### PR TITLE
Cray mpich wrappers

### DIFF
--- a/repo/cray-mpich-gtl/package.py
+++ b/repo/cray-mpich-gtl/package.py
@@ -12,7 +12,7 @@ from spack.package import LinkTree
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 
-class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
+class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
 
     version("1.0.0")
 

--- a/repo/cray-mpich-gtl/package.py
+++ b/repo/cray-mpich-gtl/package.py
@@ -23,8 +23,14 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
     def libs(self):
         return self.spec["cray-mpich"].libs
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        if dependent_spec.satisfies("+rocm"):
+            env.set("SPACK_GTL", "hip")
+        elif dependent_spec.satisfies("+cuda"):
+            env.set("SPACK_GTL", "cuda")
+
+    # def setup_dependent_run_environment(self, env, dependent_spec):
+    #    env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)
@@ -51,7 +57,15 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
                         f"""\
 #!/bin/bash
 
-{dep.prefix.bin}/{target} -lmpi_gtl_hsa "$@"
+if [[ "$SPACK_GTL" == "hip" ]]; then
+    addlibs="-lmpi_gtl_hsa"
+elif [[ "$SPACK_GTL" == "cuda" ]]; then
+    addlibs="-lmpi_gtl_cuda"
+else
+    addlibs=""
+fi
+
+{dep.prefix.bin}/{target} "$addlibs" "$@"
 """
                     )
                 st = os.stat(fpath)

--- a/repo/cray-mpich-gtl/package.py
+++ b/repo/cray-mpich-gtl/package.py
@@ -17,7 +17,7 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
     version("1.0.0")
 
     depends_on("cray-mpich", type="build")
-    provides("mpi")
+    provides("mpi@3")
 
     @property
     def libs(self):
@@ -29,8 +29,8 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
         elif dependent_spec.satisfies("+cuda"):
             env.set("SPACK_GTL", "cuda")
 
-    # def setup_dependent_run_environment(self, env, dependent_spec):
-    #    env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spack.package import *
+import os.path
+
+class CrayMpichWrappers(BundlePackage):
+
+    version("1.0.0")
+
+    def install(self, spec, prefix):
+        with open(os.path.join(prefix, "FindMPI.cmake"), "w") as f:
+            f.write("""\
+include_guard(GLOBAL)
+
+include("${CMAKE_ROOT}/Modules/FindMPI.cmake")
+
+message("cray-mpich-wrappers test231 module")
+
+if(TARGET MPI::MPI_C)
+  if(NOT DEFINED MPI_C_EXTRA_FLAGS)
+    set(MPI_C_EXTRA_FLAGS "-ltest231")
+  endif()
+  if(MPI_C_EXTRA_FLAGS)
+    separate_arguments(MPI_C_EXTRA_FLAGS NATIVE_COMMAND)
+    target_compile_options(MPI::MPI_C INTERFACE ${MPI_C_EXTRA_FLAGS})
+  endif()
+endif()
+""")

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -8,17 +8,23 @@ import os.path
 import os
 import stat
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
+from spack.package import LinkTree
 
 class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
 
     version("1.0.0")
 
-    depends_on("cray-mpich")
+    depends_on("cray-mpich", type="build")
     provides("mpi")
 
     @property
     def libs(self):
         return self.spec["cray-mpich"].libs
+
+    #def add_files_to_view(self, view, merge_map, skip_if_exists=True):
+    #    for src, dst in merge_map.items():
+    #        if "/bin/" in src:
+    #            os.copy(src, dst)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)
@@ -31,7 +37,9 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
         for subdir in os.listdir(dep.prefix):
             if subdir == "bin":
                 continue
-            os.symlink(os.path.join(dep.prefix, subdir), os.path.join(self.prefix, subdir))
+            #os.symlink(os.path.join(dep.prefix, subdir), os.path.join(self.prefix, subdir))
+            link_tree = LinkTree(os.path.join(dep.prefix, subdir))
+            link_tree.merge(os.path.join(self.prefix, subdir))
 
         mkdir(self.prefix.bin)
         for target in os.listdir(dep.prefix.bin):

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from spack.package import *
-import os.path
 import os
+import os.path
 import stat
-from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
+
+from spack.package import *
 from spack.package import LinkTree
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
 
 class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -10,6 +10,7 @@ import stat
 from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 from spack.package import LinkTree
 
+
 class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
 
     version("1.0.0")
@@ -28,7 +29,9 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
         self.setup_mpi_wrapper_variables(env)
 
     def setup_dependent_package(self, module, dependent_spec):
-        MpichEnvironmentModifications.setup_dependent_package(self, module, dependent_spec)
+        MpichEnvironmentModifications.setup_dependent_package(
+            self, module, dependent_spec
+        )
 
     def install(self, spec, prefix):
         dep = spec["cray-mpich"]
@@ -43,10 +46,12 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
             if target in ["mpicc", "mpicxx", "mpif90", "mpif77"]:
                 fpath = os.path.join(self.prefix.bin, target)
                 with open(fpath, "w") as f:
-                    f.write(f"""\
+                    f.write(
+                        f"""\
 #!/bin/bash
 
 {dep.prefix.bin}/{target} -lmpi_gtl_hsa "$@"
-""")
+"""
+                    )
                 st = os.stat(fpath)
                 os.chmod(fpath, st.st_mode | stat.S_IEXEC)

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -21,6 +21,9 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
     def libs(self):
         return self.spec["cray-mpich"].libs
 
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)
 

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -21,11 +21,6 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
     def libs(self):
         return self.spec["cray-mpich"].libs
 
-    #def add_files_to_view(self, view, merge_map, skip_if_exists=True):
-    #    for src, dst in merge_map.items():
-    #        if "/bin/" in src:
-    #            os.copy(src, dst)
-
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)
 
@@ -37,7 +32,6 @@ class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
         for subdir in os.listdir(dep.prefix):
             if subdir == "bin":
                 continue
-            #os.symlink(os.path.join(dep.prefix, subdir), os.path.join(self.prefix, subdir))
             link_tree = LinkTree(os.path.join(dep.prefix, subdir))
             link_tree.merge(os.path.join(self.prefix, subdir))
 

--- a/repo/cray-mpich-wrappers/package.py
+++ b/repo/cray-mpich-wrappers/package.py
@@ -5,27 +5,43 @@
 
 from spack.package import *
 import os.path
+import os
+import stat
+from spack_repo.builtin.packages.mpich.package import MpichEnvironmentModifications
 
-class CrayMpichWrappers(BundlePackage):
+class CrayMpichWrappers(MpichEnvironmentModifications, BundlePackage):
 
     version("1.0.0")
 
+    depends_on("cray-mpich")
+    provides("mpi")
+
+    @property
+    def libs(self):
+        return self.spec["cray-mpich"].libs
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        self.setup_mpi_wrapper_variables(env)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        MpichEnvironmentModifications.setup_dependent_package(self, module, dependent_spec)
+
     def install(self, spec, prefix):
-        with open(os.path.join(prefix, "FindMPI.cmake"), "w") as f:
-            f.write("""\
-include_guard(GLOBAL)
+        dep = spec["cray-mpich"]
+        for subdir in os.listdir(dep.prefix):
+            if subdir == "bin":
+                continue
+            os.symlink(os.path.join(dep.prefix, subdir), os.path.join(self.prefix, subdir))
 
-include("${CMAKE_ROOT}/Modules/FindMPI.cmake")
+        mkdir(self.prefix.bin)
+        for target in os.listdir(dep.prefix.bin):
+            if target in ["mpicc", "mpicxx", "mpif90", "mpif77"]:
+                fpath = os.path.join(self.prefix.bin, target)
+                with open(fpath, "w") as f:
+                    f.write(f"""\
+#!/bin/bash
 
-message("cray-mpich-wrappers test231 module")
-
-if(TARGET MPI::MPI_C)
-  if(NOT DEFINED MPI_C_EXTRA_FLAGS)
-    set(MPI_C_EXTRA_FLAGS "-ltest231")
-  endif()
-  if(MPI_C_EXTRA_FLAGS)
-    separate_arguments(MPI_C_EXTRA_FLAGS NATIVE_COMMAND)
-    target_compile_options(MPI::MPI_C INTERFACE ${MPI_C_EXTRA_FLAGS})
-  endif()
-endif()
+{dep.prefix.bin}/{target} -lmpi_gtl_hsa "$@"
 """)
+                st = os.stat(fpath)
+                os.chmod(fpath, st.st_mode | stat.S_IEXEC)

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -321,7 +321,7 @@ class LlnlElcapitan(System):
                     "buildable": False,
                     "require": "intel-oneapi-mkl",
                 },
-                "mpi": {"require": "cray-mpich-wrappers"},
+                "mpi": {"require": "cray-mpich-gtl"},
                 "libfabric": {
                     "externals": [
                         {"spec": "libfabric@2.1", "prefix": "/opt/cray/libfabric/2.1"}

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -321,7 +321,7 @@ class LlnlElcapitan(System):
                     "buildable": False,
                     "require": "intel-oneapi-mkl",
                 },
-                "mpi": {"buildable": False},
+                "mpi": {"require": "cray-mpich-wrappers"},
                 "libfabric": {
                     "externals": [
                         {"spec": "libfabric@2.1", "prefix": "/opt/cray/libfabric/2.1"}


### PR DESCRIPTION
How do deal with GPU aware MPI (maybe this needs to be recorded somewhere):

- [x] MPI is where GPU awareness needs to live, so the package links to the correct stuff (using gtl, etc.) and sets the appropriate environment variable for the MPI library if needed (these are not standardized).
- [x] If building application+cuda, will build mpi+cuda.
- [x] To turn off gpu-aware MPI, the application+cuda package needs to build mpi~cuda.
- [x] application+cuda or application~cuda will also set the internal variables for the app source (i.e., MFEM_GPU_AWARE) which will be used in ifdefs. 

In this PR:

- [x] Adds a `cray-mpich-gtl` package that copies everything from `cray-mpich` except for `mpicc/mpicxx/mpif90/mpif77` - for those wrappers, it creates a secondary wrapper script that inserts `-lmpi_gtl_hsa`.
- [x] This should make it so any package that would use `cray-mpich+gtl` does not have to link this library itself (I've only tested the substitution effects where packages that would normally use `cray-mpich` instead use this).
- [ ] Add an example+rocm which builds with MPI+rocm on Tioga or Tuolumne, verify it uses gtl @nhanford 
- [ ] Add an example+cuda which builds works with GPU-unaware MPI on matrix (openMPI or mvapich) @nhanford 
- [ ] Add or modify a test in CI @nhanford @michaelmckinsey1 

