### PR TITLE
Set kripke input arch

### DIFF
--- a/experiments/kripke/experiment.py
+++ b/experiments/kripke/experiment.py
@@ -133,6 +133,15 @@ class Kripke(
         )
 
         if self.spec.satisfies("+openmp"):
+            self.add_experiment_variable("arch", "OpenMP")
+        elif self.spec.satisfies("+cuda"):
+            self.add_experiment_variable("arch", "CUDA")
+        elif self.spec.satisfies("+rocm"):
+            self.add_experiment_variable("arch", "HIP")
+        else:
+            self.add_experiment_variable("arch", "Sequential")
+
+        if self.spec.satisfies("+openmp"):
             self.add_experiment_variable("n_threads_per_proc", 1, True)
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             self.add_experiment_variable("n_gpus", "{n_resources}", True)


### PR DESCRIPTION
## Description
This PR sets the `--arch` input variable in Kripke to the required value (`OpenMP`, `CUDA` or `HIP`)

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define an experiment