### PR TITLE
Updated CI Rules to run pipelines on changes to develop

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,16 +4,20 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
 
+    # Always allow develop pipelines 
+    - if: $CI_COMMIT_BRANCH == "develop" && $CI_PIPELINE_SOURCE == "push"
+      when: always
+
     # Run pipelines only when these files/dirs change
     - changes:
-        - .gitlab/**
-        - bin/**
-        - configs/**
-        - experiments/**
-        - lib/**
-        - modifiers/**
-        - repo/**
-        - var/**
+        - .gitlab/**/*
+        - bin/**/*
+        - configs/**/*
+        - experiments/**/*
+        - lib/**/*
+        - modifiers/**/*
+        - repo/**/*
+        - var/**/*
         - systems/llnl-elcapitan/system.py
         - systems/llnl-cluster/system.py
         - .gitlab-ci.yml

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -6,17 +6,18 @@
     - if: $CI_JOB_NAME =~ /release_resources|cleanup_pipeline_dir/ && $CI_PIPELINE_SOURCE
         != "schedule"
       when: always
-    - when: on_success
     - changes:
         - .gitlab-ci.yml
-        - .gitlab/**
-        - bin/**
-        - experiments/$BENCHMARK/**
-        - systems/$ARCHCONFIG/**
-        - repo/$BENCHMARK/**
-        - modifiers/**
-        - var/**
-        - lib/**
+        - .gitlab/**/*
+        - bin/**/*
+        - experiments/$BENCHMARK/**/*
+        - systems/$ARCHCONFIG/**/*
+        - repo/$BENCHMARK/**/*
+        - modifiers/**/*
+        - var/**/*
+        - lib/**/*
+      when: on_success
+    - when: never
 .nightly_rules:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
## Description

- Updated CI Rules to properly check recursively for watched directories, and always run pipelines on changes to the develop branch.