### PR TITLE
Caliper: Use libpfm over papi for topdown and add error message if wrong uarch

### DIFF
--- a/lib/benchpark/caliper.py
+++ b/lib/benchpark/caliper.py
@@ -76,15 +76,9 @@ class Caliper:
                     "spack_pkg_spec": f"caliper@{caliper_version}+adiak+mpi~libunwind~libdw",
                 }
                 if any("topdown" in var for var in self.spec.variants["caliper"]):
-                    papi_support = True  # check if target system supports papi
-                    if papi_support:
-                        package_specs["caliper"][
-                            "spack_pkg_spec"
-                        ] += "+papi target={}".format(system_specs["cpu_arch"])
-                    else:
-                        raise NotImplementedError(
-                            "Target system does not support the papi interface"
-                        )
+                    package_specs["caliper"][
+                        "spack_pkg_spec"
+                    ] += "+libpfm~papi target={}".format(system_specs["cpu_arch"])
                 elif self.spec.satisfies("caliper=cuda"):
                     cuda_support = (
                         self.spec.satisfies("caliper=cuda") and True

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -379,7 +379,7 @@ class Experiment(ExperimentSystemBase, ExecMode, Affinity, Hwloc):
             modifier_list += cls_list
 
             # topdown specific logic
-            uarch_whitelist = ["sapphirerapids", "emeraldrappids"]
+            uarch_whitelist = ["sapphirerapids", "emeraldrapids"]
             if len(cls_list) > 0:
                 for mod_obj in cls_list:
                     if mod_obj["name"] == "caliper" and "topdown" in mod_obj["mode"]:

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -379,14 +379,14 @@ class Experiment(ExperimentSystemBase, ExecMode, Affinity, Hwloc):
             modifier_list += cls_list
 
             # topdown specific logic
+            uarch_whitelist = ["sapphirerapids", "emeraldrappids"]
             if len(cls_list) > 0:
                 for mod_obj in cls_list:
                     if mod_obj["name"] == "caliper" and "topdown" in mod_obj["mode"]:
-                        data = self.system_spec.system.hardware_dict
-                        vendor = data["system_definition"]["processor"]["vendor"]
-                        if vendor.lower() != "intel":
+                        cpu_arch = self.system_spec.system.cpu_arch
+                        if cpu_arch.lower() not in uarch_whitelist:
                             raise ValueError(
-                                f"Topdown analysis is not supported on the provided system with vendor='{vendor}'"
+                                f"Topdown analysis is not supported on the provided system with uarch='{cpu_arch}'. Must be one of:\n\t{uarch_whitelist}"
                             )
 
         return modifier_list

--- a/lib/benchpark/experiment.py
+++ b/lib/benchpark/experiment.py
@@ -375,7 +375,20 @@ class Experiment(ExperimentSystemBase, ExecMode, Affinity, Hwloc):
         modifier_list = [{"name": "allocation"}, {"name": "exit-code"}]
         modifier_list += self.compute_modifiers_section()
         for cls in self.helpers:
-            modifier_list += cls.compute_modifiers_section()
+            cls_list = cls.compute_modifiers_section()
+            modifier_list += cls_list
+
+            # topdown specific logic
+            if len(cls_list) > 0:
+                for mod_obj in cls_list:
+                    if mod_obj["name"] == "caliper" and "topdown" in mod_obj["mode"]:
+                        data = self.system_spec.system.hardware_dict
+                        vendor = data["system_definition"]["processor"]["vendor"]
+                        if vendor.lower() != "intel":
+                            raise ValueError(
+                                f"Topdown analysis is not supported on the provided system with vendor='{vendor}'"
+                            )
+
         return modifier_list
 
     def add_experiment_variable(self, name, values, named=False, matrixed=False):

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -29,7 +29,9 @@ class MPISystem:
     name = "mpi"
 
     def system_specific_variables(self, system):
-        return {"cpu_arch": getattr(system, "cpu_arch", "unknown")}
+        return {
+            "cpu_arch": system.hardware_dict["system_definition"]["processor"]["uArch"]
+        }
 
 
 class JobQueue:

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -29,12 +29,7 @@ class MPISystem:
     name = "mpi"
 
     def system_specific_variables(self, system):
-        try:
-            cpu_arch = system.hardware_dict["system_definition"]["processor"]["uArch"]
-        except (AttributeError, KeyError, TypeError):
-            cpu_arch = "Unknown"
-
-        return {"cpu_arch": cpu_arch}
+        return {"cpu_arch": getattr(system, "cpu_arch", "unknown")}
 
 
 class JobQueue:

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -34,9 +34,7 @@ class MPISystem:
         except (AttributeError, KeyError, TypeError):
             cpu_arch = "Unknown"
 
-        return {
-            "cpu_arch": cpu_arch
-        }
+        return {"cpu_arch": cpu_arch}
 
 
 class JobQueue:

--- a/lib/benchpark/system.py
+++ b/lib/benchpark/system.py
@@ -29,8 +29,13 @@ class MPISystem:
     name = "mpi"
 
     def system_specific_variables(self, system):
+        try:
+            cpu_arch = system.hardware_dict["system_definition"]["processor"]["uArch"]
+        except (AttributeError, KeyError, TypeError):
+            cpu_arch = "Unknown"
+
         return {
-            "cpu_arch": system.hardware_dict["system_definition"]["processor"]["uArch"]
+            "cpu_arch": cpu_arch
         }
 
 

--- a/lib/benchpark/test/system.py
+++ b/lib/benchpark/test/system.py
@@ -22,7 +22,7 @@ def test_system_compute_variables_section(monkeypatch):
             "n_ranks": 2**64 - 1,
             "n_nodes": 2**64 - 1,
             "batch_submit": "placeholder",
-            "cpu_arch": "unknown",
+            "cpu_arch": "zen4",
             "mpi_command": "placeholder",
             "sys_cores_os_reserved_per_node": 12,
             "sys_cores_os_reserved_per_node_list": [

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -18,6 +18,7 @@ class AwsPcluster(System):
 
     id_to_resources = {
         "c4.xlarge": {
+            "cpu_arch": "zen",
             "sys_cores_per_node": 4,
             "sys_mem_per_node_GB": 7.5,
             "system_site": "aws",
@@ -25,6 +26,7 @@ class AwsPcluster(System):
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "c6g.xlarge": {
+            "cpu_arch": "zen",
             "sys_cores_per_node": 4,
             "sys_mem_per_node_GB": 8,
             "system_site": "aws",
@@ -32,6 +34,7 @@ class AwsPcluster(System):
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "hpc7a.48xlarge": {
+            "cpu_arch": "zen",
             "sys_cores_per_node": 96,
             "sys_mem_per_node_GB": 768,
             "system_site": "aws",
@@ -39,6 +42,7 @@ class AwsPcluster(System):
             + "/AWS_PCluster-zen-EFA/hardware_description.yaml",
         },
         "hpc6a.48xlarge": {
+            "cpu_arch": "zen",
             "sys_cores_per_node": 96,
             "sys_mem_per_node_GB": 384,
             "system_site": "aws",

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -71,9 +70,6 @@ class AwsPcluster(System):
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def system_specific_variables(self):
         return {

--- a/systems/aws-pcluster/system.py
+++ b/systems/aws-pcluster/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -70,6 +71,9 @@ class AwsPcluster(System):
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def system_specific_variables(self):
         return {

--- a/systems/aws-tutorial/system.py
+++ b/systems/aws-tutorial/system.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -68,9 +67,6 @@ class AwsTutorial(System):
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         return {

--- a/systems/aws-tutorial/system.py
+++ b/systems/aws-tutorial/system.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
+
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
 from benchpark.paths import hardware_descriptions
@@ -66,6 +68,9 @@ class AwsTutorial(System):
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         return {

--- a/systems/aws-tutorial/system.py
+++ b/systems/aws-tutorial/system.py
@@ -18,22 +18,27 @@ class AwsTutorial(System):
 
     id_to_resources = {
         "c7i.48xlarge": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 192,
             "sys_mem_per_node_GB": 384,
         },
         "c7i.metal-48xl": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 192,
             "sys_mem_per_node_GB": 384,
         },
         "c7i.24xlarge": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 96,
             "sys_mem_per_node_GB": 192,
         },
         "c7i.metal-24xl": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 96,
             "sys_mem_per_node_GB": 192,
         },
         "c7i.12xlarge": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 48,
             "sys_mem_per_node_GB": 96,
         },

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -68,6 +68,9 @@ class CscLumi(System):
         attrs = self.id_to_resources.get("lumi")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
 

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -68,9 +68,6 @@ class CscLumi(System):
         attrs = self.id_to_resources.get("lumi")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
 

--- a/systems/csc-lumi/system.py
+++ b/systems/csc-lumi/system.py
@@ -18,6 +18,7 @@ class CscLumi(System):
 
     id_to_resources = {
         "lumi": {
+            "cpu_arch": "zen3",
             "rocm_arch": "gfx90a",
             "gtl_flag": "",
             "sys_cores_per_node": 64,

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -69,9 +69,6 @@ class CscsDaint(System):
         attrs = self.id_to_resources.get("daint")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = self.cuda_config(self.cuda_version)

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -18,6 +18,7 @@ class CscsDaint(System):
 
     id_to_resources = {
         "daint": {
+            "cpu_arch": "haswell",
             "sys_cores_per_node": 12,
             "sys_gpus_per_node": 1,
             "sys_mem_per_node_GB": 64,

--- a/systems/cscs-daint/system.py
+++ b/systems/cscs-daint/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -69,6 +69,9 @@ class CscsDaint(System):
         attrs = self.id_to_resources.get("daint")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = self.cuda_config(self.cuda_version)

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -41,6 +42,9 @@ class CscsEiger(System):
         attrs = self.id_to_resources.get("eiger")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_compilers_section(self):
         return compiler_section_for(

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -18,6 +18,7 @@ class CscsEiger(System):
 
     id_to_resources = {
         "eiger": {
+            "cpu_arch": "zen2",
             "sys_cores_per_node": 128,
             "timeout": 30,
             "system_site": "cscs",

--- a/systems/cscs-eiger/system.py
+++ b/systems/cscs-eiger/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -42,9 +42,6 @@ class CscsEiger(System):
         attrs = self.id_to_resources.get("eiger")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_compilers_section(self):
         return compiler_section_for(

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -54,9 +54,6 @@ class JscJuwels(System):
         attrs = self.id_to_resources.get("juwels")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_compilers_section(self):
         nvhpc_cfg = compiler_section_for(

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -53,6 +54,9 @@ class JscJuwels(System):
         attrs = self.id_to_resources.get("juwels")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_compilers_section(self):
         nvhpc_cfg = compiler_section_for(

--- a/systems/jsc-juwels/system.py
+++ b/systems/jsc-juwels/system.py
@@ -18,6 +18,7 @@ class JscJuwels(System):
 
     id_to_resources = {
         "juwels": {
+            "cpu_arch": "rome",
             "sys_cores_per_node": 48,
             "timeout": 120,
             "sys_gpus_per_node": 4,

--- a/systems/lanl-rocinante/system.py
+++ b/systems/lanl-rocinante/system.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -108,9 +107,6 @@ class LanlRocinante(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/lanl-rocinante/system.py
+++ b/systems/lanl-rocinante/system.py
@@ -22,6 +22,7 @@ class LanlRocinante(System):
 
     id_to_resources = {
         "crossroads": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_cores_os_reserved_per_node": 0,  # No core or thread reservation
             "sys_cores_os_reserved_per_node_list": None,
@@ -40,6 +41,7 @@ class LanlRocinante(System):
             ],
         },
         "rocinante": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_cores_os_reserved_per_node": 0,  # No core or thread reservation
             "sys_cores_os_reserved_per_node_list": None,
@@ -58,6 +60,7 @@ class LanlRocinante(System):
             ],
         },
         "tycho": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_cores_os_reserved_per_node": 0,  # No core or thread reservation
             "sys_cores_os_reserved_per_node_list": None,

--- a/systems/lanl-rocinante/system.py
+++ b/systems/lanl-rocinante/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -107,6 +108,9 @@ class LanlRocinante(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -82,6 +82,9 @@ class LanlVenado(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -82,9 +82,6 @@ class LanlVenado(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/lanl-venado/system.py
+++ b/systems/lanl-venado/system.py
@@ -18,6 +18,7 @@ class LanlVenado(System):
 
     id_to_resources = {
         "grace-hopper": {
+            "cpu_arch": "neoverse",
             "cuda_arch": 90,
             "sys_cores_per_node": 144,
             "sys_gpus_per_node": 4,
@@ -27,6 +28,7 @@ class LanlVenado(System):
             + "/HPECray-neoverse-H100-Slingshot/hardware_description.yaml",
         },
         "grace-grace": {
+            "cpu_arch": "neoverse",
             "sys_cores_per_node": 144,
             "system_site": "lanl",
             "hardware_key": str(hardware_descriptions)

--- a/systems/lbnl-perlmutter/system.py
+++ b/systems/lbnl-perlmutter/system.py
@@ -24,6 +24,7 @@ class LbnlPerlmutter(System):
 
     id_to_resources = {
         "perlmutter": {
+            "cpu_arch": "zen3",
             "cuda_arch": "80",
             "sys_cores_per_node": 64,
             "sys_gpus_per_node": 4,

--- a/systems/lbnl-perlmutter/system.py
+++ b/systems/lbnl-perlmutter/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -83,6 +83,9 @@ class LbnlPerlmutter(System):
         attrs = self.id_to_resources.get("perlmutter")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def mpi_config(self):
         gtl = self.spec.variants["gtl"][0]

--- a/systems/lbnl-perlmutter/system.py
+++ b/systems/lbnl-perlmutter/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -83,9 +83,6 @@ class LbnlPerlmutter(System):
         attrs = self.id_to_resources.get("perlmutter")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def mpi_config(self):
         gtl = self.spec.variants["gtl"][0]

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -46,7 +47,6 @@ class LlnlCluster(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "dane": {
-            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_cores_os_reserved_per_node": 0,  # No explicit core reservation, first thread on each core reserved (2 threads per core)
             "sys_cores_os_reserved_per_node_list": None,
@@ -142,6 +142,9 @@ class LlnlCluster(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
         mount_point = self.spec.variants["mount_point"][0]
         if mount_point not in self.mount_points + ["none"]:

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -22,6 +22,7 @@ class LlnlCluster(System):
 
     id_to_resources = {
         "ruby": {
+            "cpu_arch": "icelake",
             "sys_cores_per_node": 56,
             "sys_cores_os_reserved_per_node": 0,  # No core or thread reservation
             "sys_cores_os_reserved_per_node_list": None,
@@ -38,6 +39,7 @@ class LlnlCluster(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "magma": {
+            "cpu_arch": "icelake",
             "sys_cores_per_node": 96,
             "system_site": "llnl",
             "hardware_key": str(hardware_descriptions)
@@ -46,6 +48,7 @@ class LlnlCluster(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "dane": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_cores_os_reserved_per_node": 0,  # No explicit core reservation, first thread on each core reserved (2 threads per core)
             "sys_cores_os_reserved_per_node_list": None,
@@ -61,6 +64,7 @@ class LlnlCluster(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "rzgenie": {
+            "cpu_arch": "haswell",
             "sys_cores_per_node": 36,
             "system_site": "llnl",
             "sys_sockets_per_node": 2,
@@ -72,6 +76,7 @@ class LlnlCluster(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "poodle": {
+            "cpu_arch": "sapphirerapids",
             "sys_cores_per_node": 112,
             "sys_sockets_per_node": 2,
             "sys_cpu_L2_KB": 2048,

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -142,9 +141,6 @@ class LlnlCluster(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
         mount_point = self.spec.variants["mount_point"][0]
         if mount_point not in self.mount_points + ["none"]:

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -251,9 +251,6 @@ class LlnlElcapitan(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
         # MI300A modes
         if self.rocm_arch == "gfx942":

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -25,6 +25,7 @@ class LlnlElcapitan(System):
 
     id_to_resources = {
         "tioga": {
+            "cpu_arch": "zen3",
             "rocm_arch": "gfx90a",
             "sys_cores_per_node": 56,
             "sys_cores_os_reserved_per_node": 8,
@@ -47,6 +48,7 @@ class LlnlElcapitan(System):
             "mount_points": ["/l/ssd", "/p/lustre1", "/p/lustre2", "/p/lustre3"],
         },
         "elcapitan": {
+            "cpu_arch": "zen4",
             "rocm_arch": "gfx942",
             "sys_cores_per_node": 84,
             "sys_cores_os_reserved_per_node": 12,

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -251,6 +251,9 @@ class LlnlElcapitan(System):
         attrs = self.id_to_resources.get(self.spec.variants["cluster"][0])
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
         # MI300A modes
         if self.rocm_arch == "gfx942":

--- a/systems/llnl-matrix/system.py
+++ b/systems/llnl-matrix/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -82,9 +82,6 @@ class LlnlMatrix(System):
         attrs = self.id_to_resources.get("matrix")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/llnl-matrix/system.py
+++ b/systems/llnl-matrix/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -82,6 +82,9 @@ class LlnlMatrix(System):
         attrs = self.id_to_resources.get("matrix")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         selections = {

--- a/systems/llnl-matrix/system.py
+++ b/systems/llnl-matrix/system.py
@@ -25,6 +25,7 @@ class LlnlMatrix(System):
 
     id_to_resources = {
         "matrix": {
+            "cpu_arch": "sapphirerapids",
             "cuda_arch": 90,
             "sys_cores_per_node": 112,
             "sys_gpus_per_node": 4,

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -106,6 +107,9 @@ class LlnlSierra(System):
         attrs = self.id_to_resources.get("lassen")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
 

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -26,6 +26,7 @@ class LlnlSierra(System):
 
     id_to_resources = {
         "lassen": {
+            "cpu_arch": "power9",
             "cuda_arch": 70,
             "sys_cores_per_node": 40,
             "sys_sockets_per_node": 2,

--- a/systems/llnl-sierra/system.py
+++ b/systems/llnl-sierra/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.cudasystem import CudaSystem
@@ -107,9 +107,6 @@ class LlnlSierra(System):
         attrs = self.id_to_resources.get("lassen")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
 

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -16,6 +16,7 @@ class RikenFugaku(System):
 
     id_to_resources = {
         "fugaku": {
+            "cpu_arch": "A64FX",
             "sys_cores_per_node": 48,
             "sys_mem_per_node_GB": 32,
             "system_site": "riken",

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -40,9 +39,6 @@ class RikenFugaku(System):
         attrs = self.id_to_resources.get("fugaku")
         for k, v in attrs.items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         # Doesn't look like we need to switch MPI based on compiler from old definition, verify this

--- a/systems/riken-fugaku/system.py
+++ b/systems/riken-fugaku/system.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 
 from benchpark.directives import maintainers, variant
 from benchpark.openmpsystem import OpenMPCPUOnlySystem
@@ -39,6 +40,9 @@ class RikenFugaku(System):
         attrs = self.id_to_resources.get("fugaku")
         for k, v in attrs.items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
     def compute_packages_section(self):
         # Doesn't look like we need to switch MPI based on compiler from old definition, verify this

--- a/systems/snl-eldorado/system.py
+++ b/systems/snl-eldorado/system.py
@@ -23,6 +23,7 @@ class SnlEldorado(System):
 
     id_to_resources = {
         "eldorado": {
+            "cpu_arch": "zen4",
             "rocm_arch": "gfx942",
             "sys_cores_per_node": 84,
             "sys_cores_os_reserved_per_node": 12,

--- a/systems/snl-eldorado/system.py
+++ b/systems/snl-eldorado/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
+import yaml
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -136,6 +136,9 @@ class SnlEldorado(System):
 
         for k, v in self.id_to_resources["eldorado"].items():
             setattr(self, k, v)
+
+        with open(self.hardware_key, "r") as f:
+            self.hardware_dict = yaml.safe_load(f)
 
         # MI300A modes
         if self.rocm_arch == "gfx942":

--- a/systems/snl-eldorado/system.py
+++ b/systems/snl-eldorado/system.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import yaml
+
 from packaging.version import Version
 
 from benchpark.directives import maintainers, variant
@@ -136,9 +136,6 @@ class SnlEldorado(System):
 
         for k, v in self.id_to_resources["eldorado"].items():
             setattr(self, k, v)
-
-        with open(self.hardware_key, "r") as f:
-            self.hardware_dict = yaml.safe_load(f)
 
         # MI300A modes
         if self.rocm_arch == "gfx942":


### PR DESCRIPTION
## Description

- [x] This is recommended in latest caliper release https://github.com/llnl/Caliper/blob/master/doc/sphinx/Topdown.rst

`The Linux perf based method is the preferred approach. It requires Caliper to be built with the -DWITH_LIBPFM=On switch or the +libpfm Spack variant.`

- [x] Depends on #1217 
- [x] hardcode uarch and add error message
   
   
Example error if running topdown on elcap
```
ValueError: Topdown analysis is not supported on the provided system with uarch='zen4'. Must be one of:
        ['sapphirerapids', 'emeraldrappids']
```