### PR TITLE
only set MPICH_GPU_SUPPORT_ENABLED to 1 when a package linked gtl lib

### DIFF
--- a/repo/cray-mpich-gtl/package.py
+++ b/repo/cray-mpich-gtl/package.py
@@ -30,7 +30,7 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
             env.set("SPACK_GTL", "cuda")
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        if dependent_spec.satisfies("+rocm"):
+        if dependent_spec.satisfies("+rocm") or dependent_spec.satisfies("+cuda"):
             env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:

--- a/repo/cray-mpich-gtl/package.py
+++ b/repo/cray-mpich-gtl/package.py
@@ -30,7 +30,8 @@ class CrayMpichGtl(MpichEnvironmentModifications, BundlePackage):
             env.set("SPACK_GTL", "cuda")
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
+        if dependent_spec.satisfies("+rocm"):
+            env.set("MPICH_GPU_SUPPORT_ENABLED", "1")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.setup_mpi_wrapper_variables(env)


### PR DESCRIPTION
The `llnl-elcapitan` system uses `cray-mpich-gtl` as the `mpi` provider. It was always setting `MPICH_GPU_SUPPORT_ENABLED=1`, even for packages where it did not `-lmpi_gtl_hsa` (for example `hpl`). This PR only activates that env var for packages that are `+rocm` (the same gate that controls whether `-lmpi_gtl_hsa` is linked by the wrapper).