### PR TITLE
Branson input parameter changes

### DIFF
--- a/experiments/branson/experiment.py
+++ b/experiments/branson/experiment.py
@@ -65,6 +65,7 @@ class Branson(
     def compute_applications_section(self):
         if self.spec.satisfies("exec_mode=test"):
             self.add_experiment_variable("num_particles", 1000000, True)
+            pool_size = 4
         else:
             if self.spec.satisfies("+throughput"):
                 photons = [

--- a/experiments/branson/experiment.py
+++ b/experiments/branson/experiment.py
@@ -100,7 +100,7 @@ class Branson(
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
             self.add_experiment_variable("pool", pool_size, False)
         self.add_experiment_variable("input_file", "3D_lb_hohlraum.xml", False)
-        self.add_experiment_variable("particle_message_size", "400000", False)
+        self.add_experiment_variable("particle_message_size", "10000", False)
 
         self.register_scaling_config(
             {

--- a/experiments/branson/experiment.py
+++ b/experiments/branson/experiment.py
@@ -90,12 +90,16 @@ class Branson(
                     400000000,
                     800000000,
                 ]
+                pool_size = 64
             else:
-                photons = 800000000
+                photons = 100000000
+                pool_size = 32
             self.add_experiment_variable("num_particles", photons, True)
         self.add_experiment_variable("resource_count", 4, False)
         if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
-            self.add_experiment_variable("pool", 32, False)
+            self.add_experiment_variable("pool", pool_size, False)
+        self.add_experiment_variable("input_file", "3D_lb_hohlraum.xml", False)
+        self.add_experiment_variable("particle_message_size", "400000", False)
 
         self.register_scaling_config(
             {

--- a/repos/ramble_applications/branson/application.py
+++ b/repos/ramble_applications/branson/application.py
@@ -27,6 +27,7 @@ class Branson(ExecutableApplication):
            + " --dd-transport-type {decomposition}"
            + " --particle-storage {layout}"
            + " --particle-algorithm {algorithm}"
+           + " --particle-message-size {particle_message_size}"
            + " --umpire-device-pool-size {pool}"
     )
 
@@ -37,6 +38,10 @@ class Branson(ExecutableApplication):
     
     workload_variable('input_file', default='3D_hohlraum_multi_node.xml',
     	description='input file name',
+      	workloads=['branson'])
+
+    workload_variable('particle_message_size', default='10000',
+    	description='Message size',
       	workloads=['branson'])
 
     workload_variable('num_particles', default='250000000',


### PR DESCRIPTION
## Description
This PR:
 - changes the problem size (number of photons) for the weak scaling case
 - replaces the input file with a more load balanced problem `3D_lb_hohlraum.xml`
 - Adds the input parameter `particle_message_size` that allows varying the MPI buffer size at runtime.

## Adding/modifying a benchmark (docs: [Adding a Benchmark](https://software.llnl.gov/benchpark/add-a-benchmark.html))

- [x] If application.py upstreamed to Ramble is insufficient, add/modify `repo/benchmark_name/application.py` plus: create, self-assign, and link here a follow up issue with a link to the PR in the Ramble repo.
- [x] Add/modify an `experiments/benchmark_name/experiment.py` to define an experiment
