### PR TITLE
Fix `id_to_resources` missing in Generic x86 cluster

### DIFF
--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -82,9 +82,7 @@ def test_info():
         check=True,
     )
     result = [
-        line.lstrip().split(" ")[0]
-        for line in text.stdout.splitlines()
-        if line.strip()
+        line.lstrip().split(" ")[0] for line in text.stdout.splitlines() if line.strip()
     ]
 
     for r in result:

--- a/lib/benchpark/test/commands.py
+++ b/lib/benchpark/test/commands.py
@@ -84,7 +84,7 @@ def test_info():
     result = [
         line.lstrip().split(" ")[0]
         for line in text.stdout.splitlines()
-        if line.strip() and not line.lstrip().startswith("generic-x86")
+        if line.strip()
     ]
 
     for r in result:

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -15,7 +15,7 @@ class GenericX86(System):
     maintainers("slabasan")
 
     id_to_resources = {
-        "default": { 
+        "default": {
             "sys_cores_per_node": 1,
             "scheduler": "mpi",
         }

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -25,6 +25,10 @@ class GenericX86(System):
         super().__init__(spec)
         self.programming_models = [OpenMPCPUOnlySystem()]
 
+        attrs = self.id_to_resources.get("default")
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
     def compute_software_section(self):
         """This is somewhat vestigial, and maybe deleted later. The experiments
         will fail if these variables are not defined though, so for now

--- a/systems/generic-x86/system.py
+++ b/systems/generic-x86/system.py
@@ -14,12 +14,16 @@ class GenericX86(System):
 
     maintainers("slabasan")
 
+    id_to_resources = {
+        "default": { 
+            "sys_cores_per_node": 1,
+            "scheduler": "mpi",
+        }
+    }
+
     def __init__(self, spec):
         super().__init__(spec)
         self.programming_models = [OpenMPCPUOnlySystem()]
-
-        self.scheduler = "mpi"
-        setattr(self, "sys_cores_per_node", 1)
 
     def compute_software_section(self):
         """This is somewhat vestigial, and maybe deleted later. The experiments


### PR DESCRIPTION
## Description

- [x] test was being ignored in lib/benchpark/test/commands.py, so undo that change
- [x] Add id_to_resources in systems/generic-x86/system.py
- [x] Closes #1320