### PR TITLE
Update versions for `raja-perf` and `raja`

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -31,8 +31,8 @@ class RajaPerf(
 
     variant(
         "version",
-        default="2025.03.0",
-        values=("develop", "latest", "2025.03.0", "2024.07.0"),
+        default="2025.12.1",
+        values=("develop", "latest", "2025.12.1", "2025.03.0", "2024.07.0"),
         description="app version",
     )
 

--- a/repos/spack_repo/benchpark/packages/raja/package.py
+++ b/repos/spack_repo/benchpark/packages/raja/package.py
@@ -10,6 +10,12 @@ from spack_repo.builtin.packages.raja.package import Raja as BuiltinRaja
 class Raja(BuiltinRaja):
 
     version(
+        "2025.12.2",
+        tag="v2025.12.2",
+        commit="eca7c5015a5cf8bf7cc8ad1829fd36d3276ab274",
+        submodules=False,
+    )
+    version(
         "2025.12.1",
         tag="v2025.12.1",
         commit="3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2",

--- a/repos/spack_repo/benchpark/packages/raja_perf/package.py
+++ b/repos/spack_repo/benchpark/packages/raja_perf/package.py
@@ -20,6 +20,20 @@ from spack_repo.builtin.packages.raja_perf.package import RajaPerf as BuiltinRaj
 class RajaPerf(BuiltinRajaPerf):
     """RAJA Performance Suite."""
 
+
+    version(
+        "2025.12.1",
+        tag="v2025.12.1",
+        commit="e3c6197dfa8f1c9ac61635c26775c333411bdcd5",
+        submodules=True,
+    )
+    version(
+        "2025.12.0",
+        tag="v2025.12.0",
+        commit="f2ad263e08db89327ceccaa9a6c1e994b6d24e67",
+        submodules=True,
+    )
+
     def setup_build_environment(self, env):
         super().setup_build_environment(env)
         if "+cuda" in self.spec:

--- a/repos/spack_repo/benchpark/packages/raja_perf/package.py
+++ b/repos/spack_repo/benchpark/packages/raja_perf/package.py
@@ -20,7 +20,6 @@ from spack_repo.builtin.packages.raja_perf.package import RajaPerf as BuiltinRaj
 class RajaPerf(BuiltinRajaPerf):
     """RAJA Performance Suite."""
 
-
     version(
         "2025.12.1",
         tag="v2025.12.1",


### PR DESCRIPTION
## Description

- [x] Add `v2025.12.1` latest version available to the `raja-perf` experiment. `2025.12.0` is also in the package, but we typically only enumerate minor versions in the experiment (there usually isn't a reason to compare these two).
- [x] Add latest `2025.12.2` version of `raja`. This actually doesn't matter for `raja-perf` because it uses submodules, but is useful for other packages.
