### PR TITLE
skip coverage on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     secrets:
       BENCHPARK_CODECOV_TOKEN: ${{ secrets.BENCHPARK_CODECOV_TOKEN }}
   coverage:
-    if: ${{ needs.changes.outputs.coverage == 'true' }}
+    if: ${{ needs.changes.outputs.coverage == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
     needs: changes
     uses: ./.github/workflows/coverage.yml
     # 'workflow_call' actions do not get access to secrets

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           ./bin/benchpark unit-test --cov=./ --cov-branch --cov-report=xml --durations=20 -ra
       - name: Upload coverage to Codecov
-        if: ${{ !contains(github.head_ref, 'dependabot/') }}
+        if: ${{ !contains(github.head_ref, 'dependabot/') && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.BENCHPARK_CODECOV_TOKEN }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -98,7 +98,7 @@ jobs:
             --executor '{execute_experiment}' \
             --where '{n_nodes} == 1'
       - name: Upload binary coverage to Codecov
-        if: ${{ !contains(github.head_ref, 'dependabot/') }}
+        if: ${{ !contains(github.head_ref, 'dependabot/') && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.BENCHPARK_CODECOV_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
           ./workspace2/ramble/bin/ramble --workspace-dir /home/runner/work/benchpark/benchpark/workspace2/dane/saxpy-agg/workspace workspace setup --dry-run
           BENCHPARK_RUN_COVERAGE=aggregate ./bin/benchpark aggregate --dest agg workspace2  # Aggregate multi-trial workspace
       - name: Upload aggregate coverage to Codecov
-        if: ${{ !contains(github.head_ref, 'dependabot/') }}
+        if: ${{ !contains(github.head_ref, 'dependabot/') && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.BENCHPARK_CODECOV_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
           ./bin/benchpark bootstrap
           BENCHPARK_RUN_COVERAGE=${{ matrix.testtype }} ./bin/benchpark-python .github/utils/dryruns.py --test ${{ matrix.testtype }}
       - name: Upload coverage to Codecov
-        if: ${{ !contains(github.head_ref, 'dependabot/') }}
+        if: ${{ !contains(github.head_ref, 'dependabot/') && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.BENCHPARK_CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

- Currently, dryruns always appear as failure on forks because the coverage step will always fail. This skips coverage on forks, so we can still easily tell if the unit tests are passing.

I made a demo PR https://github.com/llnl/benchpark/pull/1388 to show this works (this is the same PR but from a fork) and the tests are skipped there.
