### PR TITLE
fix ci system failure 

### DIFF
--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -6,6 +6,7 @@
     - if: $CI_JOB_NAME =~ /release_resources|cleanup_pipeline_dir/ && $CI_PIPELINE_SOURCE
         != "schedule"
       when: always
+    - when: on_success
     - changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
@@ -16,8 +17,6 @@
         - modifiers/**/*
         - var/**/*
         - lib/**/*
-      when: on_success
-    - when: never
 .nightly_rules:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION


## Description

- Undo a previous change from PR #1394. This should temp fix the potential system failure from the resource_release job being created without a matching allocate_resources

Note this is intended to be a temporary patch for today's hackathon so that pipelines are runnable without system failure. 