### PR TITLE
Fail in CI if experiment was skipped

### DIFF
--- a/.gitlab/utils/run-experiment.sh
+++ b/.gitlab/utils/run-experiment.sh
@@ -47,6 +47,8 @@ fi
 # Runs experiments where n_nodes == 1, and Print Log
 ramble --disable-logger --workspace-dir . on --executor '{execute_experiment}' --where '{n_nodes} == 1'
 find experiments/ -type f -name "*.out" -exec cat {} +
+# Fail if log files are empty or don't exist
+find experiments/ -type f -name "*.out" | grep -q . || { echo "No .out files found"; exit 1; }; find experiments/ -type f -name "*.out" -empty -print -quit | grep -q . && { echo "Empty .out file found"; exit 1; }
 
 # Analyze Experiments
 ramble --disable-logger --workspace-dir . workspace analyze --format json yaml text


### PR DESCRIPTION
## Description

- [x] Currently, the CI will not fail if more resources were requested than available than one node (will happen with current `osu-micro-benchmarks`). Ramble will just skip the experiment, and pass because no experiments failed. This PR checks if the output files from running the experiments are empty and will fail if they are empty, which indicates failure.
- [x] This will not work if the test needs to fail and 1+ experiments out of X executed.
