### PR TITLE
Cleanup experiment directory before repeated executions

### DIFF
--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -380,6 +380,27 @@ class Allocation(BasicModifier):
             raise ValueError(err_msg)
 
     @staticmethod
+    def _cleanup_experiment_dir_cmd():
+        """Removes artifacts from previous runs, if the experiment is executed more than once.
+
+        Ramble creates a small set of files during setup that must remain in the
+        experiment directory. Everything else at the top level is treated as
+        runtime output from an earlier execution.
+        """
+        whitelist_files = [
+            # Ramble book keeping
+            ".ramble-experiment",
+            "ramble_inventory.json",
+            "ramble_status.json",
+            # Experiment file
+            "execute_experiment",
+            # Generated when Caliper modifier is on
+            "{experiment_name}_metadata.json",
+        ]
+        keep_predicates = " ".join(f"! -name '{file}'" for file in whitelist_files)
+        return f"find . -mindepth 1 -maxdepth 1 {keep_predicates} -exec rm -rf -- {{}} +"
+
+    @staticmethod
     def _init_batch_and_cmd_opts(v):
         """System/experiment may have universal options they want to apply
         for all batch allocations or exec calls.
@@ -390,10 +411,11 @@ class Allocation(BasicModifier):
         if v.extra_cmd_opts:
             cmd_opts.extend(v.extra_cmd_opts.strip().split("\n"))
 
+        pre_exec_cmds = [Allocation._cleanup_experiment_dir_cmd()]
         if v.pre_exec_cmds:
-            v.pre_exec = v.pre_exec_cmds
-        else:
-            v.pre_exec = ""
+            pre_exec_cmds.append(v.pre_exec_cmds)
+        v.pre_exec = "\n".join(pre_exec_cmds)
+
         if v.post_exec_cmds:
             v.post_exec = v.post_exec_cmds
         else:

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -398,7 +398,9 @@ class Allocation(BasicModifier):
             "{experiment_name}_metadata.json",
         ]
         keep_predicates = " ".join(f"! -name '{file}'" for file in whitelist_files)
-        return f"find . -mindepth 1 -maxdepth 1 {keep_predicates} -exec rm -rf -- {{}} +"
+        return (
+            f"find . -mindepth 1 -maxdepth 1 {keep_predicates} -exec rm -rf -- {{}} +"
+        )
 
     @staticmethod
     def _init_batch_and_cmd_opts(v):

--- a/modifiers/allocation/modifier.py
+++ b/modifiers/allocation/modifier.py
@@ -226,6 +226,7 @@ def divide_into(dividend, divisor):
 class Allocation(BasicModifier):
 
     name = "allocation"
+    _whitelist_file_name = "benchpark_whitelist"
 
     tags("infrastructure")
 
@@ -236,6 +237,17 @@ class Allocation(BasicModifier):
 
     mode("standard", description="Standard execution mode for allocation")
     default_mode("standard")
+
+    register_phase(
+        "create_cleanup_whitelist", pipeline="setup", run_after=["make_experiments"]
+    )
+
+    def _create_cleanup_whitelist(self, workspace, app_inst):
+        whitelist_file = self.expander.expand_var(
+            f"{{experiment_run_dir}}/{self._whitelist_file_name}"
+        )
+        with open(whitelist_file, "w"):
+            pass
 
     def inherit_from_application(self, app):
         super().inherit_from_application(app)
@@ -383,23 +395,18 @@ class Allocation(BasicModifier):
     def _cleanup_experiment_dir_cmd():
         """Removes artifacts from previous runs, if the experiment is executed more than once.
 
-        Ramble creates a small set of files during setup that must remain in the
-        experiment directory. Everything else at the top level is treated as
-        runtime output from an earlier execution.
+        Setup creates an empty whitelist file. The first execution populates it
+        with setup-created files, and later executions remove anything else.
         """
-        whitelist_files = [
-            # Ramble book keeping
-            ".ramble-experiment",
-            "ramble_inventory.json",
-            "ramble_status.json",
-            # Experiment file
-            "execute_experiment",
-            # Generated when Caliper modifier is on
-            "{experiment_name}_metadata.json",
-        ]
-        keep_predicates = " ".join(f"! -name '{file}'" for file in whitelist_files)
-        return (
-            f"find . -mindepth 1 -maxdepth 1 {keep_predicates} -exec rm -rf -- {{}} +"
+        whitelist_file = Allocation._whitelist_file_name
+        return "\n".join(
+            [
+                f"[ -s {whitelist_file} ] || "
+                'find . -mindepth 1 -maxdepth 1 -printf "%f\\n" | '
+                f"sort > {whitelist_file}",
+                'find . -mindepth 1 -maxdepth 1 -printf "%f\\n" | '
+                f'grep -Fxvf {whitelist_file} | xargs -r -d "\\n" rm -rf --',
+            ]
         )
 
     @staticmethod


### PR DESCRIPTION
## Description

- [x] Certain benchmarks and modifiers generate output every execution. We often execute the same `execute_experiment` several times for various reasons, which results in many output files across the different executions. This change cleans up those files before the next execution, so only the output files from the most recent execution will persist.
- [x] At the request of @rfhaque 
- [x] Modify `modifiers/allocation/modifier.py` to add new `pre_exec` command

This PR creates a file in the experiment directory `benchpark_whitelist` that is populated before the first execution (one of the first calls in `execute_experiment`) with a list of the current files in the experiment workspace. On the next execution of the experiment, any file that is not in `benchpark_whitelist` will be deleted.