### PR TITLE
`benchpark setup`: add guards for written directories

### DIFF
--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -68,6 +68,9 @@ def determine_experiment_id(exp_src_dir):
     )
 
 
+_workspace_indicator_file = ".benchpark-ramble-workspace"
+
+
 def command(args):
     """
     experiments_root/
@@ -111,11 +114,28 @@ def command(args):
     experiments_root = pathlib.Path(os.path.abspath(experiments_root))
     system_id = pathlib.Path(os.path.abspath(system_id))
 
-    workspace_dir = os.path.join(experiments_root, experiment_id)
+    workspace_dir = pathlib.Path(experiments_root) / experiment_id
 
-    import pdb; pdb.set_trace()
     if workspace_dir.exists():
         if workspace_dir.is_dir():
+            if not (workspace_dir / _workspace_indicator_file).exists():
+                msg = (f"Derived workspace {workspace_dir} already exists and does not"
+                       " appear to have been created by `benchpark setup`. Please choose"
+                       " a different directory or clear this dir manually")
+                if workspace_dir == pathlib.Path(experiment_src_dir):
+                    # if you did `benchpark system init --dest=x/y`
+                    # and `benchpark experiment init x/y z`
+                    # then for an experiment_root R, `benchpark setup` wants
+                    # to make R/y/z (and manage it). Therefore you cannot pick
+                    # R=x (note that if you just `benchpark system init --dest=y`
+                    # where y is relative, that x is your CWD)
+                    msg = ("<experiments_root> cannot be the directory containing"
+                           " the `--dest` of `benchpark system init`")
+                msg += ("\n\nIt is recommended to choose a nonexistent directory as the"
+                        " <experiments_root> or a directory that has been used as the"
+                        " <experiments_root> before")
+                print(msg)
+                sys.exit(1)
             print(f"Clearing existing workspace {workspace_dir}")
             shutil.rmtree(workspace_dir)
         else:
@@ -125,6 +145,7 @@ def command(args):
             sys.exit(1)
 
     workspace_dir.mkdir(parents=True)
+    (workspace_dir / _workspace_indicator_file).touch()
 
     ramble_workspace_dir = workspace_dir / "workspace"
     ramble_configs_dir = ramble_workspace_dir / "configs"

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -25,7 +25,6 @@ def symlink_tree(src, dst, include_fn=None):
     dst = os.path.abspath(dst)
     if pathlib.Path(src) in pathlib.Path(dst).parents:
         raise Exception(f"Recursive copy from parent to child:\n\t{src}\n\t{dst}")
-    import pdb; pdb.set_trace()
     # By default, we include all filenames
     include_fn = include_fn or (lambda f: True)
     for x in [src, dst]:
@@ -168,8 +167,6 @@ def command(args):
         if fname.endswith(".yaml"):
             return True
         return False
-
-    #import pdb; pdb.set_trace()
 
     symlink_tree(configs_src_dir, ramble_configs_dir, include_fn)
     symlink_tree(experiment_src_dir, ramble_configs_dir, include_fn)

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -23,6 +23,9 @@ def symlink_tree(src, dst, include_fn=None):
     """Like ``cp -R`` but instead of files, create symlinks"""
     src = os.path.abspath(src)
     dst = os.path.abspath(dst)
+    if pathlib.Path(src) in pathlib.Path(dst).parents:
+        raise Exception(f"Recursive copy from parent to child:\n\t{src}\n\t{dst}")
+    import pdb; pdb.set_trace()
     # By default, we include all filenames
     include_fn = include_fn or (lambda f: True)
     for x in [src, dst]:
@@ -53,6 +56,18 @@ def setup_parser(root_parser):
     )
 
 
+def determine_experiment_id(exp_src_dir):
+    x = pathlib.Path(exp_src_dir)
+    for y in x.parents:
+        if (y / "system_id.yaml").exists():
+            # y is the system dir, we want that and everything after it
+            return str(x.relative_to(y.parent))
+    raise Exception(
+        f"No benchpark system dir detected in {exp_src_dir}"
+        " or any parent (no directories containing system_id.yaml)."
+    )
+
+
 def command(args):
     """
     experiments_root/
@@ -80,14 +95,13 @@ def command(args):
     experiments_root = pathlib.Path(os.path.abspath(args.experiments_root))
     source_dir = benchpark.paths.benchpark_root
 
-    # Experiments live inside systems: the experiment_id will include both
-    experiment_id = args.experiment
-    experiment_src_dir = pathlib.Path(os.path.abspath(str(experiment_id)))
+    experiment_src_dir = pathlib.Path(os.path.abspath(str(args.experiment)))
 
     with open(str(experiment_src_dir / "ramble.yaml"), "r") as file:
         parsed_yaml = yaml.safe_load(file)
     pkg_manager = _find(parsed_yaml, "package_manager")
     system_id = _find(parsed_yaml, "destdir")
