### PR TITLE
changes to fix benchpark mirroring

### DIFF
--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -177,7 +177,6 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
     out, err = run_command(
         f"spack -e {env_dir} python {repo_copy_script} {git_repo_dst}"
     )
-    script_output = out.strip()
 
     git_redirect_script = os.path.join(
         paths.benchpark_root, "lib", "scripts", "redirect-git-urls.py"

--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -178,25 +178,25 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
         f"spack -e {env_dir} python {repo_copy_script} {git_repo_dst}"
     )
     script_output = out.strip()
-    if script_output:
-        copied_pkgs = script_output.split("\n")
-    else:
-        copied_pkgs = []
-    git_redirects = list()
-    for pkg_name in copied_pkgs:
-        git_url = f"$this_script_dir/git-repos/{pkg_name}"
-        git_redirects.append(
-            f"spack config --scope=spack add packages:{pkg_name}:package_attributes:git:{git_url}"
-        )
-    git_redirects = "\n".join(git_redirects)
+
+    git_redirect_script = os.path.join(
+        paths.benchpark_root, "lib", "scripts", "redirect-git-urls.py"
+    )
+    shutil.copyfile(git_redirect_script, os.path.join(dest, "redirect-git-urls.py"))
 
     delete_configs_in(os.path.join(spack_dest, "etc", "spack"))
     delete_configs_in(os.path.join(ramble_dest, "etc", "ramble"))
+
     first_time_dest = os.path.join(dest, "first-time.sh")
