### PR TITLE
WIP: test CDash support for performance chart uploads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,7 @@ INCLUDE(CTest)
 find_package(Python3 REQUIRED)
 
 add_test(NAME Gitlab
-        COMMAND ${CMAKE_COMMAND} -E $ENV{EXIT_CODE})
+        COMMAND bash -c "./bin/benchpark analyze --workspace-dir wkp/dane/kripke/workspace --ctest-emit &&
+        exec ${CMAKE_COMMAND} -E \"$EXIT_CODE\""
+)
+

--- a/lib/benchpark/cmd/analyze.py
+++ b/lib/benchpark/cmd/analyze.py
@@ -340,6 +340,10 @@ def make_chart(**kwargs):
         "Note: ordering of regions in the figure are in reverse order of the tree."
     )
 
+    # CTest measurement file emission
+    if kwargs.get("ctest_emit"):
+        print(f"<CTestMeasurementFile type=\"image/png\" name=\"TestImage\">{filename}.png</CTestMeasurementFile>")
+
 
 # ----------------
 # Data Preparation
@@ -769,6 +773,12 @@ def setup_parser(root_parser):
         help="With 'archive', path for the .tar.gz (defaults to CWD/<workspace>-<timestamp>.tar.gz)",
     )
 
+    # CTest flags
+    root_parser.add_argument(
+        "--ctest-emit",
+        action="store_true",
+        help="Emit CTest measurement markup."
+    )
 
 def command(args):
     """


### PR DESCRIPTION
Modify the CTest Gitlab test to run `benchpark analyze` instead of only reporting the exit code. `benchpark analyze` now supports a `--ctest-emit` flag that emits a `CTestMeasurementFile` entry for the generated chart so CTest can include it in the CDash submission.