### PR TITLE
define missing execute-gen in ramble

### DIFF
--- a/repos/ramble_applications/gromacs/application.py
+++ b/repos/ramble_applications/gromacs/application.py
@@ -27,6 +27,9 @@ class Gromacs(ExecutableApplication):
                '-c {input_path}/conf.gro ' +
                '-p {input_path}/topol.top ' +
                '-o exp_input.tpr', use_mpi=False)
+    executable('execute-gen', 'gmx_mpi mdrun -notunepme ' +
+               '-v -resethway -noconfout -nsteps {nsteps} ' +
+               '-s exp_input.tpr', use_mpi=True)
     executable('execute-nsteps-gen', 'gmx_mpi mdrun -notunepme ' +
                '-v -resethway -noconfout -nsteps 4000 ' +
                '-s exp_input.tpr', use_mpi=True)


### PR DESCRIPTION
## Description

Earlier gromacs PR (https://github.com/llnl/benchpark/pull/835) switched the default experiment for gromacs to water_gmx50. It uses a ramble executable execute-gen, which is not defined in the application.py. The default configuration of the gromacs experiment won't build, because ramble will fail.

This PR defines an executable for execute-gen.