+    benchpark_workspace_relative = pathlib.Path(ramble_workspace_relative).parts[0]
     if not os.path.exists(first_time_dest):
         with open(first_time_dest, "w", encoding="utf-8") as f:
             f.write(f"""\
 this_script_dir=$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)
+
+venv_dir="$this_script_dir/mirror-venv"
+python3 -m venv $venv_dir && . $venv_dir/bin/activate
+pip install --no-index --find-links="$this_script_dir/pip-cache" "$this_script_dir/pip-cache"/*
 
 . $this_script_dir/setup.sh
 
@@ -205,8 +205,7 @@ spack repo add --scope=spack $this_script_dir/spack-packages/repos/spack_repo/bu
 spack repo add --scope=spack $this_script_dir/repos/spack_repo/benchpark/
 spack config --scope=spack add "config:misc_cache:$this_script_dir/spack-misc-cache"
 spack bootstrap add --scope=spack --trust local-sources "$this_script_dir/spack-bootstrap-mirror/metadata/sources/"
-# We store local copies of git repos for packages that install branch tips
-{git_redirects}
+spack python $this_script_dir/redirect-git-urls.py $this_script_dir/{benchpark_workspace_relative}
 
 # We deleted the repo config because it may have absolute paths;
 # it is reinstantiated here

--- a/lib/benchpark/cmd/mirror.py
+++ b/lib/benchpark/cmd/mirror.py
@@ -136,9 +136,22 @@ def mirror_create(args):
     if not os.path.exists(ramble_workspace_dest):
         shutil.copytree(ramble_workspace, ramble_workspace_dest, ignore=_ignore)
 
+    known_bad_paths = [
+        "lib/spack/docs/_static/spack-logo-text.svg",
+        "lib/spack/docs/_static/spack-logo-white-text.svg",
+    ]
+
+    for relpath in known_bad_paths:
+        (pathlib.Path(spack_instance) / relpath).unlink(missing_ok=True)
+
     spack_dest = os.path.join(dest, "spack")
     if not os.path.exists(spack_dest):
         copytree_tracked(spack_instance, spack_dest)
+
+    pkgs_wkp = os.path.join(workspace, "spack-packages")
+    pkgs_dest = os.path.join(dest, "spack-packages")
+    if not os.path.exists(pkgs_dest):
+        copytree_tracked(pkgs_wkp, pkgs_dest)
 
     ramble_dest = os.path.join(dest, "ramble")
     if not os.path.exists(ramble_dest):
@@ -164,12 +177,16 @@ export SPACK_DISABLE_LOCAL_CONFIG=1
     out, err = run_command(
         f"spack -e {env_dir} python {repo_copy_script} {git_repo_dst}"
     )
-    copied_pkgs = out.strip().split("\n")
+    script_output = out.strip()
+    if script_output:
+        copied_pkgs = script_output.split("\n")
+    else:
+        copied_pkgs = []
     git_redirects = list()
     for pkg_name in copied_pkgs:
         git_url = f"$this_script_dir/git-repos/{pkg_name}"
         git_redirects.append(
-            f"spack config --scope=site add packages:{pkg_name}:package_attributes:git:{git_url}"
+            f"spack config --scope=spack add packages:{pkg_name}:package_attributes:git:{git_url}"
         )
     git_redirects = "\n".join(git_redirects)
 
@@ -184,15 +201,16 @@ this_script_dir=$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)
 . $this_script_dir/setup.sh
 
 spack uninstall -ay
-spack repo add --scope=site $this_script_dir/repo
-spack config --scope=site add "config:misc_cache:$this_script_dir/spack-misc-cache"
-spack bootstrap add --scope=site --trust local-sources "$this_script_dir/spack-bootstrap-mirror/metadata/sources/"
+spack repo add --scope=spack $this_script_dir/spack-packages/repos/spack_repo/builtin/
+spack repo add --scope=spack $this_script_dir/repos/spack_repo/benchpark/
+spack config --scope=spack add "config:misc_cache:$this_script_dir/spack-misc-cache"
+spack bootstrap add --scope=spack --trust local-sources "$this_script_dir/spack-bootstrap-mirror/metadata/sources/"
 # We store local copies of git repos for packages that install branch tips
 {git_redirects}
 
 # We deleted the repo config because it may have absolute paths;
 # it is reinstantiated here
-ramble repo add --scope=site $this_script_dir/repo
+ramble repo add --scope=site $this_script_dir/repos/ramble_applications/
 ramble repo add -t modifiers --scope=site $this_script_dir/modifiers
 ramble config --scope=site add "config:disable_progress_bar:true"
 ramble config --scope=site add \"config:spack:global:args:'-d'\"
@@ -203,8 +221,8 @@ ramble config --scope=site add \"config:spack:global:args:'-d'\"
     if not os.path.exists(modifiers_dest):
         shutil.copytree(modifiers_src, modifiers_dest)
 
-    bp_repo_dest = os.path.join(dest, "repo")
-    bp_repo_src = os.path.join(paths.benchpark_root, "repo")
+    bp_repo_dest = os.path.join(dest, "repos")
+    bp_repo_src = os.path.join(paths.benchpark_root, "repos")
     if not os.path.exists(bp_repo_dest):
         shutil.copytree(bp_repo_src, bp_repo_dest)
 

--- a/lib/scripts/env-collect-branch-tips.py
+++ b/lib/scripts/env-collect-branch-tips.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 
 import spack.environment as ev
+import spack.repo
 from spack.fetch_strategy import GitFetchStrategy
 
 
@@ -10,14 +11,20 @@ def main():
     destination = sys.argv[1]
 
     e = ev.active_environment()
-    for _, spec in e.concretized_specs():
-        df = spec.package.stage[0].default_fetcher
+    for spec in e.all_specs():
+        if spec.external:
+            continue
+        pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
+        derived_spec = spack.spec.Spec(spec.name)
+        derived_spec.versions = spec.versions
+        pkg_obj = pkg_cls(derived_spec)
+        df = pkg_obj.stage[0].default_fetcher
         if not df.cachable and isinstance(df, GitFetchStrategy):
             df.get_full_repo = True
             pkg_dst = os.path.join(destination, spec.name)
             if not os.path.exists(pkg_dst):
-                spec.package.stage.fetch()
-                shutil.move(spec.package.stage.source_path, pkg_dst)
+                pkg_obj.stage.fetch()
+                shutil.move(pkg_obj.stage.source_path, pkg_dst)
             print(f"{spec.name}")
 
 

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -1,8 +1,8 @@
-import spack.config as config
-import spack.util.spack_yaml as syaml
-
 from pathlib import Path
 import sys
+
+import spack.config as config
+import spack.util.spack_yaml as syaml
 
 
 def find_dir(root, target_name):

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -1,5 +1,5 @@
-import spack.util.spack_yaml as syaml
 import spack.config as config
+import spack.util.spack_yaml as syaml
 
 from pathlib import Path
 import sys

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -4,12 +4,14 @@ import spack.config as config
 from pathlib import Path
 import sys
 
+
 def find_dir(root, target_name):
     root = Path(root)
     for path in root.rglob("*"):
         if path.is_dir() and path.name == target_name:
             return path.resolve()
     return None
+
 
 def main(benchpark_wkp_dir):
     base_dir = Path(__file__).resolve().parents[0]
@@ -26,8 +28,9 @@ def main(benchpark_wkp_dir):
         attrs_cfg = pkg_cfg.setdefault("package_attributes", {})
         attrs_cfg["git"] = str(repo_path)
 
-    #import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
     cfg.set("packages", pkgs_cfg, "auxpath")
+
 
 if __name__ == "__main__":
     main(sys.argv[1])

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -1,0 +1,33 @@
+import spack.util.spack_yaml as syaml
+import spack.config as config
+
+from pathlib import Path
+import sys
+
+def find_dir(root, target_name):
+    root = Path(root)
+    for path in root.rglob("*"):
+        if path.is_dir() and path.name == target_name:
+            return path.resolve()
+    return None
+
+def main(benchpark_wkp_dir):
+    base_dir = Path(__file__).resolve().parents[0]
+    git_repos_dir = base_dir / "git-repos"
+
+    cfg_path = find_dir(benchpark_wkp_dir, "auxiliary_software_files")
+    ds = config.DirectoryConfigScope("auxpath", cfg_path)
+    cfg = config.create_from(ds)
+    pkgs_cfg = cfg.get("packages")
+
+    for repo_path in git_repos_dir.iterdir():
+        pkg_name = repo_path.parts[-1]
+        pkg_cfg = pkgs_cfg.setdefault(pkg_name, {})
+        attrs_cfg = pkg_cfg.setdefault("package_attributes", {})
+        attrs_cfg["git"] = str(repo_path)
+
+    #import pdb; pdb.set_trace()
+    cfg.set("packages", pkgs_cfg, "auxpath")
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 
 import spack.config as config
-import spack.util.spack_yaml as syaml
 
 
 def find_dir(root, target_name):

--- a/lib/scripts/redirect-git-urls.py
+++ b/lib/scripts/redirect-git-urls.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import spack.config as config
 import spack.util.spack_yaml as syaml


### PR DESCRIPTION
`benchpark mirror create` (from https://github.com/llnl/benchpark/pull/620) has fallen behind updates to spack pin (e.g. the splitting off of `builtin` repo)

This brings it up to date.