### PR TITLE
Change CI source to merge request [DRAFT]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,8 @@ workflow:
       when: always
 
     # Run MR pipelines, plus push pipelines on develop branch, only when these files/dirs change
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab/**/*
         - bin/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,9 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
 
-    # Run pipelines only when these files/dirs change
-    - changes:
+    # Run MR pipelines, plus push pipelines on develop branch, only when these files/dirs change
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab/**/*
         - bin/**/*
         - configs/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ workflow:
       when: always
 
     # Run MR pipelines, plus push pipelines on develop branch, only when these files/dirs change
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 workflow:
   rules:
     # Always allow scheduled pipelines
+    # test
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
 

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: "${HOST}-${CI_PIPELINE_ID}"
+  resource_group: "${HOST}-${CI_PIPELINE_IID}"
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: $HOST-$CI_PIPELINE_ID
+  resource_group: "${HOST}-${CI_PIPELINE_ID}"
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: $HOST
+  resource_group: $HOST-$CI_PIPELINE_ID
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/tests/nightly.yml
+++ b/.gitlab/tests/nightly.yml
@@ -160,7 +160,7 @@ include:
 nightly_test_run:
   extends: .nightly_rules
   interruptible: false
-  resource_group: "${HOST}-${CI_PIPELINE_IID}"
+  resource_group: ${HOST}-${CI_PIPELINE_IID}
   stage: test
   tags: [$HOST, batch]
   <<: *test_clusters_nightly

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -3,7 +3,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
         - bin/**/*
@@ -18,7 +19,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
         - bin/**/*
@@ -44,7 +46,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
         - bin/**/*
@@ -67,7 +70,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
         - bin/**/*
@@ -86,7 +90,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+      changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
         - bin/**/*

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -3,7 +3,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
@@ -19,7 +20,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
@@ -46,7 +48,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
@@ -70,7 +73,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
         - .gitlab/**/*
@@ -90,7 +94,8 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "develop"))
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+        "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
         - .gitlab/**/*

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -3,7 +3,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
@@ -20,7 +20,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
@@ -48,7 +48,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
@@ -73,7 +73,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml
@@ -94,7 +94,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || ($CI_PIPELINE_SOURCE ==
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || ($CI_PIPELINE_SOURCE ==
         "push" && ($CI_COMMIT_BRANCH == "develop"))
       changes:
         - .gitlab-ci.yml


### PR DESCRIPTION
## Description

- Pipelines will now trigger on merge request events, ie explicitly when PRs are made, and will diff only against the merge target instead of the source branch's prior commit. 
- Develop branch will still have the old push pipeline behavior, so that a post merge pipeline can run. 
