### PR TITLE
Fix Gitlab Failures

### DIFF
--- a/experiments/amg2023/experiment.py
+++ b/experiments/amg2023/experiment.py
@@ -505,8 +505,8 @@ class Amg2023(
         if self.spec.satisfies("exec_mode=perf"):
             self.generate_perf_specs()
         else:
-            process_problem_size_dict = {"nx": 80, "ny": 80, "nz": 80}
-            n_resources_dict = {"px": 2, "py": 2, "pz": 2}
+            process_problem_size_dict = {"nx": 80, "ny": 80, "nz": 40}
+            n_resources_dict = {"px": 2, "py": 2, "pz": 1}
 
             # Per-process size (in zones) in each dimension
             self.add_experiment_variable(

--- a/experiments/osu-micro-benchmarks/experiment.py
+++ b/experiments/osu-micro-benchmarks/experiment.py
@@ -107,11 +107,13 @@ class OsuMicroBenchmarks(
 
     def compute_applications_section(self):
 
-        num_nodes = {"n_nodes": 2, "n_ranks": 2}
-
         if self.spec.satisfies("exec_mode=test"):
-            for pk, pv in num_nodes.items():
-                self.add_experiment_variable(pk, pv, True)
+            num_nodes = {"n_nodes": 1, "n_ranks": 2}
+        else:
+            num_nodes = {"n_nodes": 2, "n_ranks": 2}
+
+        for pk, pv in num_nodes.items():
+            self.add_experiment_variable(pk, pv, True)
 
         if self.spec.satisfies("+rocm"):
             self.add_experiment_variable("additional_args", " -d rocm", False)


### PR DESCRIPTION
## Description

- `exec_mode=test` resource requests should satisfy CI single node requirements. Other exec modes can implement different resource requests.
   - [x] Fix osu failure which skips experiment because it requests 2 nodes by default, where CI only has 1 node.
   - [x] AMG resource request 8 ranks, only 4 on tuolumne
