### PR TITLE
Fix GTL Error in Dryruns

### DIFF
--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -43,6 +43,7 @@ class JscJuwels(System):
         super().__init__(spec)
         self.programming_models = [CudaSystem()]
         self.cuda_version = Version(self.spec.variants["cuda"][0])
+        self.gtl_flag = None
 
         if self.spec.satisfies("compiler=gcc"):
             self.gcc_version = Version("12.3.0")


### PR DESCRIPTION
## Description

#1160 broke dryruns as this flag is expected if the system is a cuda or rocm system.