### PR TITLE
Fix docstrfmt error

### DIFF
--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -3,4 +3,5 @@ flake8==7.3.0
 isort[colors]==8.0.1
 codespell==2.4.2
 yamlfix==1.19.1
-docstrfmt==2.0.1
+click==8.3.3
+docstrfmt==2.0.2

--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -3,4 +3,4 @@ flake8==7.3.0
 isort[colors]==8.0.1
 codespell==2.4.2
 yamlfix==1.19.1
-docstrfmt==2.0.2
+docstrfmt==2.0.1


### PR DESCRIPTION
## Description

- docstrfmt is failing lint in CI suddenly, because of new `click` package update, so pinning that to previous version here.