### PR TITLE
Move Tuolumne back to PCI queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
   # Dane
   DANE_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive --reservation=ci
   # Matrix (NODES ARE SHARED WITHOUT --exclusive)
-  MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive -p pci
+  MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive
   # Tuolumne (max 4hr policy)
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
   # Dane
   DANE_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive --reservation=ci
   # Matrix (NODES ARE SHARED WITHOUT --exclusive)
-  MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive
+  MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive -p pci
   # Tuolumne (max 4hr policy)
   TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ variables:
   # Matrix (NODES ARE SHARED WITHOUT --exclusive)
   MATRIX_SHARED_ALLOC: -N 1 -t 04:00:00 --exclusive
   # Tuolumne (max 4hr policy)
-  TUOLUMNE_SHARED_ALLOC: -N 1 -t 3h --queue=pbatch --exclusive --setattr=gpumode=${GPUMODE}
+  TUOLUMNE_SHARED_ALLOC: -N 1 -t 4h --queue=pci --exclusive --setattr=gpumode=${GPUMODE}
     --conf=resource.rediscover=true
   # Tioga (max 2hr policy)
   TIOGA_SHARED_ALLOC: -N 1 -t 2h --queue=pci --exclusive


### PR DESCRIPTION
- [x] We had been trying to run tests in the `pbatch` queue, because we had been hogging the `pci` queue. Since this, we have removed tests for TPX/CPX on PRs, which is 2 less shared allocations per pipeline. Additionally, the number of nodes in the `pci` queue increased from `4->6`. So we will only take up as many nodes as there are running pipelines,
- [x] Try matrix in pci queue 