### PR TITLE
Add hack for incorrect dir structure

### DIFF
--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -257,7 +257,11 @@ class LlnlElcapitan(System):
             self.pmi_version = Version("6.1.12")
             self.pals_version = Version("1.2.9")
             self.llvm_version = Version("16.0.0")
-        self.short_cce_version = f"{self.cce_version.major}.{self.cce_version.minor}" if not self.override_cce_shortpath else self.override_cce_shortpath
+        self.short_cce_version = (
+            f"{self.cce_version.major}.{self.cce_version.minor}"
+            if self.override_cce_shortpath is None
+            else self.override_cce_shortpath
+        )
         self.short_rocm_version = f"{self.rocm_version.major}.0"
         # TODO: Replace this with lookups into the working set
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -225,6 +225,8 @@ class LlnlElcapitan(System):
             if self.rocm_version >= Version("7.1.0"):
                 self.cce_version = Version("21.0.0")
                 self.mpi_version = Version("9.1.0")
+                # Modules for cce/21.0 named as cce/20.0, so do not change this
+                self.override_cce_shortpath = Version("20.0")
                 # No working self.rccl_version
                 self.rccl_version = None
             elif self.rocm_version >= Version("6.4.0"):
@@ -255,7 +257,7 @@ class LlnlElcapitan(System):
             self.pmi_version = Version("6.1.12")
             self.pals_version = Version("1.2.9")
             self.llvm_version = Version("16.0.0")
-        self.short_cce_version = f"{self.cce_version.major}.{self.cce_version.minor}"
+        self.short_cce_version = f"{self.cce_version.major}.{self.cce_version.minor}" if not self.override_cce_shortpath else self.override_cce_shortpath
         self.short_rocm_version = f"{self.rocm_version.major}.0"
         # TODO: Replace this with lookups into the working set
 

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -213,6 +213,7 @@ class LlnlElcapitan(System):
         self.programming_models = [ROCmSystem(), OpenMPCPUOnlySystem()]
         self.rocm_version = Version(self.spec.variants["rocm"][0])
         self.gtl_flag = self.spec.variants["gtl"][0]
+        self.override_cce_shortpath = None
 
         # TODO: Replace this with lookups into the working set
         if self.spec.satisfies("compiler=gcc"):
@@ -809,7 +810,13 @@ class LlnlElcapitan(System):
             )
         # Avoid libunwind.so.1 error on tioga
         if self.spec.variants["cluster"][0] in ["tioga", "tuolumne"]:
-            rpaths.append(f"/opt/cray/pe/cce/{self.cce_version}/cce-clang/x86_64/lib/")
+            # cce/21 does not have libunwind.so.1
+            unwind_path = (
+                f"/opt/cray/pe/cce/{self.cce_version}/cce-clang/x86_64/lib/"
+                if self.cce_version <= Version("20.0.0")
+                else "/opt/cray/pe/cce/20.0.0/cce-clang/x86_64/lib/"
+            )
+            rpaths.append(unwind_path)
 
         cfgs = []
         # Always need an instance of llvm-gpu as an external. Sometimes as a compiler


### PR DESCRIPTION
## Description

- [x] The dir where `self.short_cce_version` is used is incorrectly named by cray, so we must add a hack to adjust for this. I already checked and LC can't fix the dir structure.
