### PR TITLE
compiler definition was wrong for clang on llnl cluster

### DIFF
--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -422,10 +422,10 @@ class LlnlCluster(System):
             cfg = merge_dicts(gcc_cfg, oneapi_cfg, weighting_cfg)
         elif self.spec.satisfies("compiler=clang"):
             cfg = compiler_section_for(
-                "clang",
+                "llvm",
                 [
                     compiler_def(
-                        "clang@19.1.3",
+                        "llvm@19.1.3+flang",
                         "/usr/tce/packages/clang/clang-19.1.3/",
                         {"c": "clang", "cxx": "clang++", "fortran": "flang-new"},
                     )

--- a/systems/llnl-cluster/system.py
+++ b/systems/llnl-cluster/system.py
@@ -99,7 +99,7 @@ class LlnlCluster(System):
     variant(
         "compiler",
         default="oneapi",
-        values=("oneapi", "gcc", "intel", "clang"),
+        values=("oneapi", "gcc", "intel", "llvm"),
         description="Which compiler to use",
     )
 
@@ -343,7 +343,7 @@ class LlnlCluster(System):
                         }
                     ],
                 }
-        elif self.spec.satisfies("compiler=clang"):
+        elif self.spec.satisfies("compiler=llvm"):
             if mpi_type == "mvapich2":
                 mpi_dict["mvapich2"] = {
                     "externals": [
@@ -420,7 +420,7 @@ class LlnlCluster(System):
             prefs = {"one_of": ["%oneapi", "%gcc"], "when": "%c"}
             weighting_cfg = {"packages": {"all": {"require": [prefs]}}}
             cfg = merge_dicts(gcc_cfg, oneapi_cfg, weighting_cfg)
-        elif self.spec.satisfies("compiler=clang"):
+        elif self.spec.satisfies("compiler=llvm"):
             cfg = compiler_section_for(
                 "llvm",
                 [
@@ -440,8 +440,8 @@ class LlnlCluster(System):
             default_compiler = "intel-oneapi-compilers-classic"
         elif self.spec.satisfies("compiler=oneapi"):
             default_compiler = "intel-oneapi-compilers"
-        elif self.spec.satisfies("compiler=clang"):
-            default_compiler = "clang"
+        elif self.spec.satisfies("compiler=llvm"):
+            default_compiler = "llvm"
 
         return {
             "software": {


### PR DESCRIPTION
1. The configuration needs to refer to it as `llvm` vs. `clang` (`clang` alias does not work in config external setup). This was failing quietly, as Ramble will automatically `spack compiler find` if `default-compiler` is not detected in the config
2. `llvm/clang` is not considered a valid fortran compiler unless the spec mentions `+flang` (so even with [1] resolved, the spack concretization of the environment using benchpark-defined llvm will fail because it isn't considered suitable).

I should be looking into how to detect instances of [1] more-generally (but not in this PR)
