### PR TITLE
install gettext into aws-tutorial

### DIFF
--- a/systems/aws-tutorial/system.py
+++ b/systems/aws-tutorial/system.py
@@ -188,6 +188,10 @@ class AwsTutorial(System):
                     "externals": [{"spec": "libtool@2.4.6", "prefix": "/usr"}],
                     "buildable": False,
                 },
+                "gettext": {
+                    "externals": [{"spec": "gettext@0.21", "prefix": "/usr"}],
+                    "buildable": False,
+                },
             }
         }
 


### PR DESCRIPTION
Reduce time for `ramble setup` in tutorial container by installing additional packages onto the system that take a while to install with ramble setup.