### PR TITLE
CPU targets

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           . workspace/setup.sh
           spack mirror add ci-buildcache oci://ghcr.io/llnl/benchpark-binary-cache
-          spack config add "packages:all:target:[x86_64_v3]"
+          spack config add "packages:all:target:[x86_64_v2]"
           env | grep SPACK >> "$GITHUB_ENV"
           env | grep -P 'RAMBLE(?!_WORKSPACE)' >> "$GITHUB_ENV"
           echo "PATH=$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
- [x] Archspec CPU microarchitecture options we should link to in the docs: https://github.com/archspec/archspec-json/blob/master/cpu/microarchitectures.json
- [x] How do packages typically specify targets - and what is best practice?  --- Per @scheibelp, they typically do not
- [ ] How can we make `x86_64` or `x86_64_v2` or `x86_64_v3` or `a64fx` variants per system, such that they set the target microarchitecture for the packages as appropriate?
- [ ] @scheibelp will propose an interface for one system
- [ ] We should stick with `x86_64_v2` as the default per @becker33 
- [ ] Why are we setting this in GitHub/workflows/run.yml: `spack config add "packages:all:target:[x86_64_v3]"`

