### PR TITLE
Laghos build fixes

### DIFF
--- a/repos/ramble_applications/laghos/application.py
+++ b/repos/ramble_applications/laghos/application.py
@@ -43,9 +43,7 @@ class Laghos(ExecutableApplication):
 
     common_args = (
         " -m {mesh}"
-        + " -epm {epm}"
-        + " -nx {nx} -ny {ny} -nz {nz}"
-        + " -rs {rs} -rp {rp}"
+        + " {mesh_options}"
         + " -ms {ms}"
         + " -ok {ok} -ot {ot} -oq {oq}"
         + " {nc} --mem --fom {gam}"
@@ -188,3 +186,28 @@ class Laghos(ExecutableApplication):
         match=r"Major kernels total time",
         file="{experiment_run_dir}/{experiment_name}.out",
     )
+
+    def _make_experiments(self, workspace, app_inst=None):
+        """
+        When setting up its mesh, Laghos strictly accepts as input either the 
+        elements per mpi (epm) or the mesh dimensions and refinement factors 
+        (nx/ny/nz/rs/rp), but not both
+
+        Here we select one of the two strategies based on the value of epm
+        if epm > 0: use -epm {epm}
+        else: use -nx {nx} -ny {ny} -nz {nz} -rs {rs} -rp {rp}
+
+        """
+        epm = int(self.expander.expand_var_name("epm"))
+
+        if epm:
+            self.variables["mesh_options"] = f"-epm {epm}"
+        else:
+            nx = int(self.expander.expand_var_name("nx"))
+            ny = int(self.expander.expand_var_name("ny"))
+            nz = int(self.expander.expand_var_name("nz"))
+            rs = int(self.expander.expand_var_name("rs"))
+            rp = int(self.expander.expand_var_name("rp"))
+            self.variables["mesh_options"] = f"-nx {nx} -ny {ny} -nz {nz} -rs {rs} -rp {rp}"
+
+        super()._make_experiments(workspace)

--- a/systems/llnl-elcapitan/system.py
+++ b/systems/llnl-elcapitan/system.py
@@ -837,7 +837,7 @@ class LlnlElcapitan(System):
         )
         rocmcc_entry = compiler_def(
             f"llvm-amdgpu@{self.rocm_version}",
-            f"/opt/rocm-{self.rocm_version}/",
+            f"/opt/rocm-{self.rocm_version}/llvm",
             {"c": "amdclang", "cxx": "amdclang++", "fortran": "amdflang"},
             modules=[f"rocm/{self.rocm_version}"],
             extra_rpaths=list(rpaths),


### PR DESCRIPTION
## Description
This PR:
- [x] Uses one of epm or nx/ny/nz/rs/rp as the input parameters for laghos. Its an error to provide both configurations as input to laghos
- [x] Fixes the llvm-amdgpu prefix path for the llnl-elcapitan system

## Adding/modifying a system (docs: [Adding a System](https://software.llnl.gov/benchpark/add-a-system-config.html))

- [x] Add/modify `systems/system_name/system.py` file

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If application.py upstreamed to Ramble is insufficient, add/modify `repo/benchmark_name/application.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Ramble repo.