### PR TITLE
Docs: system catalog missing systems

### DIFF
--- a/systems/all_hardware_descriptions/AMD-zen4-EPYC-Ethernet/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/AMD-zen4-EPYC-Ethernet/hardware_description.yaml
@@ -21,7 +21,7 @@ system_definition:
     vendor:
     name: Ethernet
   systems-tested:
-    genoa:
+    riken-genoa:
       os: Rocky
       scheduler: slurm
       compiler: gcc

--- a/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/Fujitsu-A64FX-TofuD/hardware_description.yaml
@@ -21,9 +21,15 @@ system_definition:
     vendor: Fujitsu
     name: TofuInterconnectD
   systems-tested:
-    rccs-fugaku:
+    riken-fugaku:
       os: RHEL
       scheduler: pjm
+      compiler: fj
+      runtime:
+      mpi: fujitsu-mpi
+    riken-fx700:
+      os: RHEL
+      scheduler: slurm
       compiler: fj
       runtime:
       mpi: fujitsu-mpi

--- a/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/HPECray-zen3-MI250X-Slingshot/hardware_description.yaml
@@ -34,6 +34,12 @@ system_definition:
       compiler: cce
       runtime: rocm
       mpi: cray-mpich
+    olcf-frontier:
+      os: HPECrayOS
+      scheduler: slurm
+      compiler: cce
+      runtime: rocm
+      mpi: cray-mpich
   top500-system-instances:
     Frontier:
       benchpark_system:

--- a/systems/all_hardware_descriptions/NVIDIA-cortex-GB10-Ethernet/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/NVIDIA-cortex-GB10-Ethernet/hardware_description.yaml
@@ -21,7 +21,7 @@ system_definition:
     vendor: NVIDIA
     name: 10GbEthernet
   systems-tested:
-    ng-dgx:
+    riken-dgx:
       os: Ubuntu
       scheduler: slurm
       compiler: nvhpc

--- a/systems/all_hardware_descriptions/NVIDIA-neoverse-GH200-Infiniband/hardware_description.yaml
+++ b/systems/all_hardware_descriptions/NVIDIA-neoverse-GH200-Infiniband/hardware_description.yaml
@@ -21,7 +21,7 @@ system_definition:
     vendor: NVIDIA
     name: HDR200InfiniBand
   systems-tested:
-    qc-gh200:
+    riken-gh200:
       os: Rocky
       scheduler: slurm
       compiler: nvhpc


### PR DESCRIPTION
## Description

Address gaps, inconsistencies in system catalog. Names of systems in `systems-tested` field match system directory names. Add missing `riken-fx700` system from hardware description yaml files.

- Frontier is in the table under row `HPECray-zen3-MI250X-Slingshot` and column `top500-system-instances`
- riken-dgx listed in the table under row `NVIDIA-cortex-GB10-Ethernet` and column `systems-tested`
- riken-fx700 listed in the table under row `Fujitsu-A64FX-TofuD` and column `systems-tested`
- riken-genoa listed under row `AMD-zen4-EPYC-Ethernet` and column `systems-tested`
- riken-gh200 listed under row `NVIDIA-neoverse-GH200-Infiniband` and column `systems-tested`

Fixes #1420 