### PR TITLE
Configure Benchpark to Bootstrap for Each GitLab Pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,10 +86,8 @@ bootstrap_benchpark:
   extends: .on_host_template
   stage: bootstrap-benchpark
   script:
-    - pwd
-    - ls
-    - benchpark configure --bootstrap-location $CUSTOM_CI_BUILDS_DIR
-    - benchpark bootstrap
+    - ./bin/benchpark configure --bootstrap-location $CUSTOM_CI_BUILDS_DIR
+    - ./bin/benchpark bootstrap
 cleanup_pipeline_dir:
   tags: [shell, oslic]
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,7 @@ stages:
 bootstrap_benchpark:
   tags: [shell, oslic]
   extends: .on_host_template
+  stage: bootstrap-benchpark
   script:
     - pwd
     - ls

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,15 +75,25 @@ include:
   # Nightly tests
   - local: .gitlab/tests/nightly.yml
 stages:
+  - bootstrap-benchpark
   - machine-checks
   - allocate-resources
   - test
   - release-resources
   - cleanup-dir
+bootstrap_benchpark:
+  tags: [shell, oslic]
+  extends: .on_host_template
+  script:
+    - pwd
+    - ls
+    - benchpark configure --bootstrap-location $CUSTOM_CI_BUILDS_DIR
+    - benchpark bootstrap
 cleanup_pipeline_dir:
   tags: [shell, oslic]
   needs:
     - release_resources_dane
+    - release_resources_matrix
     - release_resources_flux_tioga
     - release_resources_flux_tuolumne
   extends: .on_host_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,7 @@ bootstrap_benchpark:
   extends: .on_host_template
   stage: bootstrap-benchpark
   script:
+    - . /usr/workspace/benchpark-dev/benchpark-venv/$SYS_TYPE/bin/activate
     - ./bin/benchpark configure --bootstrap-location $CUSTOM_CI_BUILDS_DIR
     - ./bin/benchpark bootstrap
 cleanup_pipeline_dir:

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -14,29 +14,21 @@
         exit 1
       fi
 tioga-up-check:
-  needs:
-    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: tioga
   extends: [.machine-check]
 tuolumne-up-check:
-  needs:
-    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: tuolumne
   extends: [.machine-check]
 dane-up-check:
-  needs:
-    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: dane
   extends: [.machine-check]
 matrix-up-check:
-  needs:
-    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: matrix

--- a/.gitlab/utils/machine_checks.yml
+++ b/.gitlab/utils/machine_checks.yml
@@ -14,21 +14,29 @@
         exit 1
       fi
 tioga-up-check:
+  needs:
+    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: tioga
   extends: [.machine-check]
 tuolumne-up-check:
+  needs:
+    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: tuolumne
   extends: [.machine-check]
 dane-up-check:
+  needs:
+    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: dane
   extends: [.machine-check]
 matrix-up-check:
+  needs:
+    - bootstrap_benchpark
   stage: machine-checks
   variables:
     CI_MACHINE: matrix

--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -13,6 +13,9 @@ echo "ramble --disable-logger --workspace-dir . workspace setup"
 echo "ramble --disable-logger --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'"
 echo "ramble --disable-logger --workspace-dir . workspace analyze --format json yaml text"
 
+# Ensure proper bootstrap location configured
+./bin/benchpark configure --bootstrap-location $CUSTOM_CI_BUILDS_DIR
+
 # Initialize System
 ./bin/benchpark system init --dest=${HOST} ${ARCHCONFIG} $([ "$HOST" != "matrix" ] && echo "cluster=$HOST") $SYSTEM_ARGS
 

--- a/lib/benchpark/cmd/configure.py
+++ b/lib/benchpark/cmd/configure.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 
-import os
 import yaml
 
 import benchpark.paths

--- a/lib/benchpark/cmd/configure.py
+++ b/lib/benchpark/cmd/configure.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 
+import os
 import yaml
 
 import benchpark.paths
@@ -23,10 +24,8 @@ def command(args):
     data = {}
 
     if args.bootstrap_location:
-        bl = (
-            str(Path(args.bootstrap_location).expanduser().resolve()).rstrip("/")
-            + "/.benchpark/"
-        )
+        loc = os.path.expandvars(os.path.expanduser(args.bootstrap_location))
+        bl = str(Path(loc).resolve()).rstrip("/") + "/.benchpark/"
         data["bootstrap"] = {
             "location": bl,
         }


### PR DESCRIPTION
## Description

- [x] Currently, all gitlab pipelines use a benchpark bootstrap in `~/.benchpark`, which is the default. The issue is when a PR makes a change to the versions of `spack`, `spack-packages`, or `ramble` it may run concurrently with a PR that has a different commit version. Both of these pipelines may have runners that attempt to check out different repo versions in the same location `~/.benchpark`. This change makes it such that each pipeline has its own bootstrap in `$HOME/.jacamar-ci/$CI_PIPELINE_ID`, so separate pipelines will not conflict. There is already a mechanism in place for removing this directory as well, which will cleanup these bootstraps.
