### PR TITLE
Experiment info fragility

### DIFF
--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import subprocess
 import textwrap
@@ -138,7 +139,7 @@ def info_experiment(args):
             )
         )
 
-    experiment_spec = benchpark.spec.ExperimentSpec(args.name)
+    experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.name))
     conc = experiment_spec.concretize()
     experiment_class = conc.experiment
 
@@ -218,7 +219,7 @@ def setup_parser(root_parser):
     experiment_parser.add_argument(
         "--maintainers", action="store_true", help="Maintainers"
     )
-    experiment_parser.add_argument("name", help="Experiment name")
+    experiment_parser.add_argument("name", nargs=argparse.REMAINDER, help="Experiment name")
 
 
 def command(args):

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -139,9 +139,19 @@ def info_experiment(args):
             )
         )
 
-    experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.name))
+    experiment_spec_str = " ".join(args.name)
+    experiment_spec = benchpark.spec.ExperimentSpec(experiment_spec_str)
     conc = experiment_spec.concretize()
-    experiment = conc.experiment
+    try:
+        experiment = conc.experiment
+    except Exception as e:
+        msg = (
+            f"'{experiment_spec_str}' must be a valid experiment spec;"
+            " some experiments require specifying additional variants"
+            " (e.g. experiments not inheriting MpiOnlyExperiment must" \
+            " set +rocm or +cuda)."
+        )
+        raise ValueError(msg) from e
 
     if args.spack:
         subprocess.run(

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -141,7 +141,7 @@ def info_experiment(args):
 
     experiment_spec = benchpark.spec.ExperimentSpec(" ".join(args.name))
     conc = experiment_spec.concretize()
-    experiment_class = conc.experiment
+    experiment = conc.experiment
 
     if args.spack:
         subprocess.run(
@@ -149,9 +149,9 @@ def info_experiment(args):
                 "spack",
                 "info",
                 (
-                    experiment_class.spack_name
-                    if experiment_class.spack_name
-                    else experiment_class.name
+                    experiment.spack_name
+                    if experiment.spack_name
+                    else experiment.name
                 ),
             ]
         )
@@ -162,19 +162,19 @@ def info_experiment(args):
                 "ramble",
                 "info",
                 (
-                    experiment_class.ramble_name
-                    if experiment_class.ramble_name
-                    else experiment_class.name
+                    experiment.ramble_name
+                    if experiment.ramble_name
+                    else experiment.name
                 ),
             ]
         )
         return
     else:
         actions = {
-            "maintainers": (info_maintainers, [experiment_class]),
-            "ramble_name": (_info_ramble_name, [experiment_class]),
-            "spack_name": (_info_spack_name, [experiment_class]),
-            "variants": (info_variants, [experiment_class]),
+            "maintainers": (info_maintainers, [experiment]),
+            "ramble_name": (_info_ramble_name, [experiment]),
+            "spack_name": (_info_spack_name, [experiment]),
+            "variants": (info_variants, [experiment]),
         }
 
         # Call functions for enabled options, or all if no flag is set

--- a/lib/benchpark/cmd/info.py
+++ b/lib/benchpark/cmd/info.py
@@ -148,7 +148,7 @@ def info_experiment(args):
         msg = (
             f"'{experiment_spec_str}' must be a valid experiment spec;"
             " some experiments require specifying additional variants"
-            " (e.g. experiments not inheriting MpiOnlyExperiment must" \
+            " (e.g. experiments not inheriting MpiOnlyExperiment must"
             " set +rocm or +cuda)."
         )
         raise ValueError(msg) from e
@@ -158,11 +158,7 @@ def info_experiment(args):
             [
                 "spack",
                 "info",
-                (
-                    experiment.spack_name
-                    if experiment.spack_name
-                    else experiment.name
-                ),
+                (experiment.spack_name if experiment.spack_name else experiment.name),
             ]
         )
         return
@@ -171,11 +167,7 @@ def info_experiment(args):
             [
                 "ramble",
                 "info",
-                (
-                    experiment.ramble_name
-                    if experiment.ramble_name
-                    else experiment.name
-                ),
+                (experiment.ramble_name if experiment.ramble_name else experiment.name),
             ]
         )
         return
@@ -229,7 +221,9 @@ def setup_parser(root_parser):
     experiment_parser.add_argument(
         "--maintainers", action="store_true", help="Maintainers"
     )
-    experiment_parser.add_argument("name", nargs=argparse.REMAINDER, help="Experiment name")
+    experiment_parser.add_argument(
+        "name", nargs=argparse.REMAINDER, help="Experiment name"
+    )
 
 
 def command(args):

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -330,13 +330,15 @@ class ConcreteSpec(Spec):
                 for n, v in v_by_n.items():
                     if n == name:
                         if not v.validate_values_bool(values):
-                            raise Exception(f"'{values}' is not valid for variant '{name}' on {self.name}")
+                            raise Exception(
+                                f"'{values}' is not valid for variant '{name}' on {self.name}"
+                            )
                         conditions.append(when)
 
             if name not in possible_variants:
                 raise Exception(f"{name} is not a valid variant of {self.name}")
 
-            #if not conditions:
+            # if not conditions:
             #    import pdb; pdb.set_trace()
             #    print('hi')
 

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -323,15 +323,22 @@ class ConcreteSpec(Spec):
             name, values = variants_to_check.pop()
             checked.add((name, values))
 
-            conditions = [
-                w
-                for w, v_by_n in self.object_class.variants.items()
-                for n, v in v_by_n.items()
-                if n == name and v.validate_values_bool(values)
-            ]
+            conditions = []
+            possible_variants = set()
+            for when, v_by_n in self.object_class.variants.items():
+                possible_variants.update(v_by_n.keys())
+                for n, v in v_by_n.items():
+                    if n == name:
+                        if not v.validate_values_bool(values):
+                            raise Exception(f"'{values}' is not valid for variant '{name}' on {self.name}")
+                        conditions.append(when)
 
-            if not conditions:
+            if name not in possible_variants:
                 raise Exception(f"{name} is not a valid variant of {self.name}")
+
+            #if not conditions:
+            #    import pdb; pdb.set_trace()
+            #    print('hi')
 
             # This variant is already valid on self
             if any(self.satisfies(c) for c in conditions):

--- a/lib/benchpark/spec.py
+++ b/lib/benchpark/spec.py
@@ -338,10 +338,6 @@ class ConcreteSpec(Spec):
             if name not in possible_variants:
                 raise Exception(f"{name} is not a valid variant of {self.name}")
 
-            # if not conditions:
-            #    import pdb; pdb.set_trace()
-            #    print('hi')
-
             # This variant is already valid on self
             if any(self.satisfies(c) for c in conditions):
                 continue


### PR DESCRIPTION
Fixes https://github.com/llnl/benchpark/issues/1168 
    ... kind of

Also fixes the case where if you specify a wrong variant value, that benchpark was saying the variant doesn't exist

Right now, to print out all the experiment info we want, we have to actually instantiate it, which means we need to provide a valid spec, so just a name isn't always possible. This "fixes" the problem described in 1168 by reporting more info. There's quite a bit of exception output though, so annoying for a user to sift through.