### PR TITLE
laghos caliper fix

### DIFF
--- a/repos/spack_repo/benchpark/packages/laghos/package.py
+++ b/repos/spack_repo/benchpark/packages/laghos/package.py
@@ -103,7 +103,7 @@ class Laghos(MakefilePackage, CudaPackage, ROCmPackage):
         targets.append("CONFIG_MK=%s" % spec["mfem"].package.config_mk)
         targets.append("TEST_MK=%s" % spec["mfem"].package.test_mk)
         if "+caliper" in self.spec:
-            targets.append("USE_CALIPER=ON")
+            targets.append("LAGHOS_USE_CALIPER=ON")
             targets.append("CALIPER_DIR=%s" % spec["caliper"].prefix)
             targets.append("ADIAK_DIR=%s" % spec["adiak"].prefix)
         if spec.satisfies("@:2.0"):


### PR DESCRIPTION
## Description
This PR fixes the flag used to enable caliper in laghos.
The logic was changed in the PR https://github.com/CEED/Laghos/pull/205/changes#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.