### PR TITLE
`benchpark show-build`: fix error for no-source packages

### DIFF
--- a/lib/scripts/experiment-build-info.py
+++ b/lib/scripts/experiment-build-info.py
@@ -27,8 +27,10 @@ def main():
                 "url": x.url,
                 "details": spec.package.versions[spec.version],
             }
-        else:
+        elif spec.package.has_code:
             raise Exception(f"Unexpected: {spec.name} has no url attribute")
+        # else: no source e.g. cray-mpich-gtl, which is meant to communicate
+        # information to spack
 
     result = {
         "root": z.name,


### PR DESCRIPTION
`show-build` was incorrectly failing because `cray-mpich-gtl` has no source (and therefore no URL to download) - skip such packages when generating download info.