### PR TITLE
Update CI diff source

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,25 +4,32 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
 
-    # Run pipelines only when these files/dirs change
-    - changes:
-        - .gitlab/**/*
-        - bin/**/*
-        - configs/**/*
-        - experiments/**/*
-        - lib/**/*
-        - modifiers/**/*
-        - repos/**/*
-        - var/**/*
-        - systems/llnl-elcapitan/system.py
-        - systems/llnl-cluster/system.py
-        - .gitlab-ci.yml
-        - checkout-versions.yaml
-        - CTestConfig.cmake
-        - CTestGitlab.cmake
-        - pyproject.toml
-        - remote-urls.yaml
-        - requirements.txt
+    # Feature branch pipelines should diff against the integration target.
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &workflow_change_paths
+          - .gitlab/**/*
+          - bin/**/*
+          - configs/**/*
+          - experiments/**/*
+          - lib/**/*
+          - modifiers/**/*
+          - repos/**/*
+          - var/**/*
+          - systems/llnl-elcapitan/system.py
+          - systems/llnl-cluster/system.py
+          - .gitlab-ci.yml
+          - checkout-versions.yaml
+          - CTestConfig.cmake
+          - CTestGitlab.cmake
+          - pyproject.toml
+          - remote-urls.yaml
+          - requirements.txt
+
+    # Develop pipelines should diff against the previous develop commit.
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *workflow_change_paths
 
     # Otherwise, don't create a pipeline
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ workflow:
     # Feature branch pipelines should diff against the integration target.
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &workflow_change_paths
           - .gitlab/**/*
           - bin/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ workflow:
     # Feature branch pipelines should diff against the integration target.
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &workflow_change_paths
           - .gitlab/**/*
           - bin/**/*

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -3,107 +3,133 @@
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**/*
-        - bin/**/*
-        - '**/$BENCHMARK/**/*'
-        - systems/$ARCHCONFIG/**/*
-        - modifiers/**/*
-        - var/**/*
-        - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &run_test_change_paths
+          - .gitlab-ci.yml
+          - .gitlab/**/*
+          - bin/**/*
+          - '**/$BENCHMARK/**/*'
+          - systems/$ARCHCONFIG/**/*
+          - modifiers/**/*
+          - var/**/*
+          - lib/**/*
+      when: on_success
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *run_test_change_paths
       when: on_success
 .resource_rules_dane:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**/*
-        - bin/**/*
-        - '**/amg2023/**/*'
-        - '**/branson/**/*'
-        - '**/hpcg/**/*'
-        - '**/hpl/**/*'
-        - '**/ior/**/*'
-        - '**/kripke/**/*'
-        - '**/laghos/**/*'
-        - '**/lammps/**/*'
-        - '**/osu[-_]micro[-_]benchmarks/**/*'
-        - '**/phloem/**/*'
-        - '**/raja[-_]perf/**/*'
-        - '**/remhos/**/*'
-        - '**/sparta[-_]snl/**/*'
-        - systems/llnl-cluster/**/*
-        - modifiers/**/*
-        - var/**/*
-        - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &resource_dane_change_paths
+          - .gitlab-ci.yml
+          - .gitlab/**/*
+          - bin/**/*
+          - '**/amg2023/**/*'
+          - '**/branson/**/*'
+          - '**/hpcg/**/*'
+          - '**/hpl/**/*'
+          - '**/ior/**/*'
+          - '**/kripke/**/*'
+          - '**/laghos/**/*'
+          - '**/lammps/**/*'
+          - '**/osu[-_]micro[-_]benchmarks/**/*'
+          - '**/phloem/**/*'
+          - '**/raja[-_]perf/**/*'
+          - '**/remhos/**/*'
+          - '**/sparta[-_]snl/**/*'
+          - systems/llnl-cluster/**/*
+          - modifiers/**/*
+          - var/**/*
+          - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *resource_dane_change_paths
 .resource_rules_matrix:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**/*
-        - bin/**/*
-        - '**/amg2023/**/*'
-        - '**/babelstream/**/*'
-        - '**/kripke/**/*'
-        - '**/laghos/**/*'
-        - '**/lammps/**/*'
-        - '**/py[-_]scaffold/**/*'
-        - '**/raja[-_]perf/**/*'
-        - '**/remhos/**/*'
-        - '**/saxpy/**/*'
-        - '**/sparta[-_]snl/**/*'
-        - systems/llnl-matrix/**/*
-        - modifiers/**/*
-        - var/**/*
-        - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &resource_matrix_change_paths
+          - .gitlab-ci.yml
+          - .gitlab/**/*
+          - bin/**/*
+          - '**/amg2023/**/*'
+          - '**/babelstream/**/*'
+          - '**/kripke/**/*'
+          - '**/laghos/**/*'
+          - '**/lammps/**/*'
+          - '**/py[-_]scaffold/**/*'
+          - '**/raja[-_]perf/**/*'
+          - '**/remhos/**/*'
+          - '**/saxpy/**/*'
+          - '**/sparta[-_]snl/**/*'
+          - systems/llnl-matrix/**/*
+          - modifiers/**/*
+          - var/**/*
+          - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *resource_matrix_change_paths
 .resource_rules_tioga:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**/*
-        - bin/**/*
-        - '**/amg2023/**/*'
-        - '**/kripke/**/*'
-        - '**/laghos/**/*'
-        - '**/py[-_]scaffold/**/*'
-        - '**/raja[-_]perf/**/*'
-        - '**/remhos/**/*'
-        - systems/llnl-elcapitan/**/*
-        - modifiers/**/*
-        - var/**/*
-        - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &resource_tioga_change_paths
+          - .gitlab-ci.yml
+          - .gitlab/**/*
+          - bin/**/*
+          - '**/amg2023/**/*'
+          - '**/kripke/**/*'
+          - '**/laghos/**/*'
+          - '**/py[-_]scaffold/**/*'
+          - '**/raja[-_]perf/**/*'
+          - '**/remhos/**/*'
+          - systems/llnl-elcapitan/**/*
+          - modifiers/**/*
+          - var/**/*
+          - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *resource_tioga_change_paths
 .resource_rules_tuolumne:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" || $ADVANCED_JOB == "ON" && $CI_COMMIT_BRANCH
         != "main" && $CI_COMMIT_BRANCH != "develop" && $ALL_TARGETS != "ON"
       when: never
