### PR TITLE
Robust setup env

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,9 +1,12 @@
 _this_file="${BASH_SOURCE[0]-${(%):-%N}-$0}"
 _this_dir="$(CDPATH= cd -- "$(dirname -- "$_this_file")" 2>/dev/null && pwd -P)"
 
-if [ -n "$PATH" ] && [ ":$PATH:" != "${PATH#:$_this_dir/bin:}" ]; then
-  :  # already present
-else
-  PATH="$_this_dir/bin${PATH+:$PATH}"
-  export PATH
-fi
+case ":$PATH:" in
+  *":$_this_dir/bin:"*)
+    :  # already present — do nothing
+    ;;
+  *)
+    PATH="$_this_dir/bin${PATH+:$PATH}"
+    export PATH
+    ;;
+esac

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,11 +1,22 @@
-# BASH_SOURCE[0] if it exists, or ${(%):-%N} in zsh, or $0 as a final fallback
-_this_file="${BASH_SOURCE[0]-${(%):-%N}-$0}"
+if [ -n "${BASH_VERSION-}" ]; then
+  _this_file=${BASH_SOURCE[0]}
+elif [ -n "${ZSH_VERSION-}" ]; then
+  eval '_this_file=${(%):-%N}'
+else
+  echo "This script must be sourced from bash or zsh." >&2
+  return 1 2>/dev/null || exit 1
+fi
 # Get abspath
 _this_dir="$(CDPATH= cd -- "$(dirname -- "$_this_file")" 2>/dev/null && pwd -P)"
 
 case ":$PATH:" in
   *":$_this_dir/bin:"*)
-    :  # already present — do nothing
+    # already present: do nothing
+    # This is an exact match, and e.g. won't match if PATH contains this
+    # dir with a trailing slash after "bin". That's good enough to avoid
+    # adding duplicate entries when re-sourcing this, but will add a
+    # duplicate if the user manually added .../bin/ to their PATH
+    :
     ;;
   *)
     PATH="$_this_dir/bin${PATH+:$PATH}"

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,1 +1,9 @@
-export PATH=${PWD}/bin:$PATH
+_this_file="${BASH_SOURCE[0]-${(%):-%N}-$0}"
+_this_dir="$(CDPATH= cd -- "$(dirname -- "$_this_file")" 2>/dev/null && pwd -P)"
+
+if [ -n "$PATH" ] && [ ":$PATH:" != "${PATH#:$_this_dir/bin:}" ]; then
+  :  # already present
+else
+  PATH="$_this_dir/bin${PATH+:$PATH}"
+  export PATH
+fi

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,4 +1,6 @@
+# BASH_SOURCE[0] if it exists, or ${(%):-%N} in zsh, or $0 as a final fallback
 _this_file="${BASH_SOURCE[0]-${(%):-%N}-$0}"
+# Get abspath
 _this_dir="$(CDPATH= cd -- "$(dirname -- "$_this_file")" 2>/dev/null && pwd -P)"
 
 case ":$PATH:" in


### PR DESCRIPTION
Fixes https://github.com/llnl/benchpark/issues/1169

Accounts for 

* relative path invocations
* bash and zsh
* fails explicitly for sh (no reliable way to export PATH in this case)
* Also can be run multiple times (only updates PATH the first time)