### PR TITLE
avoid inserting -lmpi_gtl_hsa for caliper build

### DIFF
--- a/repos/spack_repo/benchpark/packages/caliper/package.py
+++ b/repos/spack_repo/benchpark/packages/caliper/package.py
@@ -14,5 +14,10 @@ class Caliper(BuiltinCaliper):
     directly into applications and activate them at runtime.
     """
 
+    def setup_build_environment(self, env):
+        # Do not insert -lmpi_gtl_hsa, this seems to cause a hang when doing
+        # rocm profiling in caliper
+        env.set("SPACK_GTL", "diverted")
+
     # rocp_sdk broken in upstream papi package for any ver less than 7.2
     depends_on("papi@7.2:+topdown", when="+papi")


### PR DESCRIPTION
@rfhaque noticed the benchpark/spack build of amg2023 with Caliper ROCm profiling on was hanging

I was able to reproduce that, and it seems that building Caliper with `-lmpi_gtl_hsa` is causing this hang. I don't know enough about Caliper to know why that would be a problem.