-    - changes:
-        - .gitlab-ci.yml
-        - .gitlab/**/*
-        - bin/**/*
-        - '**/amg2023/**/*'
-        - '**/branson/**/*'
-        - '**/kripke/**/*'
-        - '**/laghos/**/*'
-        - '**/lammps/**/*'
-        - '**/py[-_]scaffold/**/*'
-        - '**/raja[-_]perf/**/*'
-        - '**/remhos/**/*'
-        - '**/sparta[-_]snl/**/*'
-        - '**/stream/**/*'
-        - systems/llnl-elcapitan/**/*
-        - modifiers/**/*
-        - var/**/*
-        - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
+      changes:
+        compare_to: refs/heads/develop
+        paths: &resource_tuolumne_change_paths
+          - .gitlab-ci.yml
+          - .gitlab/**/*
+          - bin/**/*
+          - '**/amg2023/**/*'
+          - '**/branson/**/*'
+          - '**/kripke/**/*'
+          - '**/laghos/**/*'
+          - '**/lammps/**/*'
+          - '**/py[-_]scaffold/**/*'
+          - '**/raja[-_]perf/**/*'
+          - '**/remhos/**/*'
+          - '**/sparta[-_]snl/**/*'
+          - '**/stream/**/*'
+          - systems/llnl-elcapitan/**/*
+          - modifiers/**/*
+          - var/**/*
+          - lib/**/*
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "develop"
+      changes: *resource_tuolumne_change_paths
 .nightly_rules:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -5,7 +5,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &run_test_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -26,7 +26,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &resource_dane_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -57,7 +57,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &resource_matrix_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -85,7 +85,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &resource_tioga_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -109,7 +109,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/develop
+        compare_to: refs/heads/ci-diff-source-update
         paths: &resource_tuolumne_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*

--- a/.gitlab/utils/rules.yml
+++ b/.gitlab/utils/rules.yml
@@ -5,7 +5,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &run_test_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -26,7 +26,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &resource_dane_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -57,7 +57,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &resource_matrix_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -85,7 +85,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &resource_tioga_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*
@@ -109,7 +109,7 @@
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop"
       changes:
-        compare_to: refs/heads/ci-diff-source-update
+        compare_to: refs/heads/develop
         paths: &resource_tuolumne_change_paths
           - .gitlab-ci.yml
           - .gitlab/**/*

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -4,7 +4,6 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-
 #################
  Adding a System
 #################

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -4,6 +4,8 @@
 
     SPDX-License-Identifier: Apache-2.0
 
+    test
+
 #################
  Adding a System
 #################

--- a/docs/add-a-system-config.rst
+++ b/docs/add-a-system-config.rst
@@ -4,7 +4,6 @@
 
     SPDX-License-Identifier: Apache-2.0
 
-    test
 
 #################
  Adding a System


### PR DESCRIPTION
## Description

- Modify CI rules so that gitlab diffs feature branches against develop instead of against prior commits of the feature branch.
- Tested functionality by setting the diff target to this branch, and creating a test branch with a docs change, opening a PR on that test branch all before the mirroring triggered. No pipeline was created which is the correct behavior.
<img width="1185" height="140" alt="image" src="https://github.com/user-attachments/assets/f52cdc76-3a62-4563-8ca1-78ea3341850f" />
