### PR TITLE
Modified nightly resource lock to be pipeline specific

### DIFF
--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: "${HOST}-${CI_PIPELINE_ID}"
+  resource_group: "${HOST}-${CI_PIPELINE_IID}"
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: $HOST-$CI_PIPELINE_ID
+  resource_group: "${HOST}-${CI_PIPELINE_ID}"
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: $HOST
+  resource_group: $HOST-$CI_PIPELINE_ID
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: "${HOST}-${CI_PIPELINE_IID}"
+  resource_group: ${HOST}-${CI_PIPELINE_IID}
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly


### PR DESCRIPTION
## Description

- Modified nightly resource lock to be pipeline specific. This is to prevent new nightly pipelines waiting on older nightly jobs. 

<img width="1185" height="350" alt="image" src="https://github.com/user-attachments/assets/fc97f5b2-71e7-4218-9eee-6874a6f7b29e" />