### PR TITLE
Benchpark gets its first Fluxtainer

### DIFF
--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -21,6 +21,7 @@ SKIP_EXPR = [
     "stream aws-pcluster instance_type=c4.xlarge",
     "stream cscs-daint",
     "stream generic-x86",
+    "stream fluxtainer"
     # Broken URL's in application.py going to cause dryrun failure
     "genesis",
     # Not ProgrammingModelType.Mpionly

--- a/.github/utils/dryruns.py
+++ b/.github/utils/dryruns.py
@@ -21,7 +21,7 @@ SKIP_EXPR = [
     "stream aws-pcluster instance_type=c4.xlarge",
     "stream cscs-daint",
     "stream generic-x86",
-    "stream fluxtainer"
+    "stream fluxtainer",
     # Broken URL's in application.py going to cause dryrun failure
     "genesis",
     # Not ProgrammingModelType.Mpionly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       license: ${{ steps.filter.outputs.license }}
       diffpackages: ${{ steps.filter.outputs.diffpackages }}
       modified_repo_dirs: ${{ steps.get_modified_repo_dirs.outputs.modified_repo_dirs }}
-      containers: ${{ steps.filter.outputs.container }}
+      containers: ${{ steps.filter.outputs.containers }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       license: ${{ steps.filter.outputs.license }}
       diffpackages: ${{ steps.filter.outputs.diffpackages }}
       modified_repo_dirs: ${{ steps.get_modified_repo_dirs.outputs.modified_repo_dirs }}
+      containers: ${{ steps.filter.outputs.container }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'pull_request' }}
@@ -105,6 +106,9 @@ jobs:
               - 'var/**'
             diffpackages:
               - 'repo/**/package.py'
+            containers:
+              - 'containerfiles/**'
+              - 'systems/fluxtainer/**'
       - name: Get modified directories in repo/
         id: get_modified_repo_dirs
         run: |
@@ -155,6 +159,9 @@ jobs:
     uses: ./.github/workflows/diffpackages.yml
     with:
       modified_repo_dirs: ${{ needs.changes.outputs.modified_repo_dirs }}
+  containers:
+    if: ${{ needs.changes.outputs.containers == 'true' }}
+    needs: changes
   all:
     needs:
       - changes
@@ -164,6 +171,7 @@ jobs:
       - coverage
       - license
       - diffpackages
+      - containers
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
   containers:
     if: ${{ needs.changes.outputs.containers == 'true' }}
     needs: changes
+    uses: ./.github/workflows/containers.yml
   all:
     needs:
       - changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
   containers:
     if: ${{ needs.changes.outputs.containers == 'true' }}
     needs: changes
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/containers.yml
   all:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/containers.yml
   all:
     needs:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,6 +34,7 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,71 @@
+name: Build and Push Benchpark Container
+
+on:
+  # Run weekly on Sundays at 2 AM UTC
+  schedule:
+    - cron: '0 2 * * 0'
+  
+  # Allow manual trigger
+  workflow_dispatch:
+  
+  # Run on pushes to main that modify the Dockerfile
+  push:
+    branches:
+      - main
+    paths:
+      - 'containerfiles/flux/el10/Dockerfile'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/benchpark-flux-el10
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./containerfiles/flux/el10/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,9 +1,6 @@
 name: Build and Push Benchpark Container
 on:
   workflow_call:
-    paths:
-      - containerfiles/flux/el10/Dockerfile
-      - systems/fluxtainer/system.py
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/benchpark-flux-el10

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,15 +1,9 @@
 name: Build and Push Benchpark Container
 on:
-  # Run weekly on Sundays at 2 AM UTC
-  schedule:
-    - cron: 0 2 * * 0
-
-  # Allow manual trigger
-  workflow_dispatch:
-  # Run on pushes to main that modify the Dockerfile
-  push:
-    branches: [main]
-    paths: [containerfiles/flux/el10/Dockerfile]
+  workflow_call:
+    paths:
+      - containerfiles/flux/el10/Dockerfile
+      - systems/fluxtainer/system.py
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/benchpark-flux-el10

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,45 +1,35 @@
 name: Build and Push Benchpark Container
-
 on:
   # Run weekly on Sundays at 2 AM UTC
   schedule:
-    - cron: '0 2 * * 0'
-  
+    - cron: 0 2 * * 0
+
   # Allow manual trigger
   workflow_dispatch:
-  
   # Run on pushes to main that modify the Dockerfile
   push:
-    branches:
-      - main
-    paths:
-      - 'containerfiles/flux/el10/Dockerfile'
-
+    branches: [main]
+    paths: [containerfiles/flux/el10/Dockerfile]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/benchpark-flux-el10
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -50,7 +40,6 @@ jobs:
             type=ref,event=branch
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -62,7 +51,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
-
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -29,7 +29,7 @@ jobs:
           tags: |
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 versions:
-  ramble: 55d53d0  # develop on 12/20/2025 (newer than 0.6.0 release)
+  ramble: 100f97d  # develop on 04/25/2026 (newer than 0.6.0 release)
   spack: a85ec51  # Dec. 1 2025 v1.1.0
   spack-packages: 0a42215  # Jan. 20 2026

--- a/containerfiles/entrypoint.sh
+++ b/containerfiles/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Source benchpark environment
+source /home/fluxuser/benchpark/setup-env.sh
+
+# Start flux with bash
+exec /usr/bin/flux start -s4 /bin/bash

--- a/containerfiles/flux/el10/Dockerfile
+++ b/containerfiles/flux/el10/Dockerfile
@@ -1,9 +1,32 @@
 FROM fluxrm/flux-core:el10
 
-RUN git clone https://github.com/llnl/benchpark.git && \
-	cd benchpark && \
-	pip install --upgrade pip && \
-	pip install -r requirements.txt && \
-	./bin/benchpark list systems
+USER root
 
-ENTRYPOINT ["/usr/bin/flux", "start", "-s4", "/bin/bash"]
+RUN dnf clean all \
+	&& rm -rf /var/cache/dnf \
+	&& git config --global checkout.workers 1024 \
+	&& git config --global feature.manyFiles true \
+	&& echo "* soft memlock unlimited" >> /etc/security/limits.conf \
+    && echo "* hard memlock unlimited" >> /etc/security/limits.conf
+
+USER fluxuser
+
+RUN git clone https://github.com/LLNL/mpibind.git \
+	&& mkdir build \
+	&& cd mpibind \
+	&& ./bootstrap \
+	&& ./configure --prefix=$(pwd)/../build \
+	&& make -j install
+
+ENV FLUX_SHELL_RC_PATH=/home/fluxuser/build/share/mpibind:$FLUX_SHELL_RC_PATH
+
+COPY --chown=fluxuser:fluxuser . /home/fluxuser/benchpark
+
+WORKDIR /home/fluxuser/benchpark
+
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt \
+	&& ./bin/benchpark bootstrap \
+	&& echo 'source /home/fluxuser/benchpark/setup-env.sh' >> /home/fluxuser/.bashrc
+
+ENTRYPOINT ["/home/fluxuser/benchpark/containerfiles/entrypoint.sh"]

--- a/containerfiles/flux/el10/Dockerfile
+++ b/containerfiles/flux/el10/Dockerfile
@@ -1,0 +1,9 @@
+FROM fluxrm/flux-core:el10
+
+RUN git clone https://github.com/llnl/benchpark.git && \
+	cd benchpark && \
+	pip install --upgrade pip && \
+	pip install -r requirements.txt && \
+	./bin/benchpark list systems
+
+ENTRYPOINT ["/usr/bin/flux", "start", "-s4", "/bin/bash"]

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -107,7 +107,7 @@ class OsuMicroBenchmarks(
 
     def compute_applications_section(self):
 
-        num_nodes = {"n_nodes": 2, "n_ranks": 1}
+        num_nodes = {"n_nodes": 2, "n_ranks": 2}
 
         if self.spec.satisfies("exec_mode=test"):
             for pk, pv in num_nodes.items():

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -119,7 +119,7 @@ class OsuMicroBenchmarks(
             self.add_experiment_variable("additional_args", " -d cuda", False)
         if self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda"):
             resource = "n_gpus"
-            self.add_experiment_variable("n_gpus", 1, True)
+            self.add_experiment_variable("n_gpus", 2, True)
         else:
             resource = "n_nodes"
 

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -15,12 +15,8 @@ class Fluxtainer(System):
     maintainers("nhanford")
 
     id_to_resources = {
-        "arm": {
-            "cpu_arch": "arm64"
-        },
-        "x86": {
-            "cpu_arch": "x86_64_v3"
-        },
+        "arm": {"cpu_arch": "arm64"},
+        "x86": {"cpu_arch": "x86_64_v3"},
     }
 
     variant(

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -17,13 +17,13 @@ class Fluxtainer(System):
     id_to_resources = {
         "arm": {
             "cpu_arch": "arm64",
-            "sys_cores_per_node": 32,
+            "sys_cores_per_node": 8,
             "sys_mem_per_node_GB": 1,
             "n_nodes": 4,
         },
         "x86": {
             "cpu_arch": "x86_64_v3",
-            "sys_cores_per_node": 32,
+            "sys_cores_per_node": 8,
             "sys_mem_per_node_GB": 1,
             "n_nodes": 4,
         },
@@ -41,7 +41,7 @@ class Fluxtainer(System):
         self.programming_models = [OpenMPCPUOnlySystem()]
 
         self.scheduler = "flux"
-        setattr(self, "sys_cores_per_node", 32)
+        setattr(self, "sys_cores_per_node", 8)
         setattr(self, "sys_mem_per_node_GB", 2)
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -16,16 +16,10 @@ class Fluxtainer(System):
 
     id_to_resources = {
         "arm": {
-            "cpu_arch": "arm64",
-            "sys_cores_per_node": 8,
-            "sys_mem_per_node_GB": 1,
-            "n_nodes": 4,
+            "cpu_arch": "arm64"
         },
         "x86": {
-            "cpu_arch": "x86_64_v3",
-            "sys_cores_per_node": 8,
-            "sys_mem_per_node_GB": 1,
-            "n_nodes": 4,
+            "cpu_arch": "x86_64_v3"
         },
     }
 
@@ -42,7 +36,8 @@ class Fluxtainer(System):
 
         self.scheduler = "flux"
         setattr(self, "sys_cores_per_node", 8)
-        setattr(self, "sys_mem_per_node_GB", 2)
+        setattr(self, "sys_mem_per_node_GB", 1)
+        setattr(self, "n_nodes", 4)
         attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
         for k, v in attrs.items():
             setattr(self, k, v)

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -26,15 +26,12 @@ class Fluxtainer(System):
             "sys_cores_per_node": 32,
             "sys_mem_per_node_GB": 1,
             "n_nodes": 4,
-        }
+        },
     }
 
     variant(
         "instance_type",
-        values=(
-            "arm",
-            "x86"
-        ),
+        values=("arm", "x86"),
         default="x86",
         description="Target Architecture",
     )

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -173,7 +173,6 @@ class Fluxtainer(System):
                 "packages": {
                     "compiler-gcc": {"pkg_spec": "gcc@14.3.1"},
                     "default-compiler": {"pkg_spec": "gcc"},
-                    "compiler-gcc": {"pkg_spec": "gcc@14.3.1"},
                     "default-mpi": {"pkg_spec": "mpich"},
                 }
             }

--- a/systems/fluxtainer/system.py
+++ b/systems/fluxtainer/system.py
@@ -1,0 +1,183 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# Benchpark Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from benchpark.directives import maintainers, variant
+from benchpark.openmpsystem import OpenMPCPUOnlySystem
+from benchpark.system import System, compiler_def, compiler_section_for
+
+
+class Fluxtainer(System):
+    """This is the generic system class for an x86 system, gcc compiler, mpi.
+    It can be easily copied and modified to model other systems."""
+
+    maintainers("nhanford")
+
+    id_to_resources = {
+        "arm": {
+            "cpu_arch": "arm64",
+            "sys_cores_per_node": 32,
+            "sys_mem_per_node_GB": 1,
+            "n_nodes": 4,
+        },
+        "x86": {
+            "cpu_arch": "x86_64_v3",
+            "sys_cores_per_node": 32,
+            "sys_mem_per_node_GB": 1,
+            "n_nodes": 4,
+        }
+    }
+
+    variant(
+        "instance_type",
+        values=(
+            "arm",
+            "x86"
+        ),
+        default="x86",
+        description="Target Architecture",
+    )
+
+    def __init__(self, spec):
+        super().__init__(spec)
+        self.programming_models = [OpenMPCPUOnlySystem()]
+
+        self.scheduler = "flux"
+        setattr(self, "sys_cores_per_node", 32)
+        setattr(self, "sys_mem_per_node_GB", 2)
+        attrs = self.id_to_resources.get(self.spec.variants["instance_type"][0])
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+    def compute_compilers_section(self):
+        return compiler_section_for(
+            "gcc",
+            [
+                compiler_def(
+                    "gcc@14.3.1 languages=c,c++,fortran",
+                    "/usr/",
+                    {"c": "gcc", "cxx": "g++", "fortran": "gfortran"},
+                )
+            ],
+        )
+
+    def compute_packages_section(self):
+        return {
+            "packages": {
+                "mpi": {"buildable": False},
+                "mpich": {
+                    "externals": [
+                        {
+                            "spec": "mpich@4.1.2%gcc@14.3.1",
+                            "prefix": "/usr/lib64/mpich",
+                        }
+                    ]
+                },
+                "cmake": {
+                    "externals": [{"spec": "cmake@3.30.5", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "git": {
+                    "externals": [{"spec": "git@2.47.3~tcltk", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "openssl": {
+                    "externals": [{"spec": "openssl@3.0.2", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "automake": {
+                    "externals": [{"spec": "automake@1.16.5", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "openssh": {
+                    "externals": [{"spec": "openssh@9.9p1", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "m4": {
+                    "externals": [{"spec": "m4@1.4.19", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "sed": {
+                    "externals": [{"spec": "sed@4.9", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "autoconf": {
+                    "externals": [{"spec": "autoconf@2.71", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "diffutils": {
+                    "externals": [{"spec": "diffutils@3.10", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "coreutils": {
+                    "externals": [{"spec": "coreutils@8.32", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "findutils": {
+                    "externals": [{"spec": "findutils@4.10.0", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "binutils": {
+                    "externals": [
+                        {"spec": "binutils@2.41+gold~headers", "prefix": "/usr"}
+                    ],
+                    "buildable": False,
+                },
+                "perl": {
+                    "externals": [
+                        {
+                            "spec": "perl@5.74.0~cpanm+opcode+open+shared+threads",
+                            "prefix": "/usr",
+                        }
+                    ],
+                    "buildable": False,
+                },
+                "groff": {
+                    "externals": [{"spec": "groff@1.22.4", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "curl": {
+                    "externals": [
+                        {"spec": "curl@8.12.1+gssapi+ldap+nghttp2", "prefix": "/usr"}
+                    ],
+                    "buildable": False,
+                },
+                "ccache": {
+                    "externals": [{"spec": "ccache@4.11.3", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "flex": {
+                    "externals": [{"spec": "flex@2.6.4+lex", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "pkg-config": {
+                    "externals": [{"spec": "pkg-config@0.29.2", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "zlib-ng": {
+                    "externals": [{"spec": "zlib-ng@2.2.3", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "ninja": {
+                    "externals": [{"spec": "ninja@1.11.1", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+                "libtool": {
+                    "externals": [{"spec": "libtool@2.4.7", "prefix": "/usr"}],
+                    "buildable": False,
+                },
+            }
+        }
+
+    def compute_software_section(self):
+        return {
+            "software": {
+                "packages": {
+                    "compiler-gcc": {"pkg_spec": "gcc@14.3.1"},
+                    "default-compiler": {"pkg_spec": "gcc"},
+                    "compiler-gcc": {"pkg_spec": "gcc@14.3.1"},
+                    "default-mpi": {"pkg_spec": "mpich"},
+                }
+            }
+        }


### PR DESCRIPTION
## Fluxtainer System

This `system.py` describes the el10 container based on what is distributed by the Flux Framework project. The external GCC 14 and MPICH are included in the description.

## OSU Microbenchmarks Experiment Modification

An issue was uncovered in the `experiment.py` for `osu-micro-benchmarks` where only 1 rank was being specified across 2 nodes. I have changed this to 2 ranks across 2 nodes for now just to have a minimum viable product. I will deal with scaling and non-scaling benchmarks in a future PR.

## `checkout-versions.yaml`

I ran into an old bug with Ramble reporting results that appears to have been fixed recently, so I have bumped this version to the one that works.

## New Dockerfile in a new `containerfiles` directory

I created a directory structure for containerfiles in the root of the project. I tried to make this as extensible as possible. As I see it, the 2 main invariant factors requiring separate containers are the resource manager and the OS. Compilers, MPIs, and other system software should be able to coexist.

The Dockerfile itself simply clones Benchpark, installs the dependencies via PIP, and then runs a simple command to induce bootstrapping. Perhaps I should have used `benchpark bootstrap`?

## New Workflow to build and push containers to the GHCR for this project

I set this up to build a new container each week or when changes are made to the containerfile itself, or to be triggered manually. We probably don't need this rebuilding all the time, but it could be a good way to test basic functionality.

Please let me know what you think.

Thanks,
Nate