### PR TITLE
`benchpark analyze`: Normalize yaxis metric by other column

### DIFF
--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -585,6 +585,11 @@ def prepare_data(**kwargs):
             f"Adding metadata column '{metric}' to the performance data from the metadata."
         )
 
+    norm_col = kwargs.get("normalize_by", "")
+    if norm_col != "":
+        logger.info(f"Normalizing '{kwargs['yaxis_metric']}' by '{norm_col}'")
+        tk.dataframe[kwargs["yaxis_metric"]] /= tk.dataframe[norm_col]
+
     make_chart(df=tk.dataframe, x_axis=x_axis_metadata, **kwargs)
 
 
@@ -658,6 +663,14 @@ def setup_parser(root_parser):
     )
     root_parser.add_argument(
         "--no-mpi", action="store_true", help="Hide MPI regions in the tree."
+    )
+    root_parser.add_argument(
+        "--normalize-by",
+        default="",
+        type=str,
+        required=False,
+        help="Optionally normalize the y-axis column by this column.",
+        metavar="COLUMN",
     )
     root_parser.add_argument(
         "--chart-title",


### PR DESCRIPTION
## Description

- [x] Enables dividing the yaxis metric for the chart by another column in the dataframe
