### PR TITLE
Remhos changes

### DIFF
--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -72,7 +72,8 @@ class Remhos(
         self.add_experiment_variable("ms", 5, False)
 
         # resource_count is the number of resources used for this experiment:
-        self.add_experiment_variable("resource_count", 1, False)
+        self.add_experiment_variable("resource_count", 4, False)
+        self.add_experiment_variable("pool", 120, False)
 
         # Set the variables required by the experiment
         self.set_required_variables(
@@ -109,9 +110,15 @@ class Remhos(
         )
 
         if self.spec.satisfies("+cuda"):
-            self.add_experiment_variable("device", "cuda", True)
+            if self.spec.satisfies("+raja"):
+                self.add_experiment_variable("device", "raja-gpu", True)
+            else:
+                self.add_experiment_variable("device", "cuda", True)
         elif self.spec.satisfies("+rocm"):
-            self.add_experiment_variable("device", "hip", True)
+            if self.spec.satisfies("+raja"):
+                self.add_experiment_variable("device", "raja-gpu", True)
+            else:
+                self.add_experiment_variable("device", "hip", True)
         else:
             self.add_experiment_variable("device", "cpu", True)
 

--- a/experiments/remhos/experiment.py
+++ b/experiments/remhos/experiment.py
@@ -42,6 +42,13 @@ class Remhos(
         description="Use GPU-aware MPI",
     )
 
+    variant(
+        "raja",
+        default=True,
+        values=(True, False),
+        description="Use RAJA backend for MFEM",
+    )
+
     maintainers("rfhaque")
 
     def compute_applications_section(self):
@@ -133,9 +140,12 @@ class Remhos(
 
     def compute_package_section(self):
         gam = "~gpu-aware-mpi"
+        raja = "~raja"
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             if self.spec.satisfies("+gpu-aware-mpi"):
                 gam = "+gpu-aware-mpi"
+        if self.spec.satisfies("+raja"):
+            raja = "+raja"
         self.add_package_spec(
-            self.name, [f"remhos{self.determine_version()} +metis {gam}"]
+            self.name, [f"remhos{self.determine_version()} +metis {gam} {raja}"]
         )

--- a/repos/ramble_applications/remhos/application.py
+++ b/repos/ramble_applications/remhos/application.py
@@ -30,6 +30,7 @@ class Remhos(ExecutableApplication):
                      ' -vs {vs}' +
                      ' -ms {ms}' +
                      ' -no-vis' +
+                     ' --dev-pool-size {pool}' +
                      ' -pa' +
                      ' -d {device}' +
                      ' {gam}',
@@ -46,6 +47,7 @@ class Remhos(ExecutableApplication):
                      ' -vs {vs}' +
                      ' -ms {ms}' +
                      ' -no-vis' +
+                     ' --dev-pool-size {pool}' +
                      ' -pa' +
                      ' -d {device}' +
                      ' {gam}',
@@ -98,8 +100,12 @@ class Remhos(ExecutableApplication):
         description='ms',
         workloads=['2d','3d'])
 
+    workload_variable('pool', default='4',
+        description='Device pool size',
+        workloads=['2d', '3d'])
+
     workload_variable('device', default='cpu',
-        description='cpu, cuda or hip',
+        description='cpu, cuda, hip or raja-gpu',
         workloads=['2d','3d'])
 
     workload_variable('gam', default='--no-gpu-aware-mpi',


### PR DESCRIPTION
## Description
This PR adds
- [x] raja variant to remhos experiment.py
- [x] sets the input `device` parameter to `raja-gpu` when `+raja`
- [x] enables raja in remhos/mfem when `+raja`
- [x] adds input parameter for device pool size

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If application.py upstreamed to Ramble is insufficient, add/modify `repo/benchmark_name/application.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Ramble repo.
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define an experiment