### PR TITLE
AMG2023 allow hypre version v3+

### DIFF
--- a/repos/spack_repo/benchpark/packages/amg2023/package.py
+++ b/repos/spack_repo/benchpark/packages/amg2023/package.py
@@ -43,7 +43,6 @@ class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hypre~caliper")
     depends_on("hypre@:2.29.0", when="@20240511")
     depends_on("hypre@2.30.0:", when="@develop")
-    depends_on("hypre@:2.99")
     depends_on("hypre~fortran")
     depends_on("hypre+mixedint", when="+mixedint")
     depends_on("blas")


### PR DESCRIPTION
## Description
This PR allows amg to use the latest hypre version

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If package.py upstreamed to Spack is insufficient, add/modify `repo/benchmark_name/package.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Spack repo.