### PR TITLE
fix branson failure

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -57,13 +57,12 @@ include:
           - remhos
           - sparta-snl
         VARIANT: [+rocm]
-      # GTL experiments
+      # Needs caliper for mpi
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
         SCHEDULER_PARAMETERS: $ELCAP_PARAMS
         BENCHMARK: [branson]
-        VARIANT: [+rocm]
-        SYSTEM_ARGS: [+gtl]
+        VARIANT: [+rocm caliper=mpi]
       # +openmp tests
       - HOST: dane
         ARCHCONFIG: llnl-cluster

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -49,7 +49,6 @@ include:
         BENCHMARK:
           - amg2023
           - babelstream
-          - branson
           - kripke
           - laghos
           - lammps
@@ -58,6 +57,13 @@ include:
           - remhos
           - sparta-snl
         VARIANT: [+rocm]
+      # GTL experiments
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        SCHEDULER_PARAMETERS: $ELCAP_PARAMS
+        BENCHMARK: [branson]
+        VARIANT: [+rocm]
+        SYSTEM_ARGS: [+gtl]
       # +openmp tests
       - HOST: dane
         ARCHCONFIG: llnl-cluster

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -164,61 +164,67 @@ run_tests_flux_tuolumne:
   needs: [allocate_resources_tuolumne]
   parallel:
     matrix:
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK:
+      #     - amg2023
+      #     - kripke
+      #     - laghos
+      #     - lammps
+      #     - raja-perf
+      #     - remhos
+      #     - sparta-snl
+      #   VARIANT: [+rocm]
+      #   GPUMODE: SPX
+      # GTL experiments
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
-        BENCHMARK:
-          - amg2023
-          - branson
-          - kripke
-          - laghos
-          - lammps
-          - raja-perf
-          - remhos
-          - sparta-snl
+        BENCHMARK: [branson]
         VARIANT: [+rocm]
         GPUMODE: SPX
-      # Test openmp on tuolumne
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke]
-        VARIANT: [+openmp]
-        GPUMODE: SPX
-      # Test kripke+rocm+single_memory on tuolumne
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke]
-        VARIANT: [+rocm+single_memory]
-        GPUMODE: SPX
-      # Caliper profile.hip
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke]
-        VARIANT: ['+rocm caliper=mpi,time,rocm']
-        GPUMODE: SPX
-      # spack-pip
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [py-scaffold]
-        VARIANT:
-          - +rocm package_manager=spack-pip caliper=mpi,time allocation=torchrun-hpc
-      # rocm7
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [raja-perf]
-        VARIANT: ['+rocm caliper=time,rocm version=develop']
-        SYSTEM_ARGS: [rocm=7.2.1]
-        GPUMODE: SPX
-      # Caliper services
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [kripke]
-        VARIANT: [+rocm caliper_services=rocprofiler]
-        GPUMODE: SPX
-      # gcc
-      - HOST: tuolumne
-        ARCHCONFIG: llnl-elcapitan
-        BENCHMARK: [stream]
-        SYSTEM_ARGS: [compiler=gcc]
+        SYSTEM_ARGS: [+gtl]
+      # # Test openmp on tuolumne
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [kripke]
+      #   VARIANT: [+openmp]
+      #   GPUMODE: SPX
+      # # Test kripke+rocm+single_memory on tuolumne
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [kripke]
+      #   VARIANT: [+rocm+single_memory]
+      #   GPUMODE: SPX
+      # # Caliper profile.hip
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [kripke]
+      #   VARIANT: ['+rocm caliper=mpi,time,rocm']
+      #   GPUMODE: SPX
+      # # spack-pip
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [py-scaffold]
+      #   VARIANT:
+      #     - +rocm package_manager=spack-pip caliper=mpi,time allocation=torchrun-hpc
+      # # rocm7
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [raja-perf]
+      #   VARIANT: ['+rocm caliper=time,rocm version=develop']
+      #   SYSTEM_ARGS: [rocm=7.2.1]
+      #   GPUMODE: SPX
+      # # Caliper services
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [kripke]
+      #   VARIANT: [+rocm caliper_services=rocprofiler]
+      #   GPUMODE: SPX
+      # # gcc
+      # - HOST: tuolumne
+      #   ARCHCONFIG: llnl-elcapitan
+      #   BENCHMARK: [stream]
+      #   SYSTEM_ARGS: [compiler=gcc]
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -176,13 +176,12 @@ run_tests_flux_tuolumne:
       #     - sparta-snl
       #   VARIANT: [+rocm]
       #   GPUMODE: SPX
