### PR TITLE
Add "perf" mode for rajaperf

### DIFF
--- a/experiments/raja-perf/experiment.py
+++ b/experiments/raja-perf/experiment.py
@@ -72,6 +72,10 @@ class RajaPerf(
             )
             # Number of processes
             self.add_experiment_variable("n_resources", 1, False)
+        # Perf mode
+        else:
+            self.add_experiment_variable("process_problem_size", 33554432, True)
+            self.add_experiment_variable("n_resources", 4, False)
 
         self.set_required_variables(
             total_problem_size="{n_resources}*{process_problem_size}",


### PR DESCRIPTION
## Description

- [x] The `raja-perf` experiment was missing a perf configuration