### PR TITLE
Add copy button to Sphinx docs

### DIFF
--- a/.github/workflows/requirements/docs.txt
+++ b/.github/workflows/requirements/docs.txt
@@ -5,6 +5,7 @@ codespell==2.4.2
 pyyaml==6.0.3
 pandas==3.0.1
 sphinxcontrib-programoutput==0.19
+sphinx-copybutton==0.5.2
 # benchpark analyze -h command
 llnl-thicket
 matplotlib

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ author = "Olga Pearce, Alec Scott, Peter Scheibel, Greg Becker, Riyaz Haque, and
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinx_copybutton",
     "sphinx_rtd_theme",
     "sphinxcontrib.programoutput",
     "sphinx.ext.autodoc",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx
 sphinx-rtd-theme
 sphinxcontrib-programoutput
+sphinx-copybutton


### PR DESCRIPTION
## Description
Add copy button to Sphinx docs, for code snippets. This makes it easier to follow the tutorials.

Example screenshot:

<img width="2328" height="422" alt="image" src="https://github.com/user-attachments/assets/b5886d69-8f5a-4a0f-887d-345681161017" />

