### PR TITLE
Consistent Kripke versions

### DIFF
--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -31,8 +31,8 @@ class Kripke(
 
     variant(
         "version",
-        default="2025-07",
-        values=("develop", "latest", "2025-07", "1.2.7.0"),
+        default="2025.12.0",
+        values=("develop", "latest", "2025.12.0", "2025.07.0", "1.2.7.0"),
         description="app version",
     )
 

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -63,7 +63,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
-    depends_on("chai@2025.12.0+raja", when="@develop")
+    depends_on("chai@2025.12.0+raja", when="@2025.12.0")
     depends_on("fmt@9.1", when=f"^chai@2024.07.0")
     depends_on("chai@2024.07.0+raja", when="@:2025.07.0")
     depends_on("chai@2024.07.0+raja", when="@1.2.7.0:2025.07.0")

--- a/repo/kripke/package.py
+++ b/repo/kripke/package.py
@@ -21,7 +21,8 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop", submodules=False)
-    version("2025-07", submodules=False, commit="8cf38433a6a11e0dcd17864e649b2d045159ee9c")
+    version("2025.12.0", submodules=False, commit="01f6f85c02ceffcd2bc06e42cee997867dd142c5")
+    version("2025.07.0", submodules=False, commit="8cf38433a6a11e0dcd17864e649b2d045159ee9c")
     version(
         "1.2.7.0", submodules=False, commit="db920c1f5e1dcbb9e949d120e7d86efcdb777635"
     )
@@ -64,8 +65,8 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("chai@2025.12.0+raja", when="@develop")
     depends_on("fmt@9.1", when=f"^chai@2024.07.0")
-    depends_on("chai@2024.07.0+raja", when="@:2025-07")
-    depends_on("chai@2024.07.0+raja", when="@1.2.7.0:2025-07")
+    depends_on("chai@2024.07.0+raja", when="@:2025.07.0")
+    depends_on("chai@2024.07.0+raja", when="@1.2.7.0:2025.07.0")
     depends_on("fmt@9.1", when=f"^chai@2024.07.0")
 
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
## Description

- [x] Add new version `2025.12.0` to integrate src changes from radiuss `2025.12.0` package updates.
- [x] Change dated versions to match syntax of radiuss packages, for clarity
