### PR TITLE
Create separate modifier options for profiling GPU kernels

### DIFF
--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -94,13 +94,13 @@ class Caliper(BasicModifier):
     )
 
     add_mode(
-        mode_name="cuda-gpu",
+        mode_name="cuda-gputime",
         mode_option="cuda.gputime",
         description="Profile time spent in GPU kernels",
     )
 
     add_mode(
-        mode_name="rocm-gpu",
+        mode_name="rocm-gputime",
         mode_option="rocm.gputime",
         description="Profile time spent in GPU kernels",
     )

--- a/modifiers/caliper/modifier.py
+++ b/modifiers/caliper/modifier.py
@@ -83,14 +83,26 @@ class Caliper(BasicModifier):
 
     add_mode(
         mode_name="cuda",
-        mode_option="profile.cuda,cuda.gputime",
-        description="Profile CUDA API functions, time spent on GPU",
+        mode_option="profile.cuda",
+        description="Profile CUDA API functions",
     )
 
     add_mode(
         mode_name="rocm",
-        mode_option="profile.hip,rocm.gputime",
-        description="Profile HIP API functions, time spent on GPU",
+        mode_option="profile.hip",
+        description="Profile HIP API functions",
+    )
+
+    add_mode(
+        mode_name="cuda-gpu",
+        mode_option="cuda.gputime",
+        description="Profile time spent in GPU kernels",
+    )
+
+    add_mode(
+        mode_name="rocm-gpu",
+        mode_option="rocm.gputime",
+        description="Profile time spent in GPU kernels",
     )
 
     add_mode(


### PR DESCRIPTION
## Description
This PR creates a separate caliper modifier option in benchpark for profiling GPU activities
- `cuda-gpu` enables `cuda.gputime`
- `rocm-gpu` enables `rocm.gputime`

The existing GPU modifier options are changed to only support profiling the host-side CUDA and HIP API functions
- `caliper=cuda` only enables `profile.cuda`
- `caliper=rocm` only enables `profile.rocm`

A benchmark that wants to enable host and/or device profiling must provide the appropriate options explicitly e.g. `amg2023 +rocm caliper=rocm,rocm-gpu` enables `profile.rocm,rocm.gputime`

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] Add/modify `modifiers/benchmark_name/modifier.py` to define a modifier