### PR TITLE
Use shallow fetch for faster bootstrapping

### DIFF
--- a/checkout-versions.yaml
+++ b/checkout-versions.yaml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 versions:
-  ramble: 100f97d  # develop on 04/25/2026 (newer than 0.6.0 release)
-  spack: a85ec51  # Dec. 1 2025 v1.1.0
-  spack-packages: 661ecf6  # Jun 1 2026
+  # Shallow fetch requires the full commit sha
+  ramble: 100f97d9dfbc588058e37f0dfd94abd8ba742a57  # develop on 04/25/2026 (newer than 0.6.0 release)
+  spack: a85ec51644917c14d996977e876de5be20b70a0b  # Dec. 1 2025 v1.1.0
+  spack-packages: 661ecf6476a80db9d028519cef55a14109763d9d  # Jun 1 2026

--- a/lib/benchpark/runtime.py
+++ b/lib/benchpark/runtime.py
@@ -6,6 +6,7 @@
 import os
 import pathlib
 import shlex
+import shutil
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -27,6 +28,21 @@ def working_dir(location):
 
 
 def git_clone_commit(url, commit, destination):
+    try:
+        os.makedirs(destination, exist_ok=True)
+        with working_dir(destination):
+            # Newer git (>=2.49) supports `git clone --depth 1 --revision <sha>`,
+            # but uses the fetch here to cover older git versions.
+            run_command("git init")
+            run_command(f"git remote add origin {url}")
+            run_command(f"git fetch --depth 1 origin {commit}")
+            run_command("git checkout FETCH_HEAD")
+        return
+    except Exception as e:
+        if os.path.exists(destination):
+            shutil.rmtree(destination)
+        debug_print(f"Shallow fetch failed: {e}. Falling back to full clone.")
+
     run_command(f"git clone -c feature.manyFiles=true {url} {destination}")
 
     with working_dir(destination):
@@ -109,9 +125,19 @@ class RuntimeResources:
 
     def _check_and_update_bootstrap(self, desired_commit, location):
         with working_dir(location):
-            # length of hash is 7 in checkout-versions.yaml
-            current_commit = run_command("git rev-parse HEAD")[0].strip()[:7]
+            current_commit = run_command("git rev-parse HEAD")[0].strip()
             if current_commit != desired_commit:
+                try:
+                    run_command(f"git fetch --depth 1 origin {desired_commit}")
+                    run_command("git checkout FETCH_HEAD")
+                    print(
+                        f"Updating '{location}' from {current_commit} to {desired_commit}"
+                    )
+                    return
+                except Exception as e:
+                    debug_print(
+                        f"Shallow fetch failed during update: {e}. Falling back to fetch all."
+                    )
                 run_command("git fetch --all")
                 run_command(f"git checkout {desired_commit}")
                 print(


### PR DESCRIPTION
## Description

Use shallow fetch for faster bootstrapping

The `checkout-versions.yaml` is updated to use the full commit-sha, as required by remote shallow fetch.

Here's a timing comparison:

* With the change

```
$ rm -rf scratch/
$ time benchpark list experiments
Cloning Ramble to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/ramble
Cloning packages to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/spack-packages
Cloning Spack to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/spack
Experiments - BENCHMARK+PROGRAMMING_MODEL+SCALING
    ad+[mpi]
    amg2023+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    babelstream+[openmp|cuda|rocm]
    branson+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    commbench+[cuda|rocm]
    genesis+[openmp|mpi]
    gpcnet+[mpi]
    gromacs+[openmp|cuda|rocm|mpi]
    hpcg+[openmp|mpi]+[strong|weak]
    hpl+[openmp|mpi]+[strong|weak]
    ior+[mpi]+[strong|weak]
    kripke+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    laghos+[cuda|rocm|mpi]+[strong|weak|throughput]
    lammps+[openmp|cuda|rocm|mpi]+[strong]
    md-test+[mpi]+[strong]
    osu-micro-benchmarks+[cuda|rocm|mpi]
    phloem+[mpi]
    py-scaffold+[cuda|rocm]+[strong|weak]
    quicksilver+[openmp|mpi]+[strong|weak]
    qws+[openmp|mpi]+[strong|weak|throughput]
    raja-perf+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    remhos+[cuda|rocm|mpi]+[strong|weak|throughput]
    salmon-tddft+[openmp|mpi]
    smb+[mpi]
    sparta-snl+[openmp|cuda|rocm|mpi]
    stream+[mpi]
    test

real	0m7.585s
user	0m1.769s
sys	0m2.374s
```

* Without the change

```
$ git stash
Saved working directory and index state WIP on optimize-checkout-fetch: b1055bd `lanl-venado` change h100 -> gh200 (#1379)
$ rm -rf scratch/
$ time benchpark list experiments
Cloning Ramble to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/ramble
Cloning packages to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/spack-packages
Cloning Spack to /Users/linsword/hpc/contrib/benchpark/scratch/benchpark_home_fallback/spack
Experiments - BENCHMARK+PROGRAMMING_MODEL+SCALING
    ad+[mpi]
    amg2023+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    babelstream+[openmp|cuda|rocm]
    branson+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    commbench+[cuda|rocm]
    genesis+[openmp|mpi]
    gpcnet+[mpi]
    gromacs+[openmp|cuda|rocm|mpi]
    hpcg+[openmp|mpi]+[strong|weak]
    hpl+[openmp|mpi]+[strong|weak]
    ior+[mpi]+[strong|weak]
    kripke+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    laghos+[cuda|rocm|mpi]+[strong|weak|throughput]
    lammps+[openmp|cuda|rocm|mpi]+[strong]
    md-test+[mpi]+[strong]
    osu-micro-benchmarks+[cuda|rocm|mpi]
    phloem+[mpi]
    py-scaffold+[cuda|rocm]+[strong|weak]
    quicksilver+[openmp|mpi]+[strong|weak]
    qws+[openmp|mpi]+[strong|weak|throughput]
    raja-perf+[openmp|cuda|rocm|mpi]+[strong|weak|throughput]
    remhos+[cuda|rocm|mpi]+[strong|weak|throughput]
    salmon-tddft+[openmp|mpi]
    smb+[mpi]
    sparta-snl+[openmp|cuda|rocm|mpi]
    stream+[mpi]
    test

real	1m10.219s
user	3m2.025s
sys	0m12.604s
```