+    experiment_id = determine_experiment_id(experiment_src_dir)
 
     debug_print(f"source_dir = {source_dir}")
     debug_print(f"specified system/experiment = {experiment_id}")
@@ -95,17 +109,11 @@ def command(args):
     configs_src_dir = pathlib.Path(os.path.abspath(str(system_id)))
 
     experiments_root = pathlib.Path(os.path.abspath(experiments_root))
-    experiment_id = pathlib.Path(os.path.abspath(experiment_id))
     system_id = pathlib.Path(os.path.abspath(system_id))
-    common_root = pathlib.Path(
-        os.path.commonpath([experiments_root, experiment_id, system_id])
-    )
-    workspace_dir = (
-        common_root
-        / experiments_root.relative_to(common_root)
-        / experiment_id.relative_to(common_root)
-    )
 
+    workspace_dir = os.path.join(experiments_root, experiment_id)
+
+    import pdb; pdb.set_trace()
     if workspace_dir.exists():
         if workspace_dir.is_dir():
             print(f"Clearing existing workspace {workspace_dir}")
@@ -139,6 +147,8 @@ def command(args):
         if fname.endswith(".yaml"):
             return True
         return False
+
+    #import pdb; pdb.set_trace()
 
     symlink_tree(configs_src_dir, ramble_configs_dir, include_fn)
     symlink_tree(experiment_src_dir, ramble_configs_dir, include_fn)

--- a/lib/benchpark/cmd/setup.py
+++ b/lib/benchpark/cmd/setup.py
@@ -118,9 +118,11 @@ def command(args):
     if workspace_dir.exists():
         if workspace_dir.is_dir():
             if not (workspace_dir / _workspace_indicator_file).exists():
-                msg = (f"Derived workspace {workspace_dir} already exists and does not"
-                       " appear to have been created by `benchpark setup`. Please choose"
-                       " a different directory or clear this dir manually")
+                msg = (
+                    f"Derived workspace {workspace_dir} already exists and does not"
+                    " appear to have been created by `benchpark setup`. Please choose"
+                    " a different directory or clear this dir manually"
+                )
                 if workspace_dir == pathlib.Path(experiment_src_dir):
                     # if you did `benchpark system init --dest=x/y`
                     # and `benchpark experiment init x/y z`
@@ -128,11 +130,15 @@ def command(args):
                     # to make R/y/z (and manage it). Therefore you cannot pick
                     # R=x (note that if you just `benchpark system init --dest=y`
                     # where y is relative, that x is your CWD)
-                    msg = ("<experiments_root> cannot be the directory containing"
-                           " the `--dest` of `benchpark system init`")
-                msg += ("\n\nIt is recommended to choose a nonexistent directory as the"
-                        " <experiments_root> or a directory that has been used as the"
-                        " <experiments_root> before")
+                    msg = (
+                        "<experiments_root> cannot be the directory containing"
+                        " the `--dest` of `benchpark system init`"
+                    )
+                msg += (
+                    "\n\nIt is recommended to choose a nonexistent directory as the"
+                    " <experiments_root> or a directory that has been used as the"
+                    " <experiments_root> before"
+                )
                 print(msg)
                 sys.exit(1)
             print(f"Clearing existing workspace {workspace_dir}")


### PR DESCRIPTION
For ramble workspaces created under the experiment_root in `benchpark setup <experiment> <experiment_root>`, benchpark now requires either that this directory doesn't exist or that it was created by a previous invocation of `benchpark setup`

It does this by creating a sentinel file (which means that all workspaces created prior to this PR would be made invalid). This is to protect against benchpark writing into or deleting directories that it shouldn't, the general workflow is:

```
benchpark system init --dest=tioga llnl-elcapitan cluster=tioga
benchpark experiment init tioga/ kripke
benchpark setup tioga/kripke X # The first time you call benchpark setup, X shouldn't exist
...
benchpark setup ... X # You can keep calling benchpark setup on X if you want
```

(technically X itself can already exist and have content, but any directory that `benchpark setup` would create *within* X cannot yet exist)

Also adds a special check for when `benchpark setup <experiment> <experiment_root>`  the `<experiment_root>` contains the `--dest` of `benchpark system init` (this would be caught/prohibited by the above, but I generate a specific error message in this case).

This also adds a guard to the internal `symlink_tree(src, dst)` method to make sure that `src` is never a parent of `dst`.