### PR TITLE
Remove 2 allocations for PR test on Tuolumne

### DIFF
--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -25,7 +25,7 @@ allocate_resources_tuolumne:
     matrix:
       - HOST: tuolumne
         SHARED_ALLOC: $TUOLUMNE_SHARED_ALLOC
-        GPUMODE: [SPX, TPX, CPX]
+        GPUMODE: SPX
   tags: [shell, tuolumne]
   needs: [tuolumne-up-check]
 allocate_resources_tioga:
@@ -49,7 +49,7 @@ release_resources_flux_tuolumne:
   parallel:
     matrix:
       - HOST: tuolumne
-        GPUMODE: [SPX, TPX, CPX]
+        GPUMODE: SPX
   tags: [shell, tuolumne]
 release_resources_flux_tioga:
   extends: .release_resources_flux
@@ -96,19 +96,6 @@ run_tests_flux_tuolumne:
           - sparta-snl
         VARIANT: [+rocm]
         GPUMODE: SPX
-      # Test TPX, CPX
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [amg2023, kripke, laghos]
-        VARIANT: [+rocm+strong scaling-iterations=2]
-        SYSTEM_ARGS: [gpumode=TPX]
-        GPUMODE: TPX
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke, laghos]
-        VARIANT: [+rocm+strong scaling-iterations=2]
-        SYSTEM_ARGS: [gpumode=CPX]
-        GPUMODE: CPX
       # Test openmp on tuolumne
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan


### PR DESCRIPTION
## Description

**This does not prevent testing TPX and CPX in nightly tests**

CPX and TPX will still test on nightly, but testing them on PRs requires 3x the allocations, which are often not being allocated on Tuolumne, which has high contention. So this change will help the SPX test actually run. We may be even able to put our test back in PCI queue (which we had removed to add TPX and CPX tests anyway). Additionally, the TPX and CPX tests have not been catching any runtime errors that SPX has not (so no additional value).

- [x] Remove CPX and TPX from PR tests.
- [x] If we find this does not improve the contention issue, I can try changing the queue from `pbatch` to `pci`, but we have to be sure we are running <4 pipelines at a time (we still tend to be running 4> pipelines quite often). 