### PR TITLE
Fix spack buildcache push in github action

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -103,11 +103,13 @@ jobs:
           path: ./workspace/generic-x86/saxpy/openmp/workspace/archive/**
       - name: Upload Binaries to CI Cache
         if: github.ref == 'refs/heads/develop'
+        env:
+          SPACK_OCI_USER: ${{ github.actor }}
+          SPACK_OCI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack mirror set \
-            --push \
-            --oci-username ${{ github.actor }} \
-            --oci-password "${{ secrets.GITHUB_TOKEN }}" \
+          spack mirror set --push \
+            --oci-username-variable SPACK_OCI_USER \
+            --oci-password-variable SPACK_OCI_TOKEN \
             ci-buildcache
           spack buildcache push \
             -j $(($(nproc) + 1)) \

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -102,7 +102,6 @@ jobs:
           name: workspace-archive
           path: ./workspace/generic-x86/saxpy/openmp/workspace/archive/**
       - name: Upload Binaries to CI Cache
-        if: github.ref == 'refs/heads/develop'
         env:
           SPACK_OCI_USER: ${{ github.actor }}
           SPACK_OCI_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -102,6 +102,7 @@ jobs:
           name: workspace-archive
           path: ./workspace/generic-x86/saxpy/openmp/workspace/archive/**
       - name: Upload Binaries to CI Cache
+        if: github.ref == 'refs/heads/develop'
         env:
           SPACK_OCI_USER: ${{ github.actor }}
           SPACK_OCI_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- [x] The saxpy action tries to push to the buildcache at ghcr.io/llnl/benchpark-binary-cache to speedup future CI runs. This is broken because the newer versions of spack no longer allow passing the password on the command line and instead expect an env var that contains the password (ref: https://github.com/spack/spack/blob/develop/lib/spack/docs/containers.rst?utm_source=chatgpt.com)