### PR TITLE
Enable Using `MFEM_USE_RAJA` in Laghos

### DIFF
--- a/experiments/laghos/experiment.py
+++ b/experiments/laghos/experiment.py
@@ -55,6 +55,13 @@ class Laghos(
         description="nonconforming or conforming",
     )
 
+    variant(
+        "raja",
+        default=True,
+        values=(True, False),
+        description="Use RAJA backend for MFEM",
+    )
+
     maintainers("wdhawkins")
 
     def generate_perf_specs(self):
@@ -232,10 +239,13 @@ class Laghos(
 
     def compute_package_section(self):
         gam = "~gpu-aware-mpi"
+        raja = "~raja"
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             if self.spec.satisfies("+gpu-aware-mpi"):
                 gam = "+gpu-aware-mpi"
+        if self.spec.satisfies("+raja"):
+            raja = "+raja"
         self.add_package_spec(
-            self.name, [f"laghos{self.determine_version()} +metis {gam}"]
+            self.name, [f"laghos{self.determine_version()} +metis {gam} {raja}"]
         )
         self.add_package_spec("hypre", ["hypre@2.32.0: +lapack"])

--- a/repos/spack_repo/benchpark/packages/laghos/package.py
+++ b/repos/spack_repo/benchpark/packages/laghos/package.py
@@ -38,6 +38,7 @@ class Laghos(MakefilePackage, CudaPackage, ROCmPackage):
 
     depends_on("mfem+mpi+metis", when="+metis")
     depends_on("mfem+mpi~metis", when="~metis")
+    depends_on("mfem+raja", when="+raja")
     depends_on("caliper", when="+caliper")
     depends_on("adiak~shared", when="+caliper")
 

--- a/repos/spack_repo/benchpark/packages/laghos/package.py
+++ b/repos/spack_repo/benchpark/packages/laghos/package.py
@@ -31,6 +31,7 @@ class Laghos(MakefilePackage, CudaPackage, ROCmPackage):
     variant("caliper", default=False, description="Enable/disable Caliper support")
     variant("ofast", default=False, description="Enable gcc optimization flags")
     variant("gpu-aware-mpi", default=False, description="Enable GPU aware MPI")
+    variant("raja", default=True, description="Use RAJA backend for MFEM")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/repos/spack_repo/benchpark/packages/mfem/package.py
+++ b/repos/spack_repo/benchpark/packages/mfem/package.py
@@ -20,11 +20,6 @@ class Mfem(BuiltinMfem):
     depends_on("adiak", when="+caliper")
     depends_on("hypre+shared", when="+mpi~cuda")
 
-    # MFEM upstream may already handle this
-    # depends_on("raja+rocm", when="+rocm")
-    # depends_on("raja+cuda", when="+cuda")
-    # depends_on("raja", when="~rocm~cuda")
-
     requires("+caliper", when="^hypre+caliper")
 
     def configure(self, spec, prefix):
@@ -68,9 +63,5 @@ class Mfem(BuiltinMfem):
             options.append("CALIPER_DIR=%s" % self.spec["caliper"].prefix)
             options.append("MFEM_USE_ADIAK=%s" % yes_no("+adiak"))
             options.append("ADIAK_DIR=%s" % self.spec["adiak"].prefix)
-
-        # MFEM upstream should handle this
-        # if "+raja" in self.spec:
-        #     options.append("MFEM_USE_RAJA=YES")
 
         return options

--- a/repos/spack_repo/benchpark/packages/mfem/package.py
+++ b/repos/spack_repo/benchpark/packages/mfem/package.py
@@ -20,9 +20,10 @@ class Mfem(BuiltinMfem):
     depends_on("adiak", when="+caliper")
     depends_on("hypre+shared", when="+mpi~cuda")
 
-    depends_on("raja+rocm", when="+rocm")
-    depends_on("raja+cuda", when="+cuda")
-    depends_on("raja", when="~rocm~cuda")
+    # MFEM upstream may already handle this
+    # depends_on("raja+rocm", when="+rocm")
+    # depends_on("raja+cuda", when="+cuda")
+    # depends_on("raja", when="~rocm~cuda")
 
     requires("+caliper", when="^hypre+caliper")
 
@@ -68,7 +69,8 @@ class Mfem(BuiltinMfem):
             options.append("MFEM_USE_ADIAK=%s" % yes_no("+adiak"))
             options.append("ADIAK_DIR=%s" % self.spec["adiak"].prefix)
 
-        if "+raja" in self.spec:
-            options.append("MFEM_USE_RAJA=YES")
+        # MFEM upstream should handle this
+        # if "+raja" in self.spec:
+        #     options.append("MFEM_USE_RAJA=YES")
 
         return options

--- a/repos/spack_repo/benchpark/packages/mfem/package.py
+++ b/repos/spack_repo/benchpark/packages/mfem/package.py
@@ -20,6 +20,10 @@ class Mfem(BuiltinMfem):
     depends_on("adiak", when="+caliper")
     depends_on("hypre+shared", when="+mpi~cuda")
 
+    depends_on("raja+rocm", when="+rocm")
+    depends_on("raja+cuda", when="+cuda")
+    depends_on("raja", when="~rocm~cuda")
+
     requires("+caliper", when="^hypre+caliper")
 
     def configure(self, spec, prefix):
@@ -63,5 +67,8 @@ class Mfem(BuiltinMfem):
             options.append("CALIPER_DIR=%s" % self.spec["caliper"].prefix)
             options.append("MFEM_USE_ADIAK=%s" % yes_no("+adiak"))
             options.append("ADIAK_DIR=%s" % self.spec["adiak"].prefix)
+
+        if "+raja" in self.spec:
+            options.append("MFEM_USE_RAJA=YES")
 
         return options


### PR DESCRIPTION
## Description

- [x] Enable setting up mfem+raja for laghos
- [x] The upstream mfem package in spack-packages already handles the logic for using raja+cuda or +rocm etc.