### PR TITLE
Remove `rocm/7.1.0` on `llnl-elcapitan`

### DIFF
--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -126,7 +126,7 @@ run_tests_flux_tuolumne:
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [raja-perf]
         VARIANT: ['+rocm caliper=time,rocm version=develop']
-        SYSTEM_ARGS: [rocm=7.1.0]
+        SYSTEM_ARGS: [rocm=7.2.0]
         GPUMODE: SPX
 run_tests_flux_tioga:
   extends: .run_tests_flux

--- a/lib/benchpark/test/system.py
+++ b/lib/benchpark/test/system.py
@@ -60,6 +60,6 @@ def test_system_timeout():
 
 def test_rocm7():
     sys_spec = benchpark.spec.SystemSpec(
-        "llnl-elcapitan cluster=tuolumne rocm=7.1.0"
+        "llnl-elcapitan cluster=tuolumne rocm=7.2.0"
     ).concretize()
     sys_spec.system.compute_compilers_section()

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -140,7 +140,6 @@ class LlnlElcapitan(System):
             "6.4.1",
             "6.4.2",
             "6.4.3",
-            "7.1.0",
             "7.2.0",
         ),
         description="ROCm version",
@@ -223,7 +222,7 @@ class LlnlElcapitan(System):
                 f"{self.gcc_version.major}.{self.gcc_version.minor}"
             )
         else:
-            if self.rocm_version >= Version("7.1.0"):
+            if self.rocm_version >= Version("7.0.0"):
                 self.cce_version = Version("21.0.0")
                 self.mpi_version = Version("9.1.0")
                 # Modules for cce/21.0 named as cce/20.0, so do not change this


### PR DESCRIPTION
## Description

- [x] Recommended to use `rocm/7.2.0` over `rocm/7.1.0` and `rocm/7.1.0` will be deprecated https://lc.llnl.gov/confluence/spaces/ELCAP/pages/899809690/2026-02-26+User+Meeting