-      # GTL experiments
+      # needs caliper for mpi
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [branson]
-        VARIANT: [+rocm]
+        VARIANT: [+rocm caliper=mpi]
         GPUMODE: SPX
-        SYSTEM_ARGS: [+gtl]
       # # Test openmp on tuolumne
       # - HOST: tuolumne
       #   ARCHCONFIG: llnl-elcapitan

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -164,66 +164,66 @@ run_tests_flux_tuolumne:
   needs: [allocate_resources_tuolumne]
   parallel:
     matrix:
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK:
-      #     - amg2023
-      #     - kripke
-      #     - laghos
-      #     - lammps
-      #     - raja-perf
-      #     - remhos
-      #     - sparta-snl
-      #   VARIANT: [+rocm]
-      #   GPUMODE: SPX
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK:
+          - amg2023
+          - kripke
+          - laghos
+          - lammps
+          - raja-perf
+          - remhos
+          - sparta-snl
+        VARIANT: [+rocm]
+        GPUMODE: SPX
       # needs caliper for mpi
       - HOST: tuolumne
         ARCHCONFIG: llnl-elcapitan
         BENCHMARK: [branson]
         VARIANT: [+rocm caliper=mpi]
         GPUMODE: SPX
-      # # Test openmp on tuolumne
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [kripke]
-      #   VARIANT: [+openmp]
-      #   GPUMODE: SPX
-      # # Test kripke+rocm+single_memory on tuolumne
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [kripke]
-      #   VARIANT: [+rocm+single_memory]
-      #   GPUMODE: SPX
-      # # Caliper profile.hip
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [kripke]
-      #   VARIANT: ['+rocm caliper=mpi,time,rocm']
-      #   GPUMODE: SPX
-      # # spack-pip
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [py-scaffold]
-      #   VARIANT:
-      #     - +rocm package_manager=spack-pip caliper=mpi,time allocation=torchrun-hpc
-      # # rocm7
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [raja-perf]
-      #   VARIANT: ['+rocm caliper=time,rocm version=develop']
-      #   SYSTEM_ARGS: [rocm=7.2.1]
-      #   GPUMODE: SPX
-      # # Caliper services
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [kripke]
-      #   VARIANT: [+rocm caliper_services=rocprofiler]
-      #   GPUMODE: SPX
-      # # gcc
-      # - HOST: tuolumne
-      #   ARCHCONFIG: llnl-elcapitan
-      #   BENCHMARK: [stream]
-      #   SYSTEM_ARGS: [compiler=gcc]
+      # Test openmp on tuolumne
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [kripke]
+        VARIANT: [+openmp]
+        GPUMODE: SPX
+      # Test kripke+rocm+single_memory on tuolumne
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [kripke]
+        VARIANT: [+rocm+single_memory]
+        GPUMODE: SPX
+      # Caliper profile.hip
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [kripke]
+        VARIANT: ['+rocm caliper=mpi,time,rocm']
+        GPUMODE: SPX
+      # spack-pip
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [py-scaffold]
+        VARIANT:
+          - +rocm package_manager=spack-pip caliper=mpi,time allocation=torchrun-hpc
+      # rocm7
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [raja-perf]
+        VARIANT: ['+rocm caliper=time,rocm version=develop']
+        SYSTEM_ARGS: [rocm=7.2.1]
+        GPUMODE: SPX
+      # Caliper services
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [kripke]
+        VARIANT: [+rocm caliper_services=rocprofiler]
+        GPUMODE: SPX
+      # gcc
+      - HOST: tuolumne
+        ARCHCONFIG: llnl-elcapitan
+        BENCHMARK: [stream]
+        SYSTEM_ARGS: [compiler=gcc]
 run_tests_flux_tioga:
   extends: .run_tests_flux
   tags: [shell, tioga]


### PR DESCRIPTION
## Description

- [x] This is a temporary fix by building with Caliper. This should fix 2 unit test failures
- [ ] https://github.com/spack/spack-packages/pull/4411 should render this unnecessary. 

@michaelmckinsey1 is there an easy way to undo after the permanent fix if we merge this now?