### PR TITLE
Bugfix for branson CUDA build

### DIFF
--- a/experiments/branson/experiment.py
+++ b/experiments/branson/experiment.py
@@ -95,7 +95,7 @@ class Branson(
             self.add_experiment_variable("num_particles", photons, True)
         self.add_experiment_variable("resource_count", 4, False)
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-            self.add_experiment_variable("pool", 64, False)
+            self.add_experiment_variable("pool", 32, False)
 
         self.register_scaling_config(
             {

--- a/repos/spack_repo/benchpark/packages/branson/package.py
+++ b/repos/spack_repo/benchpark/packages/branson/package.py
@@ -95,21 +95,19 @@ class Branson(CMakePackage, CudaPackage, ROCmPackage):
               args.append(f"-DCUDA_ARCH={cuda_arch}")
         else:
             args.append("-DUSE_CUDA=OFF")
-            args.append("-DUSE_GPU=OFF")
-
-        if '+rocm' in spec:
-            args.append("-DUSE_HIP=ON")
-            args.append("-DUSE_GPU=ON")
-            rocm_arch_vals = spec.variants["amdgpu_target"].value
-            args.append(f"-DROCM_PATH={spec['hip'].prefix}")
-            if rocm_arch_vals:
-              rocm_arch_sorted = list(sorted(rocm_arch_vals, reverse=True))
-              rocm_arch = rocm_arch_sorted[0]
-              args.append(f"-DROCM_ARCH={rocm_arch}")
-              args.append(f"-DHIP_ARCH={rocm_arch}")
-        else:
-            args.append("-DUSE_HIP=OFF")
-            args.append("-DUSE_GPU=OFF")
+            if '+rocm' in spec:
+                args.append("-DUSE_HIP=ON")
+                args.append("-DUSE_GPU=ON")
+                rocm_arch_vals = spec.variants["amdgpu_target"].value
+                args.append(f"-DROCM_PATH={spec['hip'].prefix}")
+                if rocm_arch_vals:
+                  rocm_arch_sorted = list(sorted(rocm_arch_vals, reverse=True))
+                  rocm_arch = rocm_arch_sorted[0]
+                  args.append(f"-DROCM_ARCH={rocm_arch}")
+                  args.append(f"-DHIP_ARCH={rocm_arch}")
+            else:
+                args.append("-DUSE_HIP=OFF")
+                args.append("-DUSE_GPU=OFF")
 
         if '+umpire' in spec:
             args.append("-DUSE_UMPIRE=ON")


### PR DESCRIPTION
## Description
This PR fixes a bug in compiler flags used to enable CUDA build

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If modifying the source code of a benchmark: create, self-assign, and link here a follow up issue with a link to the PR in the benchmark repo. https://github.com/lanl/branson/pull/67
- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define an experiment