### PR TITLE
Patch CI githash to not fail on benchmarks with '-' in the name

### DIFF
--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -86,7 +86,7 @@ release_resources_flux_tioga:
     - !reference [.report_status, after_script]
     - |
       pr_workspace="$CI_PROJECT_DIR/wkp/${HOST}/${BENCHMARK}/workspace"
-      pr_json=$(find "${pr_workspace}/experiments/" -type f -name 'githash_metadata.json' | sort | head -n 1)
+      pr_json=$(find "${pr_workspace}/experiments" -type f -name 'githash_metadata.json' | sort | head -n 1)
       artifact_dir="$CI_PROJECT_DIR/artifact-githash/${HOST}/${BENCHMARK}"
       baseline_json="${artifact_dir}/baseline_githash_metadata.json"
       baseline_status_file="${artifact_dir}/baseline_job.status"

--- a/.gitlab/tests/shared_flux_clusters.yml
+++ b/.gitlab/tests/shared_flux_clusters.yml
@@ -86,7 +86,7 @@ release_resources_flux_tioga:
     - !reference [.report_status, after_script]
     - |
       pr_workspace="$CI_PROJECT_DIR/wkp/${HOST}/${BENCHMARK}/workspace"
-      pr_json=$(find "${pr_workspace}/experiments/${BENCHMARK}" -type f -name 'githash_metadata.json' | sort | head -n 1)
+      pr_json=$(find "${pr_workspace}/experiments/" -type f -name 'githash_metadata.json' | sort | head -n 1)
       artifact_dir="$CI_PROJECT_DIR/artifact-githash/${HOST}/${BENCHMARK}"
       baseline_json="${artifact_dir}/baseline_githash_metadata.json"
       baseline_status_file="${artifact_dir}/baseline_job.status"

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -90,7 +90,7 @@ release_resources_matrix:
     - !reference [.report_status, after_script]
     - |
       pr_workspace="$CI_PROJECT_DIR/wkp/${HOST}/${BENCHMARK}/workspace"
-      pr_json=$(find "${pr_workspace}/experiments/" -type f -name 'githash_metadata.json' | sort | head -n 1)
+      pr_json=$(find "${pr_workspace}/experiments" -type f -name 'githash_metadata.json' | sort | head -n 1)
       artifact_dir="$CI_PROJECT_DIR/artifact-githash/${HOST}/${BENCHMARK}"
       baseline_json="${artifact_dir}/baseline_githash_metadata.json"
       baseline_status_file="${artifact_dir}/baseline_job.status"

--- a/.gitlab/tests/shared_slurm_clusters.yml
+++ b/.gitlab/tests/shared_slurm_clusters.yml
@@ -90,7 +90,7 @@ release_resources_matrix:
     - !reference [.report_status, after_script]
     - |
       pr_workspace="$CI_PROJECT_DIR/wkp/${HOST}/${BENCHMARK}/workspace"
-      pr_json=$(find "${pr_workspace}/experiments/${BENCHMARK}" -type f -name 'githash_metadata.json' | sort | head -n 1)
+      pr_json=$(find "${pr_workspace}/experiments/" -type f -name 'githash_metadata.json' | sort | head -n 1)
       artifact_dir="$CI_PROJECT_DIR/artifact-githash/${HOST}/${BENCHMARK}"
       baseline_json="${artifact_dir}/baseline_githash_metadata.json"
       baseline_status_file="${artifact_dir}/baseline_job.status"


### PR DESCRIPTION
## Description

- Pruned the find path for the githash_metadata.json file. This is to avoid the issue where benchmarks with a '-' in the name would have folders in experiments/ have a '_' instead, resulting in the find failing.
