### PR TITLE
Ngroups in Branson

### DIFF
--- a/experiments/branson/experiment.py
+++ b/experiments/branson/experiment.py
@@ -36,7 +36,7 @@ class Branson(
 
     variant(
         "n_groups",
-        default="30",
+        default=30,
         values=int,
         description="Number of groups",
     )


### PR DESCRIPTION
The parameter was in quotes and therefore defaulting to 1 instead of 30.