### PR TITLE
Only publish nightly dashboard on cdash.org

### DIFF
--- a/.gitlab/utils/status.yml
+++ b/.gitlab/utils/status.yml
@@ -48,7 +48,7 @@
         ctest -S CTestGitlab.cmake \
           -DHOST="${HOST}" \
           -DDASHBOARD_NAME="${DASHBOARD_NAME}" \
-          -DBUILD_NAME="${HOST}/${BENCHMARK}${BV} ${VARIANT} ${SYSTEM_ARGS}" \
+          -DBUILD_NAME="${BENCHMARK}${BV} ${VARIANT} ${SYSTEM_ARGS}" \
           -DSITE="$(hostname)" \
           -DTEST_TYPE="${TEST_TYPE}"
       else

--- a/CTestGitlab.cmake
+++ b/CTestGitlab.cmake
@@ -9,7 +9,7 @@ set(CTEST_UPDATE_VERSION_ONLY 1)
 set(CTEST_SITE ${SITE})
 set(CTEST_BUILD_NAME ${BUILD_NAME})
 
-# Separate dashboards for Nightly testing and PRs
+# Separate CTest dashboards for Nightly and non-Nightly testing.
 if ("${TEST_TYPE}" STREQUAL "Nightly")
     ctest_start("Nightly" GROUP "${DASHBOARD_NAME}")
 else()
@@ -20,8 +20,10 @@ ctest_update()
 ctest_configure()
 ctest_test(INCLUDE "Gitlab")
 
-# Submit results
-ctest_submit(
-    PARTS Update Test # 'Configure' and 'Build' not uploaded
-    HTTPHEADER "Authorization: Bearer ${_auth_token}"
-)
+# Submit results to CDash only for Nightly runs.
+if ("${TEST_TYPE}" STREQUAL "Nightly")
+    ctest_submit(
+        PARTS Update Test # 'Configure' and 'Build' not uploaded
+        HTTPHEADER "Authorization: Bearer ${_auth_token}"
+    )
+endif()

--- a/docs/ci-developer-guide.rst
+++ b/docs/ci-developer-guide.rst
@@ -189,15 +189,14 @@ be incremented by 1.
  CDash
 *******
 
-The successes/failures of our GitLab tests are posted to our CDash dashboard `CDash
-dashboard <https://my.cdash.org/index.php?project=Benchpark>`_. There is a dashboard for
-the nightly tests on the develop branch, and several dashboards for each system for
-daily PRs.
+The successes/failures of our nightly GitLab tests are posted to our CDash dashboard
+`CDash dashboard <https://my.cdash.org/index.php?project=Benchpark>`_. Daily and PR jobs
+still run through CTest, but they do not submit results to CDash.
 
 The following files are related to CDash:
 
-1. ``CTestGitlab.cmake`` configures CTest variables, the dashboard names and runs the
-   tests and submits the results.
+1. ``CTestGitlab.cmake`` configures CTest variables, the dashboard names, runs the
+   tests, and submits the results for nightly jobs.
 2. ``CTestConfig.cmake`` sets the cdash token and configuration variables.
 3. ``CMakeLists.txt`` enables CTest and adds the gitlab test.
 4. ``.gitlab/utils/status.yml`` Contains the logic to run CTest after a test completes


### PR DESCRIPTION
## Description

- [x] This will allow longer history (more nightly history) also the PR tests should really be tracked on the PRs themselves, not the dashboard.
- [x] @pearce8 remove system name from dashboard "Build Name" column