### PR TITLE
Avoid hard-coding filter keywords

### DIFF
--- a/lib/benchpark/cmd/list.py
+++ b/lib/benchpark/cmd/list.py
@@ -7,6 +7,7 @@
 import llnl.util.tty.color as color
 
 from benchpark.accounting import (  # noqa: E402
+    EXP_DICT,
     benchpark_benchmarks,
     benchpark_experiments,
     benchpark_modifiers,
@@ -115,7 +116,7 @@ def setup_parser(root_parser):
         type=str,
         nargs="*",
         default=None,
-        choices=["cuda", "rocm", "openmp", "strong", "weak", "throughput"],
+        choices=set(val[1] for val in EXP_DICT.values()),
         help="Filter experiments containing a specific substring (e.g., 'cuda').",
     )
     experiments_parser.add_argument(


### PR DESCRIPTION
## Description

Before this change, the "mpi" keyword is not supported:

```
$ benchpark list experiments --experiment mpi
